### PR TITLE
test: set pytest-asyncio fixture loop scope explicitly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = session
 
 # Output
 addopts =


### PR DESCRIPTION
## Summary
Set `pytest-asyncio` fixture loop scope explicitly in `pytest.ini` to remove the deprecation warning and lock behavior to the currently expected session-scoped integration fixture setup.

## Change
- add `asyncio_default_fixture_loop_scope = session` to `pytest.ini`

## Why
With `pytest-asyncio>=1.3.0`, leaving this unset emits a deprecation warning and will change defaults in a future release.

## Verification
- `pytest tests/unit/test_models.py -q` passes
- warning about unset `asyncio_default_fixture_loop_scope` is no longer emitted
