### PR TITLE
feat(logic): show logic-sheet usages on datapoint detail page (#366)

### DIFF
--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -241,15 +241,16 @@ export const navLinksApi = {
 
 // ── Logic Engine ──────────────────────────────────────────────────────────
 export const logicApi = {
-  nodeTypes:      ()           => api.get('/logic/node-types'),
-  listGraphs:     ()           => api.get('/logic/graphs'),
-  createGraph:    (data)       => api.post('/logic/graphs', data),
-  importGraph:    (data)       => api.post('/logic/graphs/import', data),
-  getGraph:       (id)         => api.get(`/logic/graphs/${id}`),
-  saveGraph:      (id, data)   => api.put(`/logic/graphs/${id}`, data),
-  patchGraph:     (id, data)   => api.patch(`/logic/graphs/${id}`, data),
-  deleteGraph:    (id)         => api.delete(`/logic/graphs/${id}`),
-  runGraph:       (id)         => api.post(`/logic/graphs/${id}/run`),
-  duplicateGraph: (id)         => api.post(`/logic/graphs/${id}/duplicate`),
-  exportGraph:    (id)         => api.get(`/logic/graphs/${id}/export`),
+  nodeTypes:        ()           => api.get('/logic/node-types'),
+  listGraphs:       ()           => api.get('/logic/graphs'),
+  createGraph:      (data)       => api.post('/logic/graphs', data),
+  importGraph:      (data)       => api.post('/logic/graphs/import', data),
+  getGraph:         (id)         => api.get(`/logic/graphs/${id}`),
+  saveGraph:        (id, data)   => api.put(`/logic/graphs/${id}`, data),
+  patchGraph:       (id, data)   => api.patch(`/logic/graphs/${id}`, data),
+  deleteGraph:      (id)         => api.delete(`/logic/graphs/${id}`),
+  runGraph:         (id)         => api.post(`/logic/graphs/${id}/run`),
+  duplicateGraph:   (id)         => api.post(`/logic/graphs/${id}/duplicate`),
+  exportGraph:      (id)         => api.get(`/logic/graphs/${id}/export`),
+  datapointUsages:  (dpId)       => api.get(`/logic/datapoint/${dpId}/usages`),
 }

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -142,7 +142,7 @@
     <!-- Logic Verknüpfungen -->
     <div class="card">
       <div class="card-header">
-        <h3 class="font-semibold text-slate-800 dark:text-slate-100 text-sm">Logic Verknüpfungen</h3>
+        <h3 class="font-semibold text-slate-800 dark:text-slate-100 text-sm">Logik Verknüpfungen</h3>
       </div>
       <div class="card-body">
         <div v-if="logicUsagesLoading" class="flex justify-center py-4"><Spinner /></div>
@@ -160,7 +160,7 @@
                 <Badge v-if="!u.graph_enabled" variant="muted" size="xs">Deaktiviert</Badge>
               </div>
               <div class="text-xs text-slate-500 mt-1">
-                {{ u.node_type === 'datapoint_read' ? 'Read Object — Logic liest dieses Objekt' : 'Write Object — Logic schreibt auf dieses Objekt' }}
+                {{ u.node_type === 'datapoint_read' ? 'Logik liest im verlinkten Blatt dieses Objekt' : 'Logik schreibt im verlinkten Blatt auf dieses Objekt' }}
               </div>
             </div>
             <RouterLink :to="`/logic?graph=${u.graph_id}`" class="btn-icon shrink-0" title="Logic-Sheet öffnen">

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -139,6 +139,38 @@
       </div>
     </div>
 
+    <!-- Logic Verknüpfungen -->
+    <div class="card">
+      <div class="card-header">
+        <h3 class="font-semibold text-slate-800 dark:text-slate-100 text-sm">Logic Verknüpfungen</h3>
+      </div>
+      <div class="card-body">
+        <div v-if="logicUsagesLoading" class="flex justify-center py-4"><Spinner /></div>
+        <div v-else-if="!logicUsages.length" class="text-center text-slate-500 text-sm py-4">
+          Objekt wird in keinem Logic-Sheet verwendet
+        </div>
+        <div v-else class="flex flex-col gap-2">
+          <div v-for="u in logicUsages" :key="u.node_id" class="flex items-center gap-3 p-3 bg-surface-700 rounded-lg">
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-medium text-slate-700 dark:text-slate-200">{{ u.graph_name }}</span>
+                <Badge :variant="u.direction === 'SOURCE' ? 'info' : 'warning'" size="xs">
+                  {{ u.direction === 'SOURCE' ? 'Lesen' : 'Schreiben' }}
+                </Badge>
+                <Badge v-if="!u.graph_enabled" variant="muted" size="xs">Deaktiviert</Badge>
+              </div>
+              <div class="text-xs text-slate-500 mt-1">
+                {{ u.node_type === 'datapoint_read' ? 'Read Object — Logic liest dieses Objekt' : 'Write Object — Logic schreibt auf dieses Objekt' }}
+              </div>
+            </div>
+            <RouterLink :to="`/logic?graph=${u.graph_id}`" class="btn-icon shrink-0" title="Logic-Sheet öffnen">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+            </RouterLink>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Edit Objekt Modal -->
     <Modal v-model="showEdit" title="Objekt bearbeiten">
       <DataPointForm :initial="dp" :datatypes="dpStore.datatypes" :save-handler="onEditSave" @cancel="showEdit = false" />
@@ -160,7 +192,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import { dpApi } from '@/api/client'
+import { dpApi, logicApi } from '@/api/client'
 import { useDatapointStore } from '@/stores/datapoints'
 import { useWebSocketStore } from '@/stores/websocket'
 import Badge          from '@/components/ui/Badge.vue'
@@ -175,10 +207,12 @@ const props   = defineProps({ id: { type: String, required: true } })
 const dpStore = useDatapointStore()
 const ws      = useWebSocketStore()
 
-const dp              = ref(null)
-const bindings        = ref([])
-const bindingsLoading = ref(false)
-const showEdit        = ref(false)
+const dp                  = ref(null)
+const bindings            = ref([])
+const bindingsLoading     = ref(false)
+const logicUsages         = ref([])
+const logicUsagesLoading  = ref(false)
+const showEdit            = ref(false)
 const showBindingForm = ref(false)
 const showBindingConfirm = ref(false)
 const editBinding     = ref(null)
@@ -212,7 +246,7 @@ onMounted(async () => {
   unsubWs = ws.onValue((id, value, quality) => {
     if (id === props.id && dp.value) { dp.value.value = value; dp.value.quality = quality }
   })
-  await loadBindings()
+  await Promise.all([loadBindings(), loadLogicUsages()])
 })
 onUnmounted(() => unsubWs?.())
 
@@ -220,6 +254,12 @@ async function loadBindings() {
   bindingsLoading.value = true
   try { const { data } = await dpApi.listBindings(props.id); bindings.value = data }
   finally { bindingsLoading.value = false }
+}
+
+async function loadLogicUsages() {
+  logicUsagesLoading.value = true
+  try { const { data } = await logicApi.datapointUsages(props.id); logicUsages.value = data }
+  finally { logicUsagesLoading.value = false }
 }
 
 async function onEditSave(payload) {

--- a/gui/src/views/LogicView.vue
+++ b/gui/src/views/LogicView.vue
@@ -139,6 +139,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch, markRaw } from 'vue'
+import { useRoute } from 'vue-router'
 import { VueFlow, useVueFlow, addEdge } from '@vue-flow/core'
 import { Background }           from '@vue-flow/background'
 import { Controls }             from '@vue-flow/controls'
@@ -164,6 +165,7 @@ import PythonScriptNode from '@/components/logic/nodes/PythonScriptNode.vue'
 import MissingNode      from '@/components/logic/nodes/MissingNode.vue'
 
 // ── Store ──────────────────────────────────────────────────────────────────
+const route    = useRoute()
 const store    = useLogicStore()
 const settings = useSettingsStore()
 // Reactive background pattern colour — recomputes when theme changes
@@ -553,10 +555,12 @@ onMounted(async () => {
   await store.fetchNodeTypes()
   await store.fetchGraphs()
   _wsConnect()
-  // Restore last active graph
-  const lastId = localStorage.getItem('logic_active_graph')
-  if (lastId && store.graphs.find(g => g.id === lastId)) {
-    activeGraphId.value = lastId
+  // Query-Parameter ?graph=<id> hat Vorrang vor dem gespeicherten letzten Graph
+  const queryId = route.query.graph
+  const lastId  = localStorage.getItem('logic_active_graph')
+  const targetId = queryId || lastId
+  if (targetId && store.graphs.find(g => g.id === targetId)) {
+    activeGraphId.value = targetId
     await loadGraph()
   }
 })

--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -32,6 +32,7 @@ from obs.logic.models import (
     LogicGraphOut,
     LogicGraphUpdate,
     LogicNode,
+    LogicUsageOut,
     NodeTypeDef,
 )
 from obs.logic.node_types import list_node_types
@@ -347,6 +348,44 @@ async def duplicate_graph(
         pass
     result = await db.fetchone("SELECT * FROM logic_graphs WHERE id=?", (new_id,))
     return _row_to_out(result)
+
+
+@router.get("/datapoint/{dp_id}/usages", response_model=list[LogicUsageOut])
+async def get_datapoint_logic_usages(
+    dp_id: str,
+    _user: str = Depends(get_current_user),
+    db: Database = Depends(lambda: get_db()),
+) -> list[LogicUsageOut]:
+    """Return all logic graphs that reference a given DataPoint, with direction from the DP's perspective.
+
+    - datapoint_read node  → logic reads the DP   → direction SOURCE
+    - datapoint_write node → logic writes to the DP → direction DEST
+    """
+    rows = await db.fetchall("SELECT id, name, enabled, flow_data FROM logic_graphs")
+    usages: list[LogicUsageOut] = []
+    for row in rows:
+        raw = json.loads(row["flow_data"]) if row["flow_data"] else {}
+        flow = FlowData.model_validate(raw)
+        for node in flow.nodes:
+            if node.data.get("datapoint_id") != dp_id:
+                continue
+            if node.type == "datapoint_read":
+                direction = "SOURCE"
+            elif node.type == "datapoint_write":
+                direction = "DEST"
+            else:
+                continue
+            usages.append(
+                LogicUsageOut(
+                    graph_id=row["id"],
+                    graph_name=row["name"],
+                    graph_enabled=bool(row["enabled"]),
+                    node_id=node.id,
+                    node_type=node.type,
+                    direction=direction,
+                )
+            )
+    return usages
 
 
 @router.get("/graphs/{graph_id}/export")

--- a/obs/logic/models.py
+++ b/obs/logic/models.py
@@ -90,3 +90,14 @@ class NodeTypeDef(BaseModel):
     outputs: list[NodeTypePort] = []
     config_schema: dict[str, Any] = {}  # JSON schema for node data
     color: str = "#475569"  # default node color (tailwind slate-600)
+
+
+class LogicUsageOut(BaseModel):
+    """Describes a single usage of a DataPoint inside a logic graph."""
+
+    graph_id: str
+    graph_name: str
+    graph_enabled: bool
+    node_id: str
+    node_type: str  # "datapoint_read" | "datapoint_write"
+    direction: str  # "SOURCE" | "DEST" — from the DataPoint's perspective

--- a/tests/integration/test_logic_datapoint_usages.py
+++ b/tests/integration/test_logic_datapoint_usages.py
@@ -1,0 +1,187 @@
+"""Integration tests — GET /api/v1/logic/datapoint/{dp_id}/usages (issue #366).
+
+Verifies that the endpoint correctly scans all logic graphs and returns
+synthetic usage entries for every node that references a given DataPoint,
+with the correct direction from the DataPoint's perspective:
+
+  datapoint_read  → SOURCE  (logic reads the DP)
+  datapoint_write → DEST    (logic writes to the DP)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_dp(client, auth_headers, name: str) -> dict:
+    resp = await client.post(
+        "/api/v1/datapoints/",
+        json={"name": name, "data_type": "FLOAT", "tags": []},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_graph(client, auth_headers, name: str, nodes: list, edges: list | None = None, enabled: bool = True) -> str:
+    resp = await client.post(
+        "/api/v1/logic/graphs",
+        json={
+            "name": name,
+            "description": "",
+            "enabled": enabled,
+            "flow_data": {"nodes": nodes, "edges": edges or []},
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _read_node(dp_id: str, node_id: str = "n1") -> dict:
+    return {
+        "id": node_id,
+        "type": "datapoint_read",
+        "position": {"x": 0, "y": 0},
+        "data": {"datapoint_id": dp_id, "datapoint_name": "test"},
+    }
+
+
+def _write_node(dp_id: str, node_id: str = "n2") -> dict:
+    return {
+        "id": node_id,
+        "type": "datapoint_write",
+        "position": {"x": 100, "y": 0},
+        "data": {"datapoint_id": dp_id, "datapoint_name": "test"},
+    }
+
+
+async def _cleanup(client, auth_headers, graph_ids: list[str] | None = None, dp_ids: list[str] | None = None) -> None:
+    for gid in graph_ids or []:
+        await client.delete(f"/api/v1/logic/graphs/{gid}", headers=auth_headers)
+    for did in dp_ids or []:
+        await client.delete(f"/api/v1/datapoints/{did}", headers=auth_headers)
+
+
+async def _get_usages(client, auth_headers, dp_id: str) -> list[dict]:
+    resp = await client.get(f"/api/v1/logic/datapoint/{dp_id}/usages", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_usages_when_dp_not_in_any_graph(client, auth_headers):
+    dp = await _create_dp(client, auth_headers, "unused_dp_usages_test")
+    try:
+        usages = await _get_usages(client, auth_headers, dp["id"])
+        assert usages == []
+    finally:
+        await _cleanup(client, auth_headers, dp_ids=[dp["id"]])
+
+
+@pytest.mark.asyncio
+async def test_read_node_yields_source_direction(client, auth_headers):
+    dp = await _create_dp(client, auth_headers, "dp_read_source_test")
+    gid = await _create_graph(client, auth_headers, "graph_read_source", [_read_node(dp["id"])])
+    try:
+        usages = await _get_usages(client, auth_headers, dp["id"])
+        assert len(usages) == 1
+        u = usages[0]
+        assert u["graph_id"] == gid
+        assert u["graph_name"] == "graph_read_source"
+        assert u["graph_enabled"] is True
+        assert u["node_type"] == "datapoint_read"
+        assert u["direction"] == "SOURCE"
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[gid], dp_ids=[dp["id"]])
+
+
+@pytest.mark.asyncio
+async def test_write_node_yields_dest_direction(client, auth_headers):
+    dp = await _create_dp(client, auth_headers, "dp_write_dest_test")
+    gid = await _create_graph(client, auth_headers, "graph_write_dest", [_write_node(dp["id"])])
+    try:
+        usages = await _get_usages(client, auth_headers, dp["id"])
+        assert len(usages) == 1
+        u = usages[0]
+        assert u["node_type"] == "datapoint_write"
+        assert u["direction"] == "DEST"
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[gid], dp_ids=[dp["id"]])
+
+
+@pytest.mark.asyncio
+async def test_both_node_types_in_same_graph(client, auth_headers):
+    dp = await _create_dp(client, auth_headers, "dp_both_types_test")
+    gid = await _create_graph(
+        client,
+        auth_headers,
+        "graph_both",
+        [_read_node(dp["id"], "nR"), _write_node(dp["id"], "nW")],
+    )
+    try:
+        usages = await _get_usages(client, auth_headers, dp["id"])
+        assert len(usages) == 2
+        directions = {u["direction"] for u in usages}
+        assert directions == {"SOURCE", "DEST"}
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[gid], dp_ids=[dp["id"]])
+
+
+@pytest.mark.asyncio
+async def test_multiple_graphs_referencing_same_dp(client, auth_headers):
+    dp = await _create_dp(client, auth_headers, "dp_multi_graph_test")
+    gid1 = await _create_graph(client, auth_headers, "graph_mg_1", [_read_node(dp["id"])])
+    gid2 = await _create_graph(client, auth_headers, "graph_mg_2", [_write_node(dp["id"])])
+    try:
+        usages = await _get_usages(client, auth_headers, dp["id"])
+        assert len(usages) == 2
+        graph_ids = {u["graph_id"] for u in usages}
+        assert gid1 in graph_ids
+        assert gid2 in graph_ids
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[gid1, gid2], dp_ids=[dp["id"]])
+
+
+@pytest.mark.asyncio
+async def test_disabled_graph_still_appears_in_usages(client, auth_headers):
+    dp = await _create_dp(client, auth_headers, "dp_disabled_graph_test")
+    gid = await _create_graph(client, auth_headers, "graph_disabled", [_read_node(dp["id"])], enabled=False)
+    try:
+        usages = await _get_usages(client, auth_headers, dp["id"])
+        assert len(usages) == 1
+        assert usages[0]["graph_enabled"] is False
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[gid], dp_ids=[dp["id"]])
+
+
+@pytest.mark.asyncio
+async def test_other_dp_not_included(client, auth_headers):
+    dp_a = await _create_dp(client, auth_headers, "dp_other_a_test")
+    dp_b = await _create_dp(client, auth_headers, "dp_other_b_test")
+    gid = await _create_graph(client, auth_headers, "graph_only_a", [_read_node(dp_a["id"])])
+    try:
+        usages_b = await _get_usages(client, auth_headers, dp_b["id"])
+        assert usages_b == []
+        usages_a = await _get_usages(client, auth_headers, dp_a["id"])
+        assert len(usages_a) == 1
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[gid], dp_ids=[dp_a["id"], dp_b["id"]])
+
+
+@pytest.mark.asyncio
+async def test_requires_authentication(client):
+    resp = await client.get("/api/v1/logic/datapoint/00000000-0000-0000-0000-000000000000/usages")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Closes #366.

When a DataPoint is used in a logic sheet, it was previously invisible from the object's configuration — you couldn't tell at a glance which sheets reference it or in what direction. This PR fixes that.

**Architecture decision:** No dummy `AdapterBinding` records are written to the database. The logic graph JSON is already the single source of truth. A new read-only API endpoint scans all graphs on-the-fly and returns synthetic usage entries — no sync problem, no migrations.

### Changes

- **`obs/logic/models.py`** — New `LogicUsageOut` Pydantic model (`graph_id`, `graph_name`, `graph_enabled`, `node_id`, `node_type`, `direction`)
- **`obs/api/v1/logic.py`** — New endpoint `GET /api/v1/logic/datapoint/{dp_id}/usages`
  - Scans all `logic_graphs` rows, parses `flow_data` JSON, finds nodes that reference the given DataPoint
  - Direction from the DataPoint's perspective: `datapoint_read` → `SOURCE`, `datapoint_write` → `DEST`
- **`gui/src/api/client.js`** — `logicApi.datapointUsages(dpId)`
- **`gui/src/views/DataPointDetailView.vue`** — New "Logik Verknüpfungen" card below the adapter bindings:
  - Direction badge (Lesen / Schreiben) consistent with the adapter binding badges
  - German description ("Logik liest im verlinkten Blatt dieses Objekt" / "Logik schreibt im verlinkten Blatt auf dieses Objekt")
  - "Öffnen" icon-button that navigates to `/logic?graph=<graph_id>`
  - Disabled-graph badge when the sheet is inactive
- **`gui/src/views/LogicView.vue`** — Reads `?graph=<id>` query parameter on mount and pre-selects the graph; falls back to `localStorage` as before
- **`tests/integration/test_logic_datapoint_usages.py`** — 8 integration tests covering: no usages, SOURCE direction, DEST direction, both types in one graph, multiple graphs, disabled graph, isolation between DPs, authentication requirement

## Reviewer notes

- The endpoint does a full table scan of `logic_graphs` per request. Acceptable for the expected graph count (tens to low hundreds). A materialized index would be premature optimisation.
- `LogicView` now accepts `?graph=<id>` as a deep-link. If the ID is not found in the loaded graphs (e.g. deleted), it silently falls back to `localStorage`.
