### PR TITLE
fix: stop adapter page from visibly reloading every 10 seconds

### DIFF
--- a/gui/src/stores/adapters.js
+++ b/gui/src/stores/adapters.js
@@ -6,13 +6,21 @@ export const useAdapterStore = defineStore('adapters', () => {
   const instances = ref([])   // AdapterInstanceOut[]
   const loading   = ref(false)
 
-  async function fetchAdapters() {
-    loading.value = true
+  async function fetchAdapters({ silent = false } = {}) {
+    if (!silent) loading.value = true
     try {
       const { data } = await adapterApi.listInstances()
-      instances.value = data
+      if (silent && instances.value.length) {
+        // Background refresh: only update status fields to avoid re-rendering the whole list
+        for (const updated of data) {
+          const existing = instances.value.find(a => a.id === updated.id)
+          if (existing) existing.connected = updated.connected
+        }
+      } else {
+        instances.value = data
+      }
     } finally {
-      loading.value = false
+      if (!silent) loading.value = false
     }
   }
 

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -332,8 +332,8 @@ let refreshTimer = null
 
 // ------------------------------------------------------------------
 
-async function refreshInstances() {
-  await store.fetchAdapters()
+async function refreshInstances({ silent = false } = {}) {
+  await store.fetchAdapters({ silent })
   initDrafts()
   for (const a of store.instances) {
     const fb = feedback[a.id]
@@ -350,7 +350,7 @@ onMounted(async () => {
   } catch {
     availableTypesErr.value = true
   }
-  refreshTimer = window.setInterval(refreshInstances, 10000)
+  refreshTimer = window.setInterval(() => refreshInstances({ silent: true }), 10000)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
Background status refresh now runs silently (no loading spinner, no full array replacement). Only the `connected` field is updated in-place, so Vue does not re-render the entire adapter list and open inputs are preserved.

Fixes #394