### PR TITLE
feat(snmp): SNMP adapter (v1/v2c/v3) with walk discovery and binding UI

### DIFF
--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -123,6 +123,11 @@ export const adapterApi = {
   anwesenheitDatapoints:  (id)          => api.get(`/adapters/instances/${id}/anwesenheit/datapoints`),
   anwesenheitSyncBindings:(id, dpIds)  => api.post(`/adapters/instances/${id}/anwesenheit/sync-bindings`, { datapoint_ids: dpIds }),
   anwesenheitHealth:      (id)          => api.get(`/adapters/instances/${id}/anwesenheit/health`),
+  snmpWalk: (id, host, oid = '1.3.6.1.2.1', port = 161, maxResults = 200, timeout = 10) =>
+    api.get(`/adapters/instances/${id}/snmp/walk`, {
+      params: { host, oid, port, max_results: maxResults, timeout },
+      timeout: (timeout + 5) * 1000,
+    }),
 }
 
 // ── KNX Project Import ────────────────────────────────────────────────────

--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -123,11 +123,11 @@ export const adapterApi = {
   anwesenheitDatapoints:  (id)          => api.get(`/adapters/instances/${id}/anwesenheit/datapoints`),
   anwesenheitSyncBindings:(id, dpIds)  => api.post(`/adapters/instances/${id}/anwesenheit/sync-bindings`, { datapoint_ids: dpIds }),
   anwesenheitHealth:      (id)          => api.get(`/adapters/instances/${id}/anwesenheit/health`),
-  snmpWalk: (id, host, oid = '1.3.6.1.2.1', port = 161, maxResults = 200, timeout = 10) =>
-    api.get(`/adapters/instances/${id}/snmp/walk`, {
-      params: { host, oid, port, max_results: maxResults, timeout },
-      timeout: (timeout + 5) * 1000,
-    }),
+  snmpWalk: (id, host, oid = '1.3.6.1.2.1', port = 161, maxResults = 50, timeout = 10, startOid = null) => {
+    const params = { host, oid, port, max_results: maxResults, timeout }
+    if (startOid) params.start_oid = startOid
+    return api.get(`/adapters/instances/${id}/snmp/walk`, { params, timeout: (timeout + 5) * 1000 })
+  },
 }
 
 // ── KNX Project Import ────────────────────────────────────────────────────

--- a/gui/src/components/datapoints/BindingForm.vue
+++ b/gui/src/components/datapoints/BindingForm.vue
@@ -843,6 +843,107 @@
         </div>
       </template>
 
+      <!-- SNMP -->
+      <template v-if="selectedAdapterType === 'SNMP'">
+        <div class="section-header">SNMP Binding</div>
+
+        <!-- Host + Port -->
+        <div class="grid grid-cols-3 gap-4">
+          <div class="form-group col-span-2">
+            <label class="label">Gerät (IP/DNS) *</label>
+            <input v-model="cfg.host" class="input" placeholder="z.B. 192.168.1.100 oder switch.local" required />
+          </div>
+          <div class="form-group">
+            <label class="label">UDP-Port</label>
+            <input v-model.number="cfg.port" type="number" min="1" max="65535" class="input" />
+            <p class="hint">Standard: 161</p>
+          </div>
+        </div>
+
+        <!-- OID with Walk -->
+        <div class="form-group">
+          <label class="label">OID *</label>
+          <div class="flex gap-2">
+            <input
+              v-model="cfg.oid"
+              class="input flex-1 font-mono text-sm"
+              placeholder="z.B. 1.3.6.1.2.1.1.1.0"
+              required
+            />
+            <button
+              type="button"
+              class="btn-secondary px-3 text-sm whitespace-nowrap"
+              :disabled="!cfg.host || !selectedInstanceId || snmpWalkLoading"
+              @click="snmpWalk"
+            >
+              <span v-if="snmpWalkLoading" class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin mr-1"></span>
+              {{ snmpWalkLoading ? 'Walk …' : 'OID-Walk' }}
+            </button>
+          </div>
+          <!-- Walk results -->
+          <div
+            v-if="snmpWalkResults.length > 0"
+            class="mt-1 max-h-52 overflow-y-auto border border-slate-200 dark:border-slate-700 rounded-lg divide-y divide-slate-100 dark:divide-slate-700/50 bg-white dark:bg-slate-800"
+          >
+            <button
+              v-for="entry in snmpWalkResults"
+              :key="entry.oid"
+              type="button"
+              class="w-full text-left px-3 py-1.5 text-xs hover:bg-slate-50 dark:hover:bg-slate-700/50 flex gap-2 items-baseline"
+              @click="cfg.oid = entry.oid"
+            >
+              <code class="text-blue-400 shrink-0">{{ entry.oid }}</code>
+              <span class="text-slate-400 shrink-0">[{{ entry.type }}]</span>
+              <span class="text-slate-600 dark:text-slate-300 truncate">{{ entry.value }}</span>
+            </button>
+          </div>
+          <p v-if="snmpWalkError" class="text-xs text-red-400 mt-1">{{ snmpWalkError }}</p>
+          <p class="hint">
+            Beispiele:
+            <code class="text-blue-400 cursor-pointer hover:underline" @click="cfg.oid='1.3.6.1.2.1.1.1.0'">1.3.6.1.2.1.1.1.0</code> (sysDescr) ·
+            <code class="text-blue-400 cursor-pointer hover:underline" @click="cfg.oid='1.3.6.1.2.1.1.3.0'">1.3.6.1.2.1.1.3.0</code> (sysUpTime) ·
+            <code class="text-blue-400 cursor-pointer hover:underline" @click="cfg.oid='1.3.6.1.4.1'">1.3.6.1.4.1</code> (enterprises)
+          </p>
+        </div>
+
+        <!-- Datentyp + Poll-Intervall -->
+        <div class="grid grid-cols-2 gap-4">
+          <div class="form-group">
+            <label class="label">Datentyp</label>
+            <select v-model="cfg.data_type" class="input">
+              <option value="auto">auto — automatisch erkennen</option>
+              <option value="int">int — Ganzzahl</option>
+              <option value="float">float — Gleitkomma</option>
+              <option value="string">string — Zeichenkette</option>
+              <option value="hex">hex — Hexadezimal</option>
+              <option value="counter">counter — Counter32/64</option>
+              <option value="gauge">gauge — Gauge32</option>
+              <option value="timeticks">timeticks — TimeTicks (1/100 s)</option>
+            </select>
+            <p class="hint">Bestimmt wie der Rohwert umgewandelt wird</p>
+          </div>
+          <div v-if="form.direction === 'SOURCE' || form.direction === 'BOTH'" class="form-group">
+            <label class="label">Poll-Intervall (s)</label>
+            <input v-model.number="cfg.poll_interval" type="number" min="1" step="1" class="input" />
+            <p class="hint">Standard: 30 s</p>
+          </div>
+        </div>
+
+        <div class="optional-divider">Erweiterte Einstellungen</div>
+        <div class="grid grid-cols-2 gap-4">
+          <div class="form-group">
+            <label class="label">Timeout (s)</label>
+            <input v-model.number="cfg.timeout" type="number" min="0.5" max="30" step="0.5" class="input" />
+            <p class="hint">Standard: 5 s</p>
+          </div>
+          <div class="form-group">
+            <label class="label">Wiederholungen</label>
+            <input v-model.number="cfg.retries" type="number" min="0" max="5" class="input" />
+            <p class="hint">Standard: 1</p>
+          </div>
+        </div>
+      </template>
+
       <div v-if="!selectedAdapterType && !props.initial" class="p-3 bg-slate-100/80 dark:bg-slate-800/40 rounded-lg text-sm text-slate-500 text-center">
         Bitte zuerst eine Adapter-Instanz wählen
       </div>
@@ -1043,6 +1144,13 @@ const cfg = reactive({
   offset_override: null,
   on_presence_override: null,
   on_presence_value: '',
+  // SNMP
+  host: '192.168.1.1',
+  port: 161,
+  oid: '',
+  data_type: 'auto',
+  timeout: 5.0,
+  retries: 1,
   // ZEITSCHALTUHR
   timer_type: 'daily', meta_type: 'none',
   weekdays: [0,1,2,3,4,5,6], months: [], day_of_month: 0,
@@ -1102,6 +1210,11 @@ const iobrokerStates = ref([])
 const iobrokerBrowseLoading = ref(false)
 const iobrokerBrowseError = ref(null)
 let iobrokerBrowseTimer = null
+
+// SNMP Walk state
+const snmpWalkResults = ref([])
+const snmpWalkLoading = ref(false)
+const snmpWalkError   = ref(null)
 
 // Zeitschaltuhr holiday list state (for Feiertagsschaltuhr)
 const ztHolidays = ref([])   // [{date, name}, …] sorted by date
@@ -1256,6 +1369,13 @@ watch(() => props.initial, val => {
   if (cfg.offset_override      === undefined) cfg.offset_override      = null
   if (cfg.on_presence_override === undefined) cfg.on_presence_override = null
   if (cfg.on_presence_value    === undefined) cfg.on_presence_value    = ''
+  // SNMP defaults when loading
+  if (cfg.host     == null) cfg.host     = '192.168.1.1'
+  if (cfg.port     == null) cfg.port     = 161
+  if (cfg.oid      == null) cfg.oid      = ''
+  if (cfg.data_type == null) cfg.data_type = 'auto'
+  if (cfg.timeout  == null) cfg.timeout  = 5.0
+  if (cfg.retries  == null) cfg.retries  = 1
   {
     const ANW_PRESETS = ['1', '7', '14']
     if (cfg.offset_override != null) {
@@ -1389,6 +1509,24 @@ function selectIoBrokerState(state) {
   iobrokerBrowseError.value = null
 }
 
+async function snmpWalk() {
+  const instanceId = selectedInstanceId.value
+  if (!instanceId || !cfg.host) return
+  snmpWalkLoading.value = true
+  snmpWalkError.value = null
+  snmpWalkResults.value = []
+  try {
+    const startOid = cfg.oid?.trim() || '1.3.6.1.2.1'
+    const { data } = await adapterApi.snmpWalk(instanceId, cfg.host, startOid, cfg.port || 161)
+    snmpWalkResults.value = data
+    if (data.length === 0) snmpWalkError.value = 'Keine OIDs gefunden'
+  } catch (e) {
+    snmpWalkError.value = e.response?.data?.detail ?? 'SNMP Walk fehlgeschlagen'
+  } finally {
+    snmpWalkLoading.value = false
+  }
+}
+
 function onValueMapPresetChange() {
   if (form.value_map_preset !== 'custom') {
     form.value_map_custom = ''
@@ -1444,6 +1582,7 @@ watch(selectedAdapterType, type => {
     activeTab.value = 'conn'
     showAdvancedTabs.value = false
   }
+  if (type === 'SNMP' && !cfg.poll_interval) cfg.poll_interval = 30.0
 })
 
 // Zeitschaltuhr helpers
@@ -1771,6 +1910,18 @@ function buildConfig() {
       if (cfg.on_presence_override === 'setzen' && cfg.on_presence_value?.trim())
         c.on_presence_value = cfg.on_presence_value.trim()
     }
+    return c
+  }
+  if (type === 'SNMP') {
+    const c = {
+      host: cfg.host || '192.168.1.1',
+      oid:  cfg.oid  || '1.3.6.1.2.1.1.1.0',
+    }
+    if (cfg.port && cfg.port !== 161)            c.port        = cfg.port
+    if (cfg.data_type && cfg.data_type !== 'auto') c.data_type = cfg.data_type
+    if (cfg.poll_interval)                         c.poll_interval = cfg.poll_interval
+    if (cfg.timeout && cfg.timeout !== 5.0)        c.timeout    = cfg.timeout
+    if (cfg.retries !== undefined && cfg.retries !== 1) c.retries = cfg.retries
     return c
   }
   return {}

--- a/gui/src/components/datapoints/BindingForm.vue
+++ b/gui/src/components/datapoints/BindingForm.vue
@@ -870,6 +870,14 @@
               placeholder="z.B. 1.3.6.1.2.1.1.1.0"
               required
             />
+          </div>
+          <!-- Walk root (independent from binding OID) -->
+          <div class="flex gap-2 mt-2">
+            <input
+              v-model="snmpWalkRoot"
+              class="input flex-1 font-mono text-xs"
+              placeholder="Walk ab OID, z.B. 1.3.6.1.2.1"
+            />
             <button
               type="button"
               class="btn-secondary px-3 text-sm whitespace-nowrap"
@@ -1224,6 +1232,7 @@ const snmpWalkResults = ref([])
 const snmpWalkLoading = ref(false)
 const snmpWalkError   = ref(null)
 const snmpWalkHasMore = ref(false)
+const snmpWalkRoot    = ref('1.3.6.1.2.1')
 
 // Zeitschaltuhr holiday list state (for Feiertagsschaltuhr)
 const ztHolidays = ref([])   // [{date, name}, …] sorted by date
@@ -1527,7 +1536,7 @@ async function snmpWalk(append = false) {
     snmpWalkResults.value = []
   }
   try {
-    const rootOid  = cfg.oid?.trim() || '1.3.6.1.2.1'
+    const rootOid  = snmpWalkRoot.value?.trim() || '1.3.6.1.2.1'
     const startOid = append && snmpWalkResults.value.length
       ? snmpWalkResults.value[snmpWalkResults.value.length - 1].oid
       : null

--- a/gui/src/components/datapoints/BindingForm.vue
+++ b/gui/src/components/datapoints/BindingForm.vue
@@ -897,6 +897,14 @@
               <span class="text-slate-600 dark:text-slate-300 truncate">{{ entry.value }}</span>
             </button>
           </div>
+          <button
+            v-if="snmpWalkHasMore && !snmpWalkLoading"
+            type="button"
+            class="mt-1 w-full text-xs text-center py-1 rounded border border-slate-300 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400"
+            @click="snmpWalk(true)"
+          >
+            {{ snmpWalkResults.length }} geladen — weitere 50 laden …
+          </button>
           <p v-if="snmpWalkError" class="text-xs text-red-400 mt-1">{{ snmpWalkError }}</p>
           <p class="hint">
             Beispiele:
@@ -1215,6 +1223,7 @@ let iobrokerBrowseTimer = null
 const snmpWalkResults = ref([])
 const snmpWalkLoading = ref(false)
 const snmpWalkError   = ref(null)
+const snmpWalkHasMore = ref(false)
 
 // Zeitschaltuhr holiday list state (for Feiertagsschaltuhr)
 const ztHolidays = ref([])   // [{date, name}, …] sorted by date
@@ -1509,17 +1518,27 @@ function selectIoBrokerState(state) {
   iobrokerBrowseError.value = null
 }
 
-async function snmpWalk() {
+async function snmpWalk(append = false) {
   const instanceId = selectedInstanceId.value
   if (!instanceId || !cfg.host) return
   snmpWalkLoading.value = true
-  snmpWalkError.value = null
-  snmpWalkResults.value = []
+  if (!append) {
+    snmpWalkError.value = null
+    snmpWalkResults.value = []
+  }
   try {
-    const startOid = cfg.oid?.trim() || '1.3.6.1.2.1'
-    const { data } = await adapterApi.snmpWalk(instanceId, cfg.host, startOid, cfg.port || 161)
-    snmpWalkResults.value = data
-    if (data.length === 0) snmpWalkError.value = 'Keine OIDs gefunden'
+    const rootOid  = cfg.oid?.trim() || '1.3.6.1.2.1'
+    const startOid = append && snmpWalkResults.value.length
+      ? snmpWalkResults.value[snmpWalkResults.value.length - 1].oid
+      : null
+    const { data } = await adapterApi.snmpWalk(instanceId, cfg.host, rootOid, cfg.port || 161, 50, 10, startOid)
+    if (append) {
+      snmpWalkResults.value = [...snmpWalkResults.value, ...data]
+    } else {
+      snmpWalkResults.value = data
+    }
+    if (snmpWalkResults.value.length === 0) snmpWalkError.value = 'Keine OIDs gefunden'
+    snmpWalkHasMore.value = data.length === 50
   } catch (e) {
     snmpWalkError.value = e.response?.data?.detail ?? 'SNMP Walk fehlgeschlagen'
   } finally {

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -180,7 +180,7 @@
           </div>
 
           <div v-if="!isDemo" class="flex gap-3 flex-wrap">
-            <button v-if="a.adapter_type !== 'ANWESENHEITSSIMULATION'" @click="testConnection(a)" class="btn-secondary btn-sm" :disabled="busy[a.id] === 'test'"
+            <button v-if="a.adapter_type !== 'ANWESENHEITSSIMULATION' && a.adapter_type !== 'SNMP'" @click="testConnection(a)" class="btn-secondary btn-sm" :disabled="busy[a.id] === 'test'"
               title="Prüft die Verbindung mit der aktuellen Konfiguration ohne zu speichern">
               <Spinner v-if="busy[a.id] === 'test'" size="xs" color="slate" />
               Verbindung testen

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 class SnmpAdapterConfig(BaseModel):
     version: Literal["1", "2c", "3"] = Field(default="2c", title="SNMP-Version")
     community: str = Field(default="public", title="Community-String (v1/v2c)")
-    security_name: str = Field(default="", title="Security Name (v3)")
+    security_name: str = Field(default="", title="Security Name / Username (v3)")
     security_level: Literal["noAuthNoPriv", "authNoPriv", "authPriv"] = Field(default="noAuthNoPriv", title="Security Level (v3)")
     auth_protocol: Literal["MD5", "SHA", "SHA256", "SHA512"] = Field(default="MD5", title="Auth-Protokoll (v3)")
     auth_key: str = Field(default="", title="Auth-Key (v3)")
@@ -446,7 +446,7 @@ class SnmpAdapter(AdapterBase):
         s = self._snmp
         if cfg.version == "3":
             if not cfg.security_name:
-                raise ValueError("SNMPv3: Security Name darf nicht leer sein")
+                raise ValueError("SNMPv3: Security Name / Username darf nicht leer sein")
             auth_proto = s["_auth_map"].get(cfg.auth_protocol, s["_no_auth"])
             priv_proto = s["_priv_map"].get(cfg.priv_protocol, s["_no_priv"])
 

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -487,11 +487,8 @@ class SnmpAdapter(AdapterBase):
         if error_status:
             raise RuntimeError(f"{error_status.prettyPrint()} bei Index {int(error_index)}")
 
-        # var_binds is 2D: list[list[ObjectType]]; each inner list is a row.
-        # With one requested OID, the row has exactly one ObjectType.
-        for row in var_binds:
-            obj_type = row[0]
-            return obj_type[1]  # obj_type[0]=OID, obj_type[1]=value
+        for var_bind in var_binds:
+            return var_bind[1]  # ObjectType[0]=OID, ObjectType[1]=value
         return None
 
     async def _snmp_set(self, bc: SnmpBindingConfig, value: Any) -> None:
@@ -565,12 +562,10 @@ class SnmpAdapter(AdapterBase):
             if not var_binds:
                 break
 
-            # var_binds is 2D: list[list[ObjectType]]; one row per step, one ObjectType per OID.
-            for row in var_binds:
-                obj_type = row[0]
-                obj_oid  = obj_type[0]  # ObjectType[0]=OID, [1]=value
-                value    = obj_type[1]
-                oid_str  = str(obj_oid)
+            for var_bind in var_binds:
+                obj_oid = var_bind[0]  # ObjectType[0]=OID, [1]=value
+                value   = var_bind[1]
+                oid_str = str(obj_oid)
 
                 # Stop when we leave the requested subtree
                 if not (oid_str == oid or oid_str.startswith(root_prefix)):

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -126,11 +126,11 @@ def _import_pysnmp() -> dict:
         except ImportError:
             import pysnmp.hlapi.asyncio as _hlapi_mod  # type: ignore[import]
 
-        usmHMACMD5AuthProtocol   = _hlapi_mod.usmHMACMD5AuthProtocol
-        usmHMACSHAAuthProtocol   = _hlapi_mod.usmHMACSHAAuthProtocol
-        usmNoAuthProtocol        = _hlapi_mod.usmNoAuthProtocol
-        usmNoPrivProtocol        = _hlapi_mod.usmNoPrivProtocol
-        usmDESPrivProtocol       = _hlapi_mod.usmDESPrivProtocol
+        usmHMACMD5AuthProtocol = _hlapi_mod.usmHMACMD5AuthProtocol
+        usmHMACSHAAuthProtocol = _hlapi_mod.usmHMACSHAAuthProtocol
+        usmNoAuthProtocol = _hlapi_mod.usmNoAuthProtocol
+        usmNoPrivProtocol = _hlapi_mod.usmNoPrivProtocol
+        usmDESPrivProtocol = _hlapi_mod.usmDESPrivProtocol
 
         auth_map: dict[str, Any] = {
             "MD5": usmHMACMD5AuthProtocol,
@@ -445,6 +445,8 @@ class SnmpAdapter(AdapterBase):
     def _build_auth(self, cfg: SnmpAdapterConfig) -> Any:
         s = self._snmp
         if cfg.version == "3":
+            if not cfg.security_name:
+                raise ValueError("SNMPv3: Security Name darf nicht leer sein")
             auth_proto = s["_auth_map"].get(cfg.auth_protocol, s["_no_auth"])
             priv_proto = s["_priv_map"].get(cfg.priv_protocol, s["_no_priv"])
 
@@ -569,10 +571,10 @@ class SnmpAdapter(AdapterBase):
             # nextCmd var_binds is 2D: list of rows; each row holds one ObjectType per
             # requested variable. We pass one OID → each row has exactly one entry.
             for row in var_binds:
-                var_bind = row[0]           # ObjectType for our single OID
-                obj_oid  = var_bind[0]      # ObjectType[0] = OID
-                value    = var_bind[1]      # ObjectType[1] = value
-                oid_str  = str(obj_oid)
+                var_bind = row[0]  # ObjectType for our single OID
+                obj_oid = var_bind[0]  # ObjectType[0] = OID
+                value = var_bind[1]  # ObjectType[1] = value
+                oid_str = str(obj_oid)
 
                 # Stop when we leave the requested subtree
                 if not (oid_str == oid or oid_str.startswith(root_prefix)):

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -448,8 +448,7 @@ class SnmpAdapter(AdapterBase):
             raise RuntimeError(f"{error_status.prettyPrint()} bei Index {int(error_index)}")
 
         for var_bind in var_binds:
-            _oid, value = var_bind
-            return value
+            return var_bind[1]  # var_bind[0]=OID, var_bind[1]=value
         return None
 
     async def _snmp_set(self, bc: SnmpBindingConfig, value: Any) -> None:
@@ -524,7 +523,8 @@ class SnmpAdapter(AdapterBase):
                 break
 
             for var_bind in var_binds:
-                obj_oid, value = var_bind
+                obj_oid = var_bind[0]  # ObjectType[0]=OID, [1]=value
+                value   = var_bind[1]
                 oid_str = str(obj_oid)
 
                 # Stop when we leave the requested subtree

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -170,45 +170,85 @@ def _import_pysnmp() -> dict:
         return {}
 
 
+def _pretty(snmp_value: Any) -> str:
+    """Return a string representation regardless of whether the value is a pysnmp type or a Python native."""
+    if hasattr(snmp_value, "prettyPrint"):
+        return snmp_value.prettyPrint()
+    return str(snmp_value)
+
+
 def _coerce_value(snmp_value: Any, data_type: str) -> Any:
-    """Convert a pysnmp value object to a Python native type."""
+    """Convert a pysnmp value object (or already-native Python value) to a Python native type.
+
+    pysnmp 6.x with lookupMib=True may return Python int/str directly instead of
+    pysnmp wrapper objects, so we must not assume prettyPrint() is available.
+    """
+    # Already a native Python scalar — return directly or apply requested cast
+    if isinstance(snmp_value, (bool, int, float)):
+        if data_type == "float":
+            return float(snmp_value)
+        if data_type in ("int", "counter", "gauge", "timeticks"):
+            return int(snmp_value)
+        if data_type == "hex":
+            return hex(int(snmp_value))
+        if data_type == "string":
+            return str(snmp_value)
+        return snmp_value  # auto: keep native type
+
+    if isinstance(snmp_value, (bytes, bytearray)):
+        if data_type == "hex" or data_type == "auto":
+            return snmp_value.hex()
+        return snmp_value.decode(errors="replace")
+
+    if isinstance(snmp_value, str):
+        if data_type == "auto":
+            try:
+                return int(snmp_value)
+            except ValueError:
+                pass
+            try:
+                return float(snmp_value)
+            except ValueError:
+                pass
+        return snmp_value
+
+    # pysnmp wrapper object — use prettyPrint() / int() as before
     type_name = type(snmp_value).__name__
 
     if data_type == "int" or (data_type == "auto" and type_name in ("Integer32", "Integer", "Unsigned32")):
         try:
             return int(snmp_value)
         except Exception:
-            return snmp_value.prettyPrint()
+            return _pretty(snmp_value)
 
     if data_type in ("counter", "gauge") or (data_type == "auto" and type_name in ("Counter32", "Counter64", "Gauge32", "Gauge")):
         try:
             return int(snmp_value)
         except Exception:
-            return snmp_value.prettyPrint()
+            return _pretty(snmp_value)
 
     if data_type == "timeticks" or (data_type == "auto" and type_name == "TimeTicks"):
         try:
             return int(snmp_value)
         except Exception:
-            return snmp_value.prettyPrint()
+            return _pretty(snmp_value)
 
     if data_type == "float":
         try:
-            return float(snmp_value.prettyPrint())
+            return float(_pretty(snmp_value))
         except ValueError:
-            return snmp_value.prettyPrint()
+            return _pretty(snmp_value)
 
     if data_type == "hex":
         try:
             raw = bytes(snmp_value)
             return raw.hex()
         except Exception:
-            return snmp_value.prettyPrint()
+            return _pretty(snmp_value)
 
     # "string" or "auto" fallback
-    pp = snmp_value.prettyPrint()
+    pp = _pretty(snmp_value)
     if data_type == "auto":
-        # Try numeric coercion for auto mode
         try:
             return int(pp)
         except ValueError:
@@ -539,7 +579,7 @@ class SnmpAdapter(AdapterBase):
                 results.append(
                     {
                         "oid": oid_str,
-                        "value": value.prettyPrint(),
+                        "value": _pretty(value),
                         "type": type(value).__name__,
                     }
                 )

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -51,16 +51,10 @@ class SnmpAdapterConfig(BaseModel):
     version: Literal["1", "2c", "3"] = Field(default="2c", title="SNMP-Version")
     community: str = Field(default="public", title="Community-String (v1/v2c)")
     security_name: str = Field(default="", title="Security Name (v3)")
-    security_level: Literal["noAuthNoPriv", "authNoPriv", "authPriv"] = Field(
-        default="noAuthNoPriv", title="Security Level (v3)"
-    )
-    auth_protocol: Literal["MD5", "SHA", "SHA256", "SHA512"] = Field(
-        default="MD5", title="Auth-Protokoll (v3)"
-    )
+    security_level: Literal["noAuthNoPriv", "authNoPriv", "authPriv"] = Field(default="noAuthNoPriv", title="Security Level (v3)")
+    auth_protocol: Literal["MD5", "SHA", "SHA256", "SHA512"] = Field(default="MD5", title="Auth-Protokoll (v3)")
     auth_key: str = Field(default="", title="Auth-Key (v3)")
-    priv_protocol: Literal["DES", "3DES", "AES128", "AES192", "AES256"] = Field(
-        default="DES", title="Privacy-Protokoll (v3)"
-    )
+    priv_protocol: Literal["DES", "3DES", "AES128", "AES192", "AES256"] = Field(default="DES", title="Privacy-Protokoll (v3)")
     priv_key: str = Field(default="", title="Privacy-Key (v3)")
 
 
@@ -68,9 +62,7 @@ class SnmpBindingConfig(BaseModel):
     host: str = Field(default="192.168.1.1", title="Host (IP/DNS)")
     port: int = Field(default=161, ge=1, le=65535, title="UDP-Port")
     oid: str = Field(default="1.3.6.1.2.1.1.1.0", title="OID")
-    data_type: Literal["auto", "int", "float", "string", "hex", "counter", "gauge", "timeticks"] = Field(
-        default="auto", title="Datentyp"
-    )
+    data_type: Literal["auto", "int", "float", "string", "hex", "counter", "gauge", "timeticks"] = Field(default="auto", title="Datentyp")
     poll_interval: float = Field(default=30.0, ge=1.0, title="Poll-Intervall (s)")
     timeout: float = Field(default=5.0, ge=0.5, le=30.0, title="Timeout (s)")
     retries: int = Field(default=1, ge=0, le=5, title="Wiederholungen")
@@ -126,13 +118,19 @@ def _import_pysnmp() -> dict:
             }
         )
 
-        from pysnmp.hlapi import (  # type: ignore[import]
-            usmHMACMD5AuthProtocol,
-            usmHMACSHAAuthProtocol,
-            usmNoAuthProtocol,
-            usmNoPrivProtocol,
-            usmDESPrivProtocol,
-        )
+        # Auth/priv constants: in v6.x they live in hlapi.asyncio (or hlapi.v3arch.asyncio),
+        # not in hlapi directly. Try the path that already succeeded above.
+        _hlapi_mod: Any
+        try:
+            import pysnmp.hlapi.v3arch.asyncio as _hlapi_mod  # type: ignore[import]
+        except ImportError:
+            import pysnmp.hlapi.asyncio as _hlapi_mod  # type: ignore[import]
+
+        usmHMACMD5AuthProtocol   = _hlapi_mod.usmHMACMD5AuthProtocol
+        usmHMACSHAAuthProtocol   = _hlapi_mod.usmHMACSHAAuthProtocol
+        usmNoAuthProtocol        = _hlapi_mod.usmNoAuthProtocol
+        usmNoPrivProtocol        = _hlapi_mod.usmNoPrivProtocol
+        usmDESPrivProtocol       = _hlapi_mod.usmDESPrivProtocol
 
         auth_map: dict[str, Any] = {
             "MD5": usmHMACMD5AuthProtocol,
@@ -146,38 +144,21 @@ def _import_pysnmp() -> dict:
         }
 
         # Optional modern auth protocols
-        try:
-            from pysnmp.hlapi import usmHMAC192SHA256AuthProtocol  # type: ignore[import]
-            auth_map["SHA256"] = usmHMAC192SHA256AuthProtocol
-        except ImportError:
-            pass
-        try:
-            from pysnmp.hlapi import usmHMAC384SHA512AuthProtocol  # type: ignore[import]
-            auth_map["SHA512"] = usmHMAC384SHA512AuthProtocol
-        except ImportError:
-            pass
+        for attr, key in [("usmHMAC192SHA256AuthProtocol", "SHA256"), ("usmHMAC384SHA512AuthProtocol", "SHA512")]:
+            val = getattr(_hlapi_mod, attr, None)
+            if val is not None:
+                auth_map[key] = val
 
         # Optional privacy protocols
-        try:
-            from pysnmp.hlapi import usm3DESEDEPrivProtocol  # type: ignore[import]
-            priv_map["3DES"] = usm3DESEDEPrivProtocol
-        except ImportError:
-            priv_map["3DES"] = usmDESPrivProtocol
-        try:
-            from pysnmp.hlapi import usmAesCfb128Protocol  # type: ignore[import]
-            priv_map["AES128"] = usmAesCfb128Protocol
-        except ImportError:
-            pass
-        try:
-            from pysnmp.hlapi import usmAesCfb192Protocol  # type: ignore[import]
-            priv_map["AES192"] = usmAesCfb192Protocol
-        except ImportError:
-            pass
-        try:
-            from pysnmp.hlapi import usmAesCfb256Protocol  # type: ignore[import]
-            priv_map["AES256"] = usmAesCfb256Protocol
-        except ImportError:
-            pass
+        for attr, key, fallback in [
+            ("usm3DESEDEPrivProtocol", "3DES", usmDESPrivProtocol),
+            ("usmAesCfb128Protocol", "AES128", None),
+            ("usmAesCfb192Protocol", "AES192", None),
+            ("usmAesCfb256Protocol", "AES256", None),
+        ]:
+            val = getattr(_hlapi_mod, attr, fallback)
+            if val is not None:
+                priv_map[key] = val
 
         symbols["_auth_map"] = auth_map
         symbols["_priv_map"] = priv_map
@@ -193,17 +174,13 @@ def _coerce_value(snmp_value: Any, data_type: str) -> Any:
     """Convert a pysnmp value object to a Python native type."""
     type_name = type(snmp_value).__name__
 
-    if data_type == "int" or (
-        data_type == "auto" and type_name in ("Integer32", "Integer", "Unsigned32")
-    ):
+    if data_type == "int" or (data_type == "auto" and type_name in ("Integer32", "Integer", "Unsigned32")):
         try:
             return int(snmp_value)
         except Exception:
             return snmp_value.prettyPrint()
 
-    if data_type in ("counter", "gauge") or (
-        data_type == "auto" and type_name in ("Counter32", "Counter64", "Gauge32", "Gauge")
-    ):
+    if data_type in ("counter", "gauge") or (data_type == "auto" and type_name in ("Counter32", "Counter64", "Gauge32", "Gauge")):
         try:
             return int(snmp_value)
         except Exception:
@@ -287,8 +264,8 @@ class SnmpAdapter(AdapterBase):
 
     def __init__(self, event_bus: Any, config: dict | None = None, **kwargs) -> None:
         super().__init__(event_bus, config, **kwargs)
-        self._snmp: dict = {}           # lazy-loaded pysnmp symbols
-        self._engine: Any = None        # SnmpEngine instance
+        self._snmp: dict = {}  # lazy-loaded pysnmp symbols
+        self._engine: Any = None  # SnmpEngine instance
         self._poll_tasks: list[asyncio.Task] = []
 
     # ------------------------------------------------------------------
@@ -508,7 +485,11 @@ class SnmpAdapter(AdapterBase):
         retries: int = 1,
         max_results: int = 500,
     ) -> list[dict[str, str]]:
-        """SNMP-Walk über einen OID-Teilbaum; gibt Liste von {oid, value, type} zurück."""
+        """SNMP-Walk über einen OID-Teilbaum; gibt Liste von {oid, value, type} zurück.
+
+        nextCmd() in pysnmp hlapi returns a single GETNEXT step per call, so we
+        loop manually and stop once the returned OID leaves the target subtree.
+        """
         if not self._engine:
             raise RuntimeError("SNMP Adapter nicht verbunden")
 
@@ -517,15 +498,21 @@ class SnmpAdapter(AdapterBase):
         auth = self._build_auth(cfg)
         transport = s["UdpTransportTarget"]((host, port), timeout=timeout, retries=retries)
 
+        # Normalise root OID for subtree comparison (ensure trailing dot)
+        root_prefix = oid if oid.endswith(".") else oid + "."
+
         results: list[dict[str, str]] = []
-        async for error_indication, error_status, _error_index, var_binds in s["nextCmd"](
-            self._engine,
-            auth,
-            transport,
-            s["ContextData"](),
-            s["ObjectType"](s["ObjectIdentity"](oid)),
-            lexicographicMode=False,
-        ):
+        current_oid = oid
+
+        while True:
+            error_indication, error_status, _error_index, var_binds = await s["nextCmd"](
+                self._engine,
+                auth,
+                transport,
+                s["ContextData"](),
+                s["ObjectType"](s["ObjectIdentity"](current_oid)),
+            )
+
             if error_indication:
                 logger.warning("SNMP Walk Fehler: %s", error_indication)
                 break
@@ -533,16 +520,27 @@ class SnmpAdapter(AdapterBase):
                 logger.warning("SNMP Walk Status-Fehler: %s", error_status.prettyPrint())
                 break
 
+            if not var_binds:
+                break
+
             for var_bind in var_binds:
                 obj_oid, value = var_bind
+                oid_str = str(obj_oid)
+
+                # Stop when we leave the requested subtree
+                if not (oid_str == oid or oid_str.startswith(root_prefix)):
+                    return results
+
                 results.append(
                     {
-                        "oid": str(obj_oid),
+                        "oid": oid_str,
                         "value": value.prettyPrint(),
                         "type": type(value).__name__,
                     }
                 )
-                if len(results) >= max_results:
-                    return results
+                current_oid = oid_str
+
+            if len(results) >= max_results:
+                break
 
         return results

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -522,12 +522,18 @@ class SnmpAdapter(AdapterBase):
         port: int = 161,
         timeout: float = 5.0,
         retries: int = 1,
-        max_results: int = 500,
+        max_results: int = 50,
+        start_oid: str | None = None,
     ) -> list[dict[str, str]]:
         """SNMP-Walk über einen OID-Teilbaum; gibt Liste von {oid, value, type} zurück.
 
-        nextCmd() in pysnmp hlapi returns a single GETNEXT step per call, so we
-        loop manually and stop once the returned OID leaves the target subtree.
+        getCmd()  → var_binds is 1D: [ObjectType, ...]
+        nextCmd() → var_binds is 2D: [[ObjectType, ...], ...]  (table rows)
+        Each call to nextCmd() returns one GETNEXT step; we loop until the
+        returned OID leaves the requested subtree.
+
+        start_oid: optional cursor for pagination — walk starts here instead of
+        at `oid`, but the subtree boundary is still determined by `oid`.
         """
         if not self._engine:
             raise RuntimeError("SNMP Adapter nicht verbunden")
@@ -537,11 +543,9 @@ class SnmpAdapter(AdapterBase):
         auth = self._build_auth(cfg)
         transport = s["UdpTransportTarget"]((host, port), timeout=timeout, retries=retries)
 
-        # Normalise root OID for subtree comparison (ensure trailing dot)
         root_prefix = oid if oid.endswith(".") else oid + "."
-
         results: list[dict[str, str]] = []
-        current_oid = oid
+        current_oid = start_oid if start_oid else oid
 
         while True:
             error_indication, error_status, _error_index, var_binds = await s["nextCmd"](
@@ -562,10 +566,13 @@ class SnmpAdapter(AdapterBase):
             if not var_binds:
                 break
 
-            for var_bind in var_binds:
-                obj_oid = var_bind[0]  # ObjectType[0]=OID, [1]=value
-                value   = var_bind[1]
-                oid_str = str(obj_oid)
+            # nextCmd var_binds is 2D: list of rows; each row holds one ObjectType per
+            # requested variable. We pass one OID → each row has exactly one entry.
+            for row in var_binds:
+                var_bind = row[0]           # ObjectType for our single OID
+                obj_oid  = var_bind[0]      # ObjectType[0] = OID
+                value    = var_bind[1]      # ObjectType[1] = value
+                oid_str  = str(obj_oid)
 
                 # Stop when we leave the requested subtree
                 if not (oid_str == oid or oid_str.startswith(root_prefix)):

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -53,9 +53,9 @@ class SnmpAdapterConfig(BaseModel):
     security_name: str = Field(default="", title="Security Name / Username (v3)")
     security_level: Literal["noAuthNoPriv", "authNoPriv", "authPriv"] = Field(default="noAuthNoPriv", title="Security Level (v3)")
     auth_protocol: Literal["MD5", "SHA", "SHA256", "SHA512"] = Field(default="MD5", title="Auth-Protokoll (v3)")
-    auth_key: str = Field(default="", title="Auth-Key (v3)")
+    auth_key: str = Field(default="", title="Auth-Key (v3)", json_schema_extra={"format": "password"})
     priv_protocol: Literal["DES", "3DES", "AES128", "AES192", "AES256"] = Field(default="DES", title="Privacy-Protokoll (v3)")
-    priv_key: str = Field(default="", title="Privacy-Key (v3)")
+    priv_key: str = Field(default="", title="Privacy-Key (v3)", json_schema_extra={"format": "password"})
 
 
 class SnmpBindingConfig(BaseModel):

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -447,8 +447,11 @@ class SnmpAdapter(AdapterBase):
         if error_status:
             raise RuntimeError(f"{error_status.prettyPrint()} bei Index {int(error_index)}")
 
-        for var_bind in var_binds:
-            return var_bind[1]  # var_bind[0]=OID, var_bind[1]=value
+        # var_binds is 2D: list[list[ObjectType]]; each inner list is a row.
+        # With one requested OID, the row has exactly one ObjectType.
+        for row in var_binds:
+            obj_type = row[0]
+            return obj_type[1]  # obj_type[0]=OID, obj_type[1]=value
         return None
 
     async def _snmp_set(self, bc: SnmpBindingConfig, value: Any) -> None:
@@ -522,10 +525,12 @@ class SnmpAdapter(AdapterBase):
             if not var_binds:
                 break
 
-            for var_bind in var_binds:
-                obj_oid = var_bind[0]  # ObjectType[0]=OID, [1]=value
-                value   = var_bind[1]
-                oid_str = str(obj_oid)
+            # var_binds is 2D: list[list[ObjectType]]; one row per step, one ObjectType per OID.
+            for row in var_binds:
+                obj_type = row[0]
+                obj_oid  = obj_type[0]  # ObjectType[0]=OID, [1]=value
+                value    = obj_type[1]
+                oid_str  = str(obj_oid)
 
                 # Stop when we leave the requested subtree
                 if not (oid_str == oid or oid_str.startswith(root_prefix)):

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -1,0 +1,548 @@
+"""SNMP Adapter — SNMPv1, v2c, v3
+
+Pollt SOURCE-Bindings per UDP/SNMP zyklisch, schreibt DEST-Bindings via SNMP SET.
+Jedes Binding konfiguriert seinen eigenen Host/Port – SNMP ist zustandslos/UDP,
+daher gibt es keine persistente Verbindung, sondern einen Credential-Container.
+
+Adapter-Konfiguration (adapter_instances.config):
+  version:          "1" | "2c" | "3"                            (default: "2c")
+  -- v1/v2c --
+  community:        str                                          (default: "public")
+  -- v3 --
+  security_name:    str                                          (default: "")
+  security_level:   "noAuthNoPriv" | "authNoPriv" | "authPriv"  (default: "noAuthNoPriv")
+  auth_protocol:    "MD5" | "SHA" | "SHA256" | "SHA512"         (default: "MD5")
+  auth_key:         str                                          (default: "")
+  priv_protocol:    "DES" | "3DES" | "AES128" | "AES192" | "AES256"  (default: "DES")
+  priv_key:         str                                          (default: "")
+
+Binding-Konfiguration (adapter_bindings.config):
+  host:             str    IP oder DNS-Name des Geräts           (default: "192.168.1.1")
+  port:             int    UDP-Port                              (default: 161)
+  oid:              str    z.B. "1.3.6.1.2.1.1.1.0"
+  data_type:        "auto" | "int" | "float" | "string" | "hex" | "counter" | "gauge" | "timeticks"
+                                                                 (default: "auto")
+  poll_interval:    float  Sekunden (SOURCE/BOTH)                (default: 30.0)
+  timeout:          float  Sekunden pro Anfrage                  (default: 5.0)
+  retries:          int    Wiederholungen bei Fehler             (default: 1)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from obs.adapters.base import AdapterBase
+from obs.adapters.registry import register
+from obs.core.event_bus import DataValueEvent
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config Schemas
+# ---------------------------------------------------------------------------
+
+
+class SnmpAdapterConfig(BaseModel):
+    version: Literal["1", "2c", "3"] = Field(default="2c", title="SNMP-Version")
+    community: str = Field(default="public", title="Community-String (v1/v2c)")
+    security_name: str = Field(default="", title="Security Name (v3)")
+    security_level: Literal["noAuthNoPriv", "authNoPriv", "authPriv"] = Field(
+        default="noAuthNoPriv", title="Security Level (v3)"
+    )
+    auth_protocol: Literal["MD5", "SHA", "SHA256", "SHA512"] = Field(
+        default="MD5", title="Auth-Protokoll (v3)"
+    )
+    auth_key: str = Field(default="", title="Auth-Key (v3)")
+    priv_protocol: Literal["DES", "3DES", "AES128", "AES192", "AES256"] = Field(
+        default="DES", title="Privacy-Protokoll (v3)"
+    )
+    priv_key: str = Field(default="", title="Privacy-Key (v3)")
+
+
+class SnmpBindingConfig(BaseModel):
+    host: str = Field(default="192.168.1.1", title="Host (IP/DNS)")
+    port: int = Field(default=161, ge=1, le=65535, title="UDP-Port")
+    oid: str = Field(default="1.3.6.1.2.1.1.1.0", title="OID")
+    data_type: Literal["auto", "int", "float", "string", "hex", "counter", "gauge", "timeticks"] = Field(
+        default="auto", title="Datentyp"
+    )
+    poll_interval: float = Field(default=30.0, ge=1.0, title="Poll-Intervall (s)")
+    timeout: float = Field(default=5.0, ge=0.5, le=30.0, title="Timeout (s)")
+    retries: int = Field(default=1, ge=0, le=5, title="Wiederholungen")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — lazy pysnmp import
+# ---------------------------------------------------------------------------
+
+
+def _import_pysnmp() -> dict:
+    """Import pysnmp symbols; supports both v5 (hlapi.asyncio) and v6 (hlapi.v3arch.asyncio)."""
+    symbols: dict = {}
+    try:
+        try:
+            from pysnmp.hlapi.v3arch.asyncio import (  # type: ignore[import]
+                CommunityData,
+                ContextData,
+                ObjectIdentity,
+                ObjectType,
+                SnmpEngine,
+                UdpTransportTarget,
+                UsmUserData,
+                getCmd,
+                nextCmd,
+                setCmd,
+            )
+        except ImportError:
+            from pysnmp.hlapi.asyncio import (  # type: ignore[import]
+                CommunityData,
+                ContextData,
+                ObjectIdentity,
+                ObjectType,
+                SnmpEngine,
+                UdpTransportTarget,
+                UsmUserData,
+                getCmd,
+                nextCmd,
+                setCmd,
+            )
+        symbols.update(
+            {
+                "getCmd": getCmd,
+                "setCmd": setCmd,
+                "nextCmd": nextCmd,
+                "SnmpEngine": SnmpEngine,
+                "CommunityData": CommunityData,
+                "UsmUserData": UsmUserData,
+                "UdpTransportTarget": UdpTransportTarget,
+                "ContextData": ContextData,
+                "ObjectType": ObjectType,
+                "ObjectIdentity": ObjectIdentity,
+            }
+        )
+
+        from pysnmp.hlapi import (  # type: ignore[import]
+            usmHMACMD5AuthProtocol,
+            usmHMACSHAAuthProtocol,
+            usmNoAuthProtocol,
+            usmNoPrivProtocol,
+            usmDESPrivProtocol,
+        )
+
+        auth_map: dict[str, Any] = {
+            "MD5": usmHMACMD5AuthProtocol,
+            "SHA": usmHMACSHAAuthProtocol,
+            "SHA256": usmHMACSHAAuthProtocol,
+            "SHA512": usmHMACSHAAuthProtocol,
+        }
+        priv_map: dict[str, Any] = {
+            "DES": usmDESPrivProtocol,
+            "noPriv": usmNoPrivProtocol,
+        }
+
+        # Optional modern auth protocols
+        try:
+            from pysnmp.hlapi import usmHMAC192SHA256AuthProtocol  # type: ignore[import]
+            auth_map["SHA256"] = usmHMAC192SHA256AuthProtocol
+        except ImportError:
+            pass
+        try:
+            from pysnmp.hlapi import usmHMAC384SHA512AuthProtocol  # type: ignore[import]
+            auth_map["SHA512"] = usmHMAC384SHA512AuthProtocol
+        except ImportError:
+            pass
+
+        # Optional privacy protocols
+        try:
+            from pysnmp.hlapi import usm3DESEDEPrivProtocol  # type: ignore[import]
+            priv_map["3DES"] = usm3DESEDEPrivProtocol
+        except ImportError:
+            priv_map["3DES"] = usmDESPrivProtocol
+        try:
+            from pysnmp.hlapi import usmAesCfb128Protocol  # type: ignore[import]
+            priv_map["AES128"] = usmAesCfb128Protocol
+        except ImportError:
+            pass
+        try:
+            from pysnmp.hlapi import usmAesCfb192Protocol  # type: ignore[import]
+            priv_map["AES192"] = usmAesCfb192Protocol
+        except ImportError:
+            pass
+        try:
+            from pysnmp.hlapi import usmAesCfb256Protocol  # type: ignore[import]
+            priv_map["AES256"] = usmAesCfb256Protocol
+        except ImportError:
+            pass
+
+        symbols["_auth_map"] = auth_map
+        symbols["_priv_map"] = priv_map
+        symbols["_no_auth"] = usmNoAuthProtocol
+        symbols["_no_priv"] = usmNoPrivProtocol
+        return symbols
+
+    except ImportError:
+        return {}
+
+
+def _coerce_value(snmp_value: Any, data_type: str) -> Any:
+    """Convert a pysnmp value object to a Python native type."""
+    type_name = type(snmp_value).__name__
+
+    if data_type == "int" or (
+        data_type == "auto" and type_name in ("Integer32", "Integer", "Unsigned32")
+    ):
+        try:
+            return int(snmp_value)
+        except Exception:
+            return snmp_value.prettyPrint()
+
+    if data_type in ("counter", "gauge") or (
+        data_type == "auto" and type_name in ("Counter32", "Counter64", "Gauge32", "Gauge")
+    ):
+        try:
+            return int(snmp_value)
+        except Exception:
+            return snmp_value.prettyPrint()
+
+    if data_type == "timeticks" or (data_type == "auto" and type_name == "TimeTicks"):
+        try:
+            return int(snmp_value)
+        except Exception:
+            return snmp_value.prettyPrint()
+
+    if data_type == "float":
+        try:
+            return float(snmp_value.prettyPrint())
+        except ValueError:
+            return snmp_value.prettyPrint()
+
+    if data_type == "hex":
+        try:
+            raw = bytes(snmp_value)
+            return raw.hex()
+        except Exception:
+            return snmp_value.prettyPrint()
+
+    # "string" or "auto" fallback
+    pp = snmp_value.prettyPrint()
+    if data_type == "auto":
+        # Try numeric coercion for auto mode
+        try:
+            return int(pp)
+        except ValueError:
+            pass
+        try:
+            return float(pp)
+        except ValueError:
+            pass
+    return pp
+
+
+def _encode_write_value(value: Any, data_type: str) -> Any:
+    """Encode a Python value to a pysnmp type for SNMP SET operations."""
+    try:
+        from pysnmp.proto.rfc1902 import Integer32, OctetString  # type: ignore[import]
+    except ImportError:
+        return value
+
+    if data_type in ("int", "counter", "gauge"):
+        return Integer32(int(value))
+    if data_type == "string":
+        return OctetString(str(value).encode())
+    if data_type == "float":
+        return OctetString(str(value).encode())
+    if data_type == "hex":
+        if isinstance(value, str):
+            try:
+                return OctetString(bytes.fromhex(value))
+            except ValueError:
+                pass
+        return OctetString(str(value).encode())
+
+    # auto: detect from Python type
+    if isinstance(value, bool):
+        return Integer32(int(value))
+    if isinstance(value, int):
+        return Integer32(value)
+    return OctetString(str(value).encode())
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+@register
+class SnmpAdapter(AdapterBase):
+    """SNMPv1/v2c/v3 adapter — polls SOURCE bindings, writes DEST bindings via SET."""
+
+    adapter_type = "SNMP"
+    config_schema = SnmpAdapterConfig
+    binding_config_schema = SnmpBindingConfig
+
+    def __init__(self, event_bus: Any, config: dict | None = None, **kwargs) -> None:
+        super().__init__(event_bus, config, **kwargs)
+        self._snmp: dict = {}           # lazy-loaded pysnmp symbols
+        self._engine: Any = None        # SnmpEngine instance
+        self._poll_tasks: list[asyncio.Task] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        self._snmp = _import_pysnmp()
+        if not self._snmp:
+            msg = "pysnmp nicht installiert — SNMP deaktiviert. Ausführen: pip install pysnmp"
+            logger.error(msg)
+            await self._publish_status(False, msg)
+            return
+
+        self._engine = self._snmp["SnmpEngine"]()
+        cfg = SnmpAdapterConfig(**self._config)
+        detail = f"SNMPv{cfg.version}"
+        if cfg.version in ("1", "2c"):
+            detail += f" community={cfg.community!r}"
+        else:
+            detail += f" user={cfg.security_name!r} level={cfg.security_level}"
+
+        await self._publish_status(True, detail)
+        logger.info("SNMP Adapter bereit: %s", detail)
+
+    async def disconnect(self) -> None:
+        for t in self._poll_tasks:
+            t.cancel()
+        self._poll_tasks.clear()
+        self._engine = None
+        await self._publish_status(False, "Getrennt")
+
+    # ------------------------------------------------------------------
+    # Bindings
+    # ------------------------------------------------------------------
+
+    async def _on_bindings_reloaded(self) -> None:
+        for t in self._poll_tasks:
+            t.cancel()
+        self._poll_tasks.clear()
+
+        source_bindings = [b for b in self._bindings if b.direction in ("SOURCE", "BOTH")]
+        for binding in source_bindings:
+            t = asyncio.create_task(
+                self._poll_loop(binding),
+                name=f"snmp-poll-{binding.id}",
+            )
+            self._poll_tasks.append(t)
+
+        logger.debug("SNMP: %d Poll-Tasks gestartet", len(self._poll_tasks))
+
+    # ------------------------------------------------------------------
+    # Poll loop
+    # ------------------------------------------------------------------
+
+    async def _poll_loop(self, binding: Any) -> None:
+        try:
+            bc = SnmpBindingConfig(**binding.config)
+        except Exception:
+            logger.warning("Ungültige SNMP-Binding-Konfiguration %s — übersprungen", binding.id)
+            return
+
+        while True:
+            try:
+                raw = await self._snmp_get(bc)
+                if raw is None:
+                    raise ValueError("Kein Wert empfangen")
+
+                value = _coerce_value(raw, bc.data_type)
+                quality = "good"
+
+                if binding.value_formula:
+                    from obs.core.formula import apply_formula
+
+                    value = apply_formula(binding.value_formula, value)
+                if binding.value_map:
+                    from obs.core.transformation import apply_value_map
+
+                    value = apply_value_map(value, binding.value_map)
+
+                await self._bus.publish(
+                    DataValueEvent(
+                        datapoint_id=binding.datapoint_id,
+                        value=value,
+                        quality=quality,
+                        source_adapter=self.adapter_type,
+                        binding_id=binding.id,
+                    )
+                )
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.warning("SNMP Poll-Fehler (Binding %s): %s", binding.id, exc)
+                await self._bus.publish(
+                    DataValueEvent(
+                        datapoint_id=binding.datapoint_id,
+                        value=None,
+                        quality="bad",
+                        source_adapter=self.adapter_type,
+                        binding_id=binding.id,
+                    )
+                )
+
+            await asyncio.sleep(bc.poll_interval)
+
+    # ------------------------------------------------------------------
+    # Read / Write
+    # ------------------------------------------------------------------
+
+    async def read(self, binding: Any) -> Any:
+        if not self._engine:
+            return None
+        try:
+            bc = SnmpBindingConfig(**binding.config)
+            raw = await self._snmp_get(bc)
+            if raw is None:
+                return None
+            return _coerce_value(raw, bc.data_type)
+        except Exception:
+            logger.exception("SNMP read fehlgeschlagen für Binding %s", binding.id)
+            return None
+
+    async def write(self, binding: Any, value: Any) -> None:
+        if not self._engine:
+            logger.warning("SNMP write übersprungen — nicht verbunden")
+            return
+        try:
+            bc = SnmpBindingConfig(**binding.config)
+            await self._snmp_set(bc, value)
+        except Exception:
+            logger.exception("SNMP write fehlgeschlagen für Binding %s", binding.id)
+
+    # ------------------------------------------------------------------
+    # SNMP GET / SET low-level
+    # ------------------------------------------------------------------
+
+    def _build_auth(self, cfg: SnmpAdapterConfig) -> Any:
+        s = self._snmp
+        if cfg.version == "3":
+            auth_proto = s["_auth_map"].get(cfg.auth_protocol, s["_no_auth"])
+            priv_proto = s["_priv_map"].get(cfg.priv_protocol, s["_no_priv"])
+
+            if cfg.security_level == "noAuthNoPriv":
+                return s["UsmUserData"](cfg.security_name)
+            if cfg.security_level == "authNoPriv":
+                return s["UsmUserData"](
+                    cfg.security_name,
+                    authKey=cfg.auth_key,
+                    authProtocol=auth_proto,
+                )
+            # authPriv
+            return s["UsmUserData"](
+                cfg.security_name,
+                authKey=cfg.auth_key,
+                privKey=cfg.priv_key,
+                authProtocol=auth_proto,
+                privProtocol=priv_proto,
+            )
+
+        mp_model = 0 if cfg.version == "1" else 1
+        return s["CommunityData"](cfg.community, mpModel=mp_model)
+
+    async def _snmp_get(self, bc: SnmpBindingConfig) -> Any:
+        s = self._snmp
+        cfg = SnmpAdapterConfig(**self._config)
+        auth = self._build_auth(cfg)
+        transport = s["UdpTransportTarget"]((bc.host, bc.port), timeout=bc.timeout, retries=bc.retries)
+
+        error_indication, error_status, error_index, var_binds = await s["getCmd"](
+            self._engine,
+            auth,
+            transport,
+            s["ContextData"](),
+            s["ObjectType"](s["ObjectIdentity"](bc.oid)),
+        )
+
+        if error_indication:
+            raise RuntimeError(str(error_indication))
+        if error_status:
+            raise RuntimeError(f"{error_status.prettyPrint()} bei Index {int(error_index)}")
+
+        for var_bind in var_binds:
+            _oid, value = var_bind
+            return value
+        return None
+
+    async def _snmp_set(self, bc: SnmpBindingConfig, value: Any) -> None:
+        s = self._snmp
+        cfg = SnmpAdapterConfig(**self._config)
+        auth = self._build_auth(cfg)
+        transport = s["UdpTransportTarget"]((bc.host, bc.port), timeout=bc.timeout, retries=bc.retries)
+        snmp_value = _encode_write_value(value, bc.data_type)
+
+        error_indication, error_status, error_index, _var_binds = await s["setCmd"](
+            self._engine,
+            auth,
+            transport,
+            s["ContextData"](),
+            s["ObjectType"](s["ObjectIdentity"](bc.oid), snmp_value),
+        )
+
+        if error_indication:
+            raise RuntimeError(str(error_indication))
+        if error_status:
+            raise RuntimeError(f"{error_status.prettyPrint()} bei Index {int(error_index)}")
+
+    # ------------------------------------------------------------------
+    # SNMP Walk (für Discovery-Endpunkt)
+    # ------------------------------------------------------------------
+
+    async def snmp_walk(
+        self,
+        host: str,
+        oid: str,
+        port: int = 161,
+        timeout: float = 5.0,
+        retries: int = 1,
+        max_results: int = 500,
+    ) -> list[dict[str, str]]:
+        """SNMP-Walk über einen OID-Teilbaum; gibt Liste von {oid, value, type} zurück."""
+        if not self._engine:
+            raise RuntimeError("SNMP Adapter nicht verbunden")
+
+        s = self._snmp
+        cfg = SnmpAdapterConfig(**self._config)
+        auth = self._build_auth(cfg)
+        transport = s["UdpTransportTarget"]((host, port), timeout=timeout, retries=retries)
+
+        results: list[dict[str, str]] = []
+        async for error_indication, error_status, _error_index, var_binds in s["nextCmd"](
+            self._engine,
+            auth,
+            transport,
+            s["ContextData"](),
+            s["ObjectType"](s["ObjectIdentity"](oid)),
+            lexicographicMode=False,
+        ):
+            if error_indication:
+                logger.warning("SNMP Walk Fehler: %s", error_indication)
+                break
+            if error_status:
+                logger.warning("SNMP Walk Status-Fehler: %s", error_status.prettyPrint())
+                break
+
+            for var_bind in var_binds:
+                obj_oid, value = var_bind
+                results.append(
+                    {
+                        "oid": str(obj_oid),
+                        "value": value.prettyPrint(),
+                        "type": type(value).__name__,
+                    }
+                )
+                if len(results) >= max_results:
+                    return results
+
+        return results

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -1075,8 +1075,12 @@ async def snmp_walk(
 
     try:
         entries = await instance.snmp_walk(
-            host=host, oid=oid, port=port, timeout=timeout,
-            max_results=max_results, start_oid=start_oid,
+            host=host,
+            oid=oid,
+            port=port,
+            timeout=timeout,
+            max_results=max_results,
+            start_oid=start_oid,
         )
         return [SnmpWalkEntry(**e) for e in entries]
     except Exception as exc:

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -1021,6 +1021,67 @@ async def anwesenheit_sync_bindings(
 
 
 # ---------------------------------------------------------------------------
+# SNMP Walk (Discovery)
+# ---------------------------------------------------------------------------
+
+
+class SnmpWalkEntry(BaseModel):
+    oid: str
+    value: str
+    type: str
+
+
+@router.get("/instances/{instance_id}/snmp/walk", response_model=list[SnmpWalkEntry])
+async def snmp_walk(
+    instance_id: uuid.UUID,
+    host: str = Query(..., description="IP-Adresse oder DNS-Name des SNMP-Geräts"),
+    oid: str = Query(default="1.3.6.1.2.1", description="Start-OID für den Walk"),
+    port: int = Query(default=161, ge=1, le=65535, description="UDP-Port"),
+    timeout: float = Query(default=5.0, ge=0.5, le=30.0, description="Timeout pro Request (s)"),
+    max_results: int = Query(default=500, ge=1, le=2000, description="Maximale Anzahl Einträge"),
+    _user: str = Depends(get_current_user),
+    db: Database = Depends(lambda: get_db()),
+) -> list[SnmpWalkEntry]:
+    """SNMP-Walk über einen OID-Teilbaum — nützlich für OID-Discovery beim Binding-Anlegen."""
+    row = await db.fetchone("SELECT * FROM adapter_instances WHERE id=?", (str(instance_id),))
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Instanz nicht gefunden")
+    if row["adapter_type"] != "SNMP":
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Nur für SNMP-Instanzen verfügbar")
+
+    instance = adapter_registry.get_instance_by_id(str(instance_id))
+    if instance is None or not instance.connected:
+        # Adapter nicht verbunden → temporäre Instanz erzeugen
+        from obs.adapters.snmp.adapter import SnmpAdapter
+        from obs.core.event_bus import EventBus
+
+        raw_config = row["config"] or "{}"
+        import json as _json
+
+        config_dict = _json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+        dummy_bus = EventBus()
+        instance = SnmpAdapter(event_bus=dummy_bus, config=config_dict)
+        await instance.connect()
+        if not instance.connected:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "SNMP Adapter konnte nicht verbunden werden (pysnmp installiert?)",
+            )
+
+    if not hasattr(instance, "snmp_walk"):
+        raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED, "snmp_walk nicht verfügbar")
+
+    try:
+        entries = await instance.snmp_walk(host=host, oid=oid, port=port, timeout=timeout, max_results=max_results)
+        return [SnmpWalkEntry(**e) for e in entries]
+    except Exception as exc:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            f"SNMP Walk fehlgeschlagen: {exc}",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
 # Typ-Routen (unverändert — Schema-Abfragen + Legacy-Config)
 # ---------------------------------------------------------------------------
 

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -1035,14 +1035,18 @@ class SnmpWalkEntry(BaseModel):
 async def snmp_walk(
     instance_id: uuid.UUID,
     host: str = Query(..., description="IP-Adresse oder DNS-Name des SNMP-Geräts"),
-    oid: str = Query(default="1.3.6.1.2.1", description="Start-OID für den Walk"),
+    oid: str = Query(default="1.3.6.1.2.1", description="Subtree-Root OID"),
     port: int = Query(default=161, ge=1, le=65535, description="UDP-Port"),
     timeout: float = Query(default=5.0, ge=0.5, le=30.0, description="Timeout pro Request (s)"),
-    max_results: int = Query(default=500, ge=1, le=2000, description="Maximale Anzahl Einträge"),
+    max_results: int = Query(default=50, ge=1, le=500, description="Einträge pro Seite"),
+    start_oid: str | None = Query(default=None, description="Cursor für Paginierung (letzter OID der Vorseite)"),
     _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> list[SnmpWalkEntry]:
-    """SNMP-Walk über einen OID-Teilbaum — nützlich für OID-Discovery beim Binding-Anlegen."""
+    """SNMP-Walk über einen OID-Teilbaum — nützlich für OID-Discovery beim Binding-Anlegen.
+
+    Paginierung: start_oid auf den letzten OID der Vorseite setzen um weitere Einträge zu laden.
+    """
     row = await db.fetchone("SELECT * FROM adapter_instances WHERE id=?", (str(instance_id),))
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Instanz nicht gefunden")
@@ -1051,13 +1055,11 @@ async def snmp_walk(
 
     instance = adapter_registry.get_instance_by_id(str(instance_id))
     if instance is None or not instance.connected:
-        # Adapter nicht verbunden → temporäre Instanz erzeugen
         from obs.adapters.snmp.adapter import SnmpAdapter
         from obs.core.event_bus import EventBus
-
-        raw_config = row["config"] or "{}"
         import json as _json
 
+        raw_config = row["config"] or "{}"
         config_dict = _json.loads(raw_config) if isinstance(raw_config, str) else raw_config
         dummy_bus = EventBus()
         instance = SnmpAdapter(event_bus=dummy_bus, config=config_dict)
@@ -1072,7 +1074,10 @@ async def snmp_walk(
         raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED, "snmp_walk nicht verfügbar")
 
     try:
-        entries = await instance.snmp_walk(host=host, oid=oid, port=port, timeout=timeout, max_results=max_results)
+        entries = await instance.snmp_walk(
+            host=host, oid=oid, port=port, timeout=timeout,
+            max_results=max_results, start_oid=start_oid,
+        )
         return [SnmpWalkEntry(**e) for e in entries]
     except Exception as exc:
         raise HTTPException(

--- a/obs/main.py
+++ b/obs/main.py
@@ -119,6 +119,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     import obs.adapters.modbus_tcp.adapter
     import obs.adapters.mqtt.adapter
     import obs.adapters.onewire.adapter
+    import obs.adapters.snmp.adapter  # noqa: F401
     import obs.adapters.anwesenheit.adapter  # noqa: F401
     import obs.adapters.zeitschaltuhr.adapter  # noqa: F401
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ aiomqtt>=2.5.1,<3         # 1.x→2.x renamed Client(host=) to Client(hostname=)
 xknx>=3.15.0,<4           # major versions have restructured telegram/apci imports
 pymodbus>=3.13.0,<3.14.0
 w1thermsensor>=2.3.0
+pysnmp>=6.1.0,<7          # SNMPv1/v2c/v3 adapter; 6.x restructured hlapi paths
 
 # Authentication
 python-jose[cryptography]>=3.5.0,<4

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -316,7 +316,7 @@ class TestPollLoop:
         snmp_value = _make_snmp_value("42", "Integer32", int_val=42)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [[(MagicMock(), snmp_value)]])
+            return (None, None, None, [(MagicMock(), snmp_value)])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999})
@@ -369,7 +369,7 @@ class TestPollLoop:
         snmp_value = _make_snmp_value("1000", "Integer32", int_val=1000)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [[(MagicMock(), snmp_value)]])
+            return (None, None, None, [(MagicMock(), snmp_value)])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding(
@@ -397,7 +397,7 @@ class TestPollLoop:
         snmp_value = _make_snmp_value("1", "Integer32", int_val=1)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [[(MagicMock(), snmp_value)]])
+            return (None, None, None, [(MagicMock(), snmp_value)])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding(
@@ -446,7 +446,7 @@ class TestOnBindingsReloaded:
         snmp_value = _make_snmp_value("1", "Integer32", int_val=1)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [[(MagicMock(), snmp_value)]])
+            return (None, None, None, [(MagicMock(), snmp_value)])
 
         snmp_symbols["getCmd"] = fake_get
 
@@ -477,7 +477,7 @@ class TestOnBindingsReloaded:
         snmp_value = _make_snmp_value("0", "Integer32", int_val=0)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [[(MagicMock(), snmp_value)]])
+            return (None, None, None, [(MagicMock(), snmp_value)])
 
         snmp_symbols["getCmd"] = fake_get
 
@@ -509,7 +509,7 @@ class TestRead:
         snmp_value = _make_snmp_value("55", "Integer32", int_val=55)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [[(MagicMock(), snmp_value)]])
+            return (None, None, None, [(MagicMock(), snmp_value)])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 30})
@@ -584,9 +584,9 @@ class TestSnmpWalk:
 
         # nextCmd is a coroutine (one GETNEXT per call); walk loops until subtree ends
         responses = iter([
-            (None, None, None, [[(oid1, val1)]]),
-            (None, None, None, [[(oid2, val2)]]),
-            (None, None, None, [[(oid_out, val_out)]]),
+            (None, None, None, [(oid1, val1)]),
+            (None, None, None, [(oid2, val2)]),
+            (None, None, None, [(oid_out, val_out)]),
         ])
 
         async def fake_next(*args, **kwargs):
@@ -617,7 +617,7 @@ class TestSnmpWalk:
             oid.__str__ = MagicMock(return_value=f"1.3.6.1.2.1.1.{i}.0")
             val = _make_snmp_value(str(i), "Integer32", int_val=i)
             type(val).__name__ = "Integer32"
-            return (None, None, None, [[(oid, val)]])
+            return (None, None, None, [(oid, val)])
 
         snmp_symbols["nextCmd"] = fake_next_many
 

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -583,11 +583,13 @@ class TestSnmpWalk:
         val_out = _make_snmp_value("x", "OctetString")
         type(val_out).__name__ = "OctetString"
 
-        responses = iter([
-            _make_walk_row("1.3.6.1.2.1.1.1.0", "Linux 5.15", "OctetString"),
-            _make_walk_row("1.3.6.1.2.1.1.2.0", "42", "Integer32", int_val=42),
-            (None, None, None, [[(oid_out, val_out)]]),  # outside subtree
-        ])
+        responses = iter(
+            [
+                _make_walk_row("1.3.6.1.2.1.1.1.0", "Linux 5.15", "OctetString"),
+                _make_walk_row("1.3.6.1.2.1.1.2.0", "42", "Integer32", int_val=42),
+                (None, None, None, [[(oid_out, val_out)]]),  # outside subtree
+            ]
+        )
 
         async def fake_next(*args, **kwargs):
             return next(responses)
@@ -638,7 +640,9 @@ class TestSnmpWalk:
         snmp_symbols["nextCmd"] = fake_next
 
         results = await adapter.snmp_walk(
-            host="192.168.1.1", oid="1.3.6.1.2.1", max_results=1,
+            host="192.168.1.1",
+            oid="1.3.6.1.2.1",
+            max_results=1,
             start_oid="1.3.6.1.2.1.1.8.0",
         )
         assert len(results) == 1

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -6,8 +6,6 @@ Alle pysnmp-Aufrufe werden gemockt — kein echtes SNMP-Gerät erforderlich.
 from __future__ import annotations
 
 import asyncio
-import uuid
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -48,7 +46,7 @@ def snmp_symbols():
     fake_no_priv = MagicMock(name="noPriv")
 
     return {
-        "getCmd": None,      # wird pro Test gesetzt
+        "getCmd": None,  # wird pro Test gesetzt
         "setCmd": None,
         "nextCmd": None,
         "SnmpEngine": MagicMock(return_value=fake_engine),
@@ -203,6 +201,7 @@ class TestEncodeWriteValue:
     def test_int_type(self):
         try:
             from pysnmp.proto.rfc1902 import Integer32
+
             val = _encode_write_value(42, "int")
             assert isinstance(val, Integer32)
         except ImportError:
@@ -211,6 +210,7 @@ class TestEncodeWriteValue:
     def test_string_type(self):
         try:
             from pysnmp.proto.rfc1902 import OctetString
+
             val = _encode_write_value("hello", "string")
             assert isinstance(val, OctetString)
         except ImportError:
@@ -219,6 +219,7 @@ class TestEncodeWriteValue:
     def test_bool_auto(self):
         try:
             from pysnmp.proto.rfc1902 import Integer32
+
             val = _encode_write_value(True, "auto")
             assert isinstance(val, Integer32)
         except ImportError:
@@ -227,6 +228,7 @@ class TestEncodeWriteValue:
     def test_float_auto(self):
         try:
             from pysnmp.proto.rfc1902 import OctetString
+
             val = _encode_write_value(3.14, "auto")
             assert isinstance(val, OctetString)
         except ImportError:
@@ -281,8 +283,6 @@ class TestConnect:
             await adapter.connect()
 
         # Fake poll task
-        cancelled = []
-
         async def _dummy():
             await asyncio.sleep(9999)
 
@@ -480,9 +480,7 @@ class TestOnBindingsReloaded:
 
         snmp_symbols["getCmd"] = fake_get
 
-        binding = make_binding(
-            {"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999}
-        )
+        binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999})
 
         await adapter.reload_bindings([binding])
         old_task = adapter._poll_tasks[0]

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -559,6 +559,17 @@ class TestWrite:
 # ---------------------------------------------------------------------------
 
 
+def _make_walk_row(oid_str: str, value_str: str, type_name: str = "OctetString", int_val: int | None = None):
+    """Create a nextCmd 2D-row: [[( OID-mock, value-mock )]] matching pysnmp's actual return format."""
+    oid = MagicMock()
+    oid.__str__ = MagicMock(return_value=oid_str)
+    val = _make_snmp_value(value_str, type_name, int_val=int_val)
+    type(val).__name__ = type_name
+    # nextCmd returns list-of-rows; each row is a list with one ObjectType per requested OID.
+    # We model ObjectType as a 2-tuple (oid, val) since it supports indexing.
+    return (None, None, None, [[(oid, val)]])
+
+
 class TestSnmpWalk:
     @pytest.mark.asyncio
     async def test_walk_returns_oid_value_type(self, mock_bus, snmp_symbols):
@@ -567,26 +578,15 @@ class TestSnmpWalk:
         adapter._engine = snmp_symbols["SnmpEngine"]()
         adapter._connected = True
 
-        oid1 = MagicMock()
-        oid1.__str__ = MagicMock(return_value="1.3.6.1.2.1.1.1.0")
-        val1 = _make_snmp_value("Linux 5.15", "OctetString")
-        type(val1).__name__ = "OctetString"
-
-        oid2 = MagicMock()
-        oid2.__str__ = MagicMock(return_value="1.3.6.1.2.1.1.2.0")
-        val2 = _make_snmp_value("42", "Integer32", int_val=42)
-        type(val2).__name__ = "Integer32"
-
         oid_out = MagicMock()
-        oid_out.__str__ = MagicMock(return_value="1.3.6.1.3.1.1.0")  # outside subtree
+        oid_out.__str__ = MagicMock(return_value="1.3.6.1.3.1.1.0")  # outside subtree → stops walk
         val_out = _make_snmp_value("x", "OctetString")
         type(val_out).__name__ = "OctetString"
 
-        # nextCmd is a coroutine (one GETNEXT per call); walk loops until subtree ends
         responses = iter([
-            (None, None, None, [(oid1, val1)]),
-            (None, None, None, [(oid2, val2)]),
-            (None, None, None, [(oid_out, val_out)]),
+            _make_walk_row("1.3.6.1.2.1.1.1.0", "Linux 5.15", "OctetString"),
+            _make_walk_row("1.3.6.1.2.1.1.2.0", "42", "Integer32", int_val=42),
+            (None, None, None, [[(oid_out, val_out)]]),  # outside subtree
         ])
 
         async def fake_next(*args, **kwargs):
@@ -613,16 +613,36 @@ class TestSnmpWalk:
         async def fake_next_many(*args, **kwargs):
             i = counter["n"]
             counter["n"] += 1
-            oid = MagicMock()
-            oid.__str__ = MagicMock(return_value=f"1.3.6.1.2.1.1.{i}.0")
-            val = _make_snmp_value(str(i), "Integer32", int_val=i)
-            type(val).__name__ = "Integer32"
-            return (None, None, None, [(oid, val)])
+            return _make_walk_row(f"1.3.6.1.2.1.1.{i}.0", str(i), "Integer32", int_val=i)
 
         snmp_symbols["nextCmd"] = fake_next_many
 
         results = await adapter.snmp_walk(host="192.168.1.1", oid="1.3.6.1.2.1", max_results=5)
         assert len(results) == 5
+
+    @pytest.mark.asyncio
+    async def test_walk_start_oid_pagination(self, mock_bus, snmp_symbols):
+        """start_oid lets the walk continue from a cursor (pagination)."""
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        called_with = []
+
+        async def fake_next(*args, **kwargs):
+            # Record what OID was passed as the varBind
+            called_with.append(str(args[4][0][0]))  # ObjectIdentity string
+            return _make_walk_row("1.3.6.1.2.1.1.9.0", "val", "OctetString")
+
+        snmp_symbols["nextCmd"] = fake_next
+
+        results = await adapter.snmp_walk(
+            host="192.168.1.1", oid="1.3.6.1.2.1", max_results=1,
+            start_oid="1.3.6.1.2.1.1.8.0",
+        )
+        assert len(results) == 1
+        assert results[0]["oid"] == "1.3.6.1.2.1.1.9.0"
 
     @pytest.mark.asyncio
     async def test_walk_raises_when_not_connected(self, mock_bus):

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -316,7 +316,7 @@ class TestPollLoop:
         snmp_value = _make_snmp_value("42", "Integer32", int_val=42)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [(MagicMock(), snmp_value)])
+            return (None, None, None, [[(MagicMock(), snmp_value)]])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999})
@@ -369,7 +369,7 @@ class TestPollLoop:
         snmp_value = _make_snmp_value("1000", "Integer32", int_val=1000)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [(MagicMock(), snmp_value)])
+            return (None, None, None, [[(MagicMock(), snmp_value)]])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding(
@@ -397,7 +397,7 @@ class TestPollLoop:
         snmp_value = _make_snmp_value("1", "Integer32", int_val=1)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [(MagicMock(), snmp_value)])
+            return (None, None, None, [[(MagicMock(), snmp_value)]])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding(
@@ -446,7 +446,7 @@ class TestOnBindingsReloaded:
         snmp_value = _make_snmp_value("1", "Integer32", int_val=1)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [(MagicMock(), snmp_value)])
+            return (None, None, None, [[(MagicMock(), snmp_value)]])
 
         snmp_symbols["getCmd"] = fake_get
 
@@ -477,7 +477,7 @@ class TestOnBindingsReloaded:
         snmp_value = _make_snmp_value("0", "Integer32", int_val=0)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [(MagicMock(), snmp_value)])
+            return (None, None, None, [[(MagicMock(), snmp_value)]])
 
         snmp_symbols["getCmd"] = fake_get
 
@@ -509,7 +509,7 @@ class TestRead:
         snmp_value = _make_snmp_value("55", "Integer32", int_val=55)
 
         async def fake_get(*args, **kwargs):
-            return (None, None, None, [(MagicMock(), snmp_value)])
+            return (None, None, None, [[(MagicMock(), snmp_value)]])
 
         snmp_symbols["getCmd"] = fake_get
         binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 30})
@@ -584,9 +584,9 @@ class TestSnmpWalk:
 
         # nextCmd is a coroutine (one GETNEXT per call); walk loops until subtree ends
         responses = iter([
-            (None, None, None, [(oid1, val1)]),
-            (None, None, None, [(oid2, val2)]),
-            (None, None, None, [(oid_out, val_out)]),
+            (None, None, None, [[(oid1, val1)]]),
+            (None, None, None, [[(oid2, val2)]]),
+            (None, None, None, [[(oid_out, val_out)]]),
         ])
 
         async def fake_next(*args, **kwargs):
@@ -617,7 +617,7 @@ class TestSnmpWalk:
             oid.__str__ = MagicMock(return_value=f"1.3.6.1.2.1.1.{i}.0")
             val = _make_snmp_value(str(i), "Integer32", int_val=i)
             type(val).__name__ = "Integer32"
-            return (None, None, None, [(oid, val)])
+            return (None, None, None, [[(oid, val)]])
 
         snmp_symbols["nextCmd"] = fake_next_many
 

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -290,6 +290,7 @@ class TestConnect:
         adapter._poll_tasks.append(t)
 
         await adapter.disconnect()
+        await asyncio.sleep(0)  # let event loop process the cancellation
         assert adapter.connected is False
         assert len(adapter._poll_tasks) == 0
         assert t.cancelled()
@@ -486,6 +487,7 @@ class TestOnBindingsReloaded:
         old_task = adapter._poll_tasks[0]
 
         await adapter.reload_bindings([binding])  # zweites Reload
+        await asyncio.sleep(0)  # let event loop process the cancellation
         assert old_task.cancelled()
         for t in adapter._poll_tasks:
             t.cancel()
@@ -575,9 +577,20 @@ class TestSnmpWalk:
         val2 = _make_snmp_value("42", "Integer32", int_val=42)
         type(val2).__name__ = "Integer32"
 
+        oid_out = MagicMock()
+        oid_out.__str__ = MagicMock(return_value="1.3.6.1.3.1.1.0")  # outside subtree
+        val_out = _make_snmp_value("x", "OctetString")
+        type(val_out).__name__ = "OctetString"
+
+        # nextCmd is a coroutine (one GETNEXT per call); walk loops until subtree ends
+        responses = iter([
+            (None, None, None, [(oid1, val1)]),
+            (None, None, None, [(oid2, val2)]),
+            (None, None, None, [(oid_out, val_out)]),
+        ])
+
         async def fake_next(*args, **kwargs):
-            yield (None, None, None, [(oid1, val1)])
-            yield (None, None, None, [(oid2, val2)])
+            return next(responses)
 
         snmp_symbols["nextCmd"] = fake_next
 
@@ -595,13 +608,16 @@ class TestSnmpWalk:
         adapter._engine = snmp_symbols["SnmpEngine"]()
         adapter._connected = True
 
+        counter = {"n": 0}
+
         async def fake_next_many(*args, **kwargs):
-            for i in range(100):
-                oid = MagicMock()
-                oid.__str__ = MagicMock(return_value=f"1.3.6.1.2.1.1.{i}.0")
-                val = _make_snmp_value(str(i), "Integer32", int_val=i)
-                type(val).__name__ = "Integer32"
-                yield (None, None, None, [(oid, val)])
+            i = counter["n"]
+            counter["n"] += 1
+            oid = MagicMock()
+            oid.__str__ = MagicMock(return_value=f"1.3.6.1.2.1.1.{i}.0")
+            val = _make_snmp_value(str(i), "Integer32", int_val=i)
+            type(val).__name__ = "Integer32"
+            return (None, None, None, [(oid, val)])
 
         snmp_symbols["nextCmd"] = fake_next_many
 
@@ -625,7 +641,7 @@ class TestSnmpWalk:
         error_ind.__str__ = MagicMock(return_value="noSuchName")
 
         async def fake_next_err(*args, **kwargs):
-            yield (error_ind, None, None, [])
+            return (error_ind, None, None, [])
 
         snmp_symbols["nextCmd"] = fake_next_err
 

--- a/tests/adapters/test_snmp_adapter.py
+++ b/tests/adapters/test_snmp_adapter.py
@@ -1,0 +1,708 @@
+"""Unit tests für den SNMP Adapter.
+
+Alle pysnmp-Aufrufe werden gemockt — kein echtes SNMP-Gerät erforderlich.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from obs.adapters.snmp.adapter import (
+    SnmpAdapter,
+    SnmpAdapterConfig,
+    SnmpBindingConfig,
+    _coerce_value,
+    _encode_write_value,
+)
+from tests.adapters.conftest import make_binding
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_bus():
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def snmp_symbols():
+    """Fake pysnmp-Symbol-Dict, das _import_pysnmp() zurückgibt."""
+    fake_engine = MagicMock(name="SnmpEngine")
+    fake_community = MagicMock(name="CommunityData")
+    fake_usm = MagicMock(name="UsmUserData")
+    fake_transport = MagicMock(name="UdpTransportTarget")
+    fake_ctx = MagicMock(name="ContextData")
+    fake_ot = MagicMock(name="ObjectType")
+    fake_oi = MagicMock(name="ObjectIdentity")
+    fake_no_auth = MagicMock(name="noAuth")
+    fake_no_priv = MagicMock(name="noPriv")
+
+    return {
+        "getCmd": None,      # wird pro Test gesetzt
+        "setCmd": None,
+        "nextCmd": None,
+        "SnmpEngine": MagicMock(return_value=fake_engine),
+        "CommunityData": MagicMock(return_value=fake_community),
+        "UsmUserData": MagicMock(return_value=fake_usm),
+        "UdpTransportTarget": MagicMock(return_value=fake_transport),
+        "ContextData": MagicMock(return_value=fake_ctx),
+        "ObjectType": MagicMock(return_value=fake_ot),
+        "ObjectIdentity": MagicMock(return_value=fake_oi),
+        "_auth_map": {"MD5": MagicMock(), "SHA": MagicMock(), "SHA256": MagicMock(), "SHA512": MagicMock()},
+        "_priv_map": {"DES": MagicMock(), "3DES": MagicMock(), "AES128": MagicMock(), "AES192": MagicMock(), "AES256": MagicMock()},
+        "_no_auth": fake_no_auth,
+        "_no_priv": fake_no_priv,
+    }
+
+
+def _make_snmp_value(pp: str, type_name: str = "OctetString", int_val: int | None = None) -> MagicMock:
+    """Erzeugt ein Mock-pysnmp-Wertobjekt."""
+    v = MagicMock()
+    v.prettyPrint.return_value = pp
+    type(v).__name__ = type_name
+    if int_val is not None:
+        v.__int__ = MagicMock(return_value=int_val)
+        # Damit int(v) funktioniert
+        v.__index__ = MagicMock(return_value=int_val)
+    return v
+
+
+async def _async_get_result(error_indication, error_status, error_index, var_binds):
+    """Hilfsfunktion: erstellt eine Coroutine, die ein Tupel zurückgibt."""
+    return (error_indication, error_status, error_index, var_binds)
+
+
+# ---------------------------------------------------------------------------
+# Config Validation
+# ---------------------------------------------------------------------------
+
+
+class TestSnmpAdapterConfig:
+    def test_defaults_v2c(self):
+        cfg = SnmpAdapterConfig()
+        assert cfg.version == "2c"
+        assert cfg.community == "public"
+
+    def test_v1_community(self):
+        cfg = SnmpAdapterConfig(version="1", community="private")
+        assert cfg.version == "1"
+        assert cfg.community == "private"
+
+    def test_v3_fields(self):
+        cfg = SnmpAdapterConfig(
+            version="3",
+            security_name="admin",
+            security_level="authPriv",
+            auth_protocol="SHA",
+            auth_key="authpass",
+            priv_protocol="AES128",
+            priv_key="privpass",
+        )
+        assert cfg.version == "3"
+        assert cfg.security_level == "authPriv"
+        assert cfg.priv_protocol == "AES128"
+
+
+class TestSnmpBindingConfig:
+    def test_defaults(self):
+        bc = SnmpBindingConfig(oid="1.3.6.1.2.1.1.1.0")
+        assert bc.host == "192.168.1.1"
+        assert bc.port == 161
+        assert bc.data_type == "auto"
+        assert bc.poll_interval == 30.0
+
+    def test_custom_host_and_oid(self):
+        bc = SnmpBindingConfig(host="switch.local", port=161, oid="1.3.6.1.2.1.2.2.1.10.1")
+        assert bc.host == "switch.local"
+        assert bc.oid == "1.3.6.1.2.1.2.2.1.10.1"
+
+
+# ---------------------------------------------------------------------------
+# Value Coercion
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceValue:
+    def test_auto_integer32(self):
+        v = _make_snmp_value("42", "Integer32", int_val=42)
+        result = _coerce_value(v, "auto")
+        assert result == 42
+
+    def test_auto_counter32(self):
+        v = _make_snmp_value("12345", "Counter32", int_val=12345)
+        result = _coerce_value(v, "auto")
+        assert result == 12345
+
+    def test_auto_timeticks(self):
+        v = _make_snmp_value("360000", "TimeTicks", int_val=360000)
+        result = _coerce_value(v, "auto")
+        assert result == 360000
+
+    def test_auto_numeric_string(self):
+        v = _make_snmp_value("99", "OctetString")
+        result = _coerce_value(v, "auto")
+        assert result == 99
+
+    def test_auto_float_string(self):
+        v = _make_snmp_value("23.5", "OctetString")
+        result = _coerce_value(v, "auto")
+        assert result == pytest.approx(23.5)
+
+    def test_auto_non_numeric_string(self):
+        v = _make_snmp_value("Linux 5.15.0", "OctetString")
+        result = _coerce_value(v, "auto")
+        assert result == "Linux 5.15.0"
+
+    def test_explicit_int(self):
+        v = _make_snmp_value("100", "OctetString", int_val=100)
+        result = _coerce_value(v, "int")
+        assert result == 100
+
+    def test_explicit_float(self):
+        v = _make_snmp_value("22.75", "OctetString")
+        result = _coerce_value(v, "float")
+        assert result == pytest.approx(22.75)
+
+    def test_explicit_string(self):
+        v = _make_snmp_value("42", "Integer32", int_val=42)
+        result = _coerce_value(v, "string")
+        assert result == "42"
+
+    def test_gauge(self):
+        v = _make_snmp_value("500", "Gauge32", int_val=500)
+        result = _coerce_value(v, "gauge")
+        assert result == 500
+
+    def test_counter(self):
+        v = _make_snmp_value("9999", "Counter64", int_val=9999)
+        result = _coerce_value(v, "counter")
+        assert result == 9999
+
+    def test_timeticks_explicit(self):
+        v = _make_snmp_value("7200", "TimeTicks", int_val=7200)
+        result = _coerce_value(v, "timeticks")
+        assert result == 7200
+
+
+# ---------------------------------------------------------------------------
+# Write Value Encoding
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeWriteValue:
+    def test_int_type(self):
+        try:
+            from pysnmp.proto.rfc1902 import Integer32
+            val = _encode_write_value(42, "int")
+            assert isinstance(val, Integer32)
+        except ImportError:
+            pytest.skip("pysnmp nicht installiert")
+
+    def test_string_type(self):
+        try:
+            from pysnmp.proto.rfc1902 import OctetString
+            val = _encode_write_value("hello", "string")
+            assert isinstance(val, OctetString)
+        except ImportError:
+            pytest.skip("pysnmp nicht installiert")
+
+    def test_bool_auto(self):
+        try:
+            from pysnmp.proto.rfc1902 import Integer32
+            val = _encode_write_value(True, "auto")
+            assert isinstance(val, Integer32)
+        except ImportError:
+            pytest.skip("pysnmp nicht installiert")
+
+    def test_float_auto(self):
+        try:
+            from pysnmp.proto.rfc1902 import OctetString
+            val = _encode_write_value(3.14, "auto")
+            assert isinstance(val, OctetString)
+        except ImportError:
+            pytest.skip("pysnmp nicht installiert")
+
+
+# ---------------------------------------------------------------------------
+# Adapter Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    @pytest.mark.asyncio
+    async def test_connect_without_pysnmp(self, mock_bus):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        with patch("obs.adapters.snmp.adapter._import_pysnmp", return_value={}):
+            await adapter.connect()
+        assert adapter.connected is False
+        mock_bus.publish.assert_called_once()
+        event = mock_bus.publish.call_args[0][0]
+        assert event.connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_with_pysnmp_v2c(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        with patch("obs.adapters.snmp.adapter._import_pysnmp", return_value=snmp_symbols):
+            await adapter.connect()
+        assert adapter.connected is True
+
+    @pytest.mark.asyncio
+    async def test_connect_v3_auth_priv(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(
+            event_bus=mock_bus,
+            config={
+                "version": "3",
+                "security_name": "obs-user",
+                "security_level": "authPriv",
+                "auth_protocol": "SHA",
+                "auth_key": "authpassphrase",
+                "priv_protocol": "AES128",
+                "priv_key": "privpassphrase",
+            },
+        )
+        with patch("obs.adapters.snmp.adapter._import_pysnmp", return_value=snmp_symbols):
+            await adapter.connect()
+        assert adapter.connected is True
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_poll_tasks(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        with patch("obs.adapters.snmp.adapter._import_pysnmp", return_value=snmp_symbols):
+            await adapter.connect()
+
+        # Fake poll task
+        cancelled = []
+
+        async def _dummy():
+            await asyncio.sleep(9999)
+
+        t = asyncio.create_task(_dummy())
+        adapter._poll_tasks.append(t)
+
+        await adapter.disconnect()
+        assert adapter.connected is False
+        assert len(adapter._poll_tasks) == 0
+        assert t.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# Poll Loop
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoop:
+    def _make_adapter(self, mock_bus, snmp_symbols, config=None):
+        cfg = config or {"version": "2c", "community": "public"}
+        adapter = SnmpAdapter(event_bus=mock_bus, config=cfg)
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_publishes_good_value(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols)
+        snmp_value = _make_snmp_value("42", "Integer32", int_val=42)
+
+        async def fake_get(*args, **kwargs):
+            return (None, None, None, [(MagicMock(), snmp_value)])
+
+        snmp_symbols["getCmd"] = fake_get
+        binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999})
+
+        # Einen Durchlauf des Poll-Loops ausführen
+        async def run_once():
+            task = asyncio.create_task(adapter._poll_loop(binding))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        await run_once()
+        assert mock_bus.publish.called
+        event = mock_bus.publish.call_args[0][0]
+        assert event.quality == "good"
+        assert event.datapoint_id == binding.datapoint_id
+
+    @pytest.mark.asyncio
+    async def test_publishes_bad_quality_on_snmp_error(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols)
+
+        async def fake_get_error(*args, **kwargs):
+            error_indication = MagicMock()
+            error_indication.__str__ = MagicMock(return_value="Timeout")
+            return (error_indication, None, None, [])
+
+        snmp_symbols["getCmd"] = fake_get_error
+        binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999})
+
+        async def run_once():
+            task = asyncio.create_task(adapter._poll_loop(binding))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        await run_once()
+        event = mock_bus.publish.call_args[0][0]
+        assert event.quality == "bad"
+        assert event.value is None
+
+    @pytest.mark.asyncio
+    async def test_applies_value_formula(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols)
+        snmp_value = _make_snmp_value("1000", "Integer32", int_val=1000)
+
+        async def fake_get(*args, **kwargs):
+            return (None, None, None, [(MagicMock(), snmp_value)])
+
+        snmp_symbols["getCmd"] = fake_get
+        binding = make_binding(
+            {"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999},
+            value_formula="x / 10",
+        )
+
+        async def run_once():
+            task = asyncio.create_task(adapter._poll_loop(binding))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        await run_once()
+        event = mock_bus.publish.call_args[0][0]
+        assert event.quality == "good"
+        assert event.value == pytest.approx(100.0)
+
+    @pytest.mark.asyncio
+    async def test_applies_value_map(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols)
+        snmp_value = _make_snmp_value("1", "Integer32", int_val=1)
+
+        async def fake_get(*args, **kwargs):
+            return (None, None, None, [(MagicMock(), snmp_value)])
+
+        snmp_symbols["getCmd"] = fake_get
+        binding = make_binding(
+            {"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999},
+            value_map={"1": "up", "2": "down"},
+        )
+
+        async def run_once():
+            task = asyncio.create_task(adapter._poll_loop(binding))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        await run_once()
+        event = mock_bus.publish.call_args[0][0]
+        assert event.value == "up"
+
+    @pytest.mark.asyncio
+    async def test_invalid_binding_config_skipped(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols)
+        binding = make_binding({"oid": "1.3.6.1.2.1.1.1.0", "poll_interval": -999})  # ungültig
+
+        # Soll sofort beendet werden ohne publish
+        task = asyncio.create_task(adapter._poll_loop(binding))
+        await asyncio.sleep(0.05)
+        assert task.done()
+        mock_bus.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# On Bindings Reloaded
+# ---------------------------------------------------------------------------
+
+
+class TestOnBindingsReloaded:
+    @pytest.mark.asyncio
+    async def test_starts_poll_task_for_source_binding(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        snmp_value = _make_snmp_value("1", "Integer32", int_val=1)
+
+        async def fake_get(*args, **kwargs):
+            return (None, None, None, [(MagicMock(), snmp_value)])
+
+        snmp_symbols["getCmd"] = fake_get
+
+        source_binding = make_binding(
+            {"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999},
+            direction="SOURCE",
+        )
+        dest_binding = make_binding(
+            {"host": "192.168.1.2", "oid": "1.3.6.1.4.1.1.0", "poll_interval": 999},
+            direction="DEST",
+        )
+
+        await adapter.reload_bindings([source_binding, dest_binding])
+        await asyncio.sleep(0.05)
+
+        assert len(adapter._poll_tasks) == 1  # nur SOURCE-Binding bekommt einen Task
+        # Aufräumen
+        for t in adapter._poll_tasks:
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_cancels_old_tasks_on_reload(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        snmp_value = _make_snmp_value("0", "Integer32", int_val=0)
+
+        async def fake_get(*args, **kwargs):
+            return (None, None, None, [(MagicMock(), snmp_value)])
+
+        snmp_symbols["getCmd"] = fake_get
+
+        binding = make_binding(
+            {"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 999}
+        )
+
+        await adapter.reload_bindings([binding])
+        old_task = adapter._poll_tasks[0]
+
+        await adapter.reload_bindings([binding])  # zweites Reload
+        assert old_task.cancelled()
+        for t in adapter._poll_tasks:
+            t.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Read / Write
+# ---------------------------------------------------------------------------
+
+
+class TestRead:
+    @pytest.mark.asyncio
+    async def test_read_returns_coerced_value(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        snmp_value = _make_snmp_value("55", "Integer32", int_val=55)
+
+        async def fake_get(*args, **kwargs):
+            return (None, None, None, [(MagicMock(), snmp_value)])
+
+        snmp_symbols["getCmd"] = fake_get
+        binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.2.1.1.1.0", "poll_interval": 30})
+        result = await adapter.read(binding)
+        assert result == 55
+
+    @pytest.mark.asyncio
+    async def test_read_returns_none_when_not_connected(self, mock_bus):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={})
+        result = await adapter.read(make_binding({"host": "192.168.1.1", "oid": "1.2.3"}))
+        assert result is None
+
+
+class TestWrite:
+    @pytest.mark.asyncio
+    async def test_write_calls_set_cmd(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        set_called_with: list = []
+
+        async def fake_set(*args, **kwargs):
+            set_called_with.append((args, kwargs))
+            return (None, None, None, [])
+
+        snmp_symbols["setCmd"] = fake_set
+        binding = make_binding(
+            {"host": "192.168.1.1", "oid": "1.3.6.1.4.1.1.0", "data_type": "int", "poll_interval": 30},
+            direction="DEST",
+        )
+        await adapter.write(binding, 42)
+        assert len(set_called_with) == 1
+
+    @pytest.mark.asyncio
+    async def test_write_skipped_when_not_connected(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={})
+        snmp_symbols["setCmd"] = AsyncMock()
+        binding = make_binding({"host": "192.168.1.1", "oid": "1.3.6.1.4.1.1.0", "poll_interval": 30})
+        await adapter.write(binding, 1)
+        snmp_symbols["setCmd"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SNMP Walk
+# ---------------------------------------------------------------------------
+
+
+class TestSnmpWalk:
+    @pytest.mark.asyncio
+    async def test_walk_returns_oid_value_type(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        oid1 = MagicMock()
+        oid1.__str__ = MagicMock(return_value="1.3.6.1.2.1.1.1.0")
+        val1 = _make_snmp_value("Linux 5.15", "OctetString")
+        type(val1).__name__ = "OctetString"
+
+        oid2 = MagicMock()
+        oid2.__str__ = MagicMock(return_value="1.3.6.1.2.1.1.2.0")
+        val2 = _make_snmp_value("42", "Integer32", int_val=42)
+        type(val2).__name__ = "Integer32"
+
+        async def fake_next(*args, **kwargs):
+            yield (None, None, None, [(oid1, val1)])
+            yield (None, None, None, [(oid2, val2)])
+
+        snmp_symbols["nextCmd"] = fake_next
+
+        results = await adapter.snmp_walk(host="192.168.1.1", oid="1.3.6.1.2.1")
+        assert len(results) == 2
+        assert results[0]["oid"] == "1.3.6.1.2.1.1.1.0"
+        assert results[0]["value"] == "Linux 5.15"
+        assert results[0]["type"] == "OctetString"
+        assert results[1]["oid"] == "1.3.6.1.2.1.1.2.0"
+
+    @pytest.mark.asyncio
+    async def test_walk_stops_at_max_results(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        async def fake_next_many(*args, **kwargs):
+            for i in range(100):
+                oid = MagicMock()
+                oid.__str__ = MagicMock(return_value=f"1.3.6.1.2.1.1.{i}.0")
+                val = _make_snmp_value(str(i), "Integer32", int_val=i)
+                type(val).__name__ = "Integer32"
+                yield (None, None, None, [(oid, val)])
+
+        snmp_symbols["nextCmd"] = fake_next_many
+
+        results = await adapter.snmp_walk(host="192.168.1.1", oid="1.3.6.1.2.1", max_results=5)
+        assert len(results) == 5
+
+    @pytest.mark.asyncio
+    async def test_walk_raises_when_not_connected(self, mock_bus):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={})
+        with pytest.raises(RuntimeError, match="nicht verbunden"):
+            await adapter.snmp_walk(host="192.168.1.1", oid="1.3.6.1.2.1")
+
+    @pytest.mark.asyncio
+    async def test_walk_stops_on_error_indication(self, mock_bus, snmp_symbols):
+        adapter = SnmpAdapter(event_bus=mock_bus, config={"version": "2c", "community": "public"})
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        adapter._connected = True
+
+        error_ind = MagicMock()
+        error_ind.__str__ = MagicMock(return_value="noSuchName")
+
+        async def fake_next_err(*args, **kwargs):
+            yield (error_ind, None, None, [])
+
+        snmp_symbols["nextCmd"] = fake_next_err
+
+        results = await adapter.snmp_walk(host="192.168.1.1", oid="1.3.6.1.2.1")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Auth helper: _build_auth
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAuth:
+    def _make_adapter(self, mock_bus, snmp_symbols, config):
+        adapter = SnmpAdapter(event_bus=mock_bus, config=config)
+        adapter._snmp = snmp_symbols
+        adapter._engine = snmp_symbols["SnmpEngine"]()
+        return adapter
+
+    def test_v2c_uses_community_data(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols, {"version": "2c", "community": "private"})
+        cfg = SnmpAdapterConfig(**adapter._config)
+        adapter._build_auth(cfg)
+        snmp_symbols["CommunityData"].assert_called_with("private", mpModel=1)
+
+    def test_v1_uses_mp_model_0(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(mock_bus, snmp_symbols, {"version": "1", "community": "public"})
+        cfg = SnmpAdapterConfig(**adapter._config)
+        adapter._build_auth(cfg)
+        snmp_symbols["CommunityData"].assert_called_with("public", mpModel=0)
+
+    def test_v3_no_auth_no_priv(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(
+            mock_bus,
+            snmp_symbols,
+            {"version": "3", "security_name": "user", "security_level": "noAuthNoPriv"},
+        )
+        cfg = SnmpAdapterConfig(**adapter._config)
+        adapter._build_auth(cfg)
+        snmp_symbols["UsmUserData"].assert_called_with("user")
+
+    def test_v3_auth_no_priv(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(
+            mock_bus,
+            snmp_symbols,
+            {
+                "version": "3",
+                "security_name": "user",
+                "security_level": "authNoPriv",
+                "auth_protocol": "MD5",
+                "auth_key": "secret123",
+            },
+        )
+        cfg = SnmpAdapterConfig(**adapter._config)
+        adapter._build_auth(cfg)
+        call_kwargs = snmp_symbols["UsmUserData"].call_args[1]
+        assert call_kwargs["authKey"] == "secret123"
+        assert "privKey" not in call_kwargs
+
+    def test_v3_auth_priv(self, mock_bus, snmp_symbols):
+        adapter = self._make_adapter(
+            mock_bus,
+            snmp_symbols,
+            {
+                "version": "3",
+                "security_name": "user",
+                "security_level": "authPriv",
+                "auth_protocol": "SHA",
+                "auth_key": "authpass",
+                "priv_protocol": "AES128",
+                "priv_key": "privpass",
+            },
+        )
+        cfg = SnmpAdapterConfig(**adapter._config)
+        adapter._build_auth(cfg)
+        call_kwargs = snmp_symbols["UsmUserData"].call_args[1]
+        assert call_kwargs["authKey"] == "authpass"
+        assert call_kwargs["privKey"] == "privpass"

--- a/tests/contracts/test_pysnmp_contract.py
+++ b/tests/contracts/test_pysnmp_contract.py
@@ -143,9 +143,11 @@ def _import_auth_constants():
     """Auth/priv constants moved from hlapi to hlapi.asyncio in pysnmp 6.x."""
     try:
         from pysnmp.hlapi.v3arch.asyncio import usmHMACMD5AuthProtocol, usmDESPrivProtocol  # noqa: F401
+
         return usmHMACMD5AuthProtocol, usmDESPrivProtocol
     except ImportError:
         from pysnmp.hlapi.asyncio import usmHMACMD5AuthProtocol, usmDESPrivProtocol  # noqa: F401
+
         return usmHMACMD5AuthProtocol, usmDESPrivProtocol
 
 
@@ -211,9 +213,11 @@ def test_object_type_with_oid():
 def _hlapi_asyncio():
     try:
         import pysnmp.hlapi.v3arch.asyncio as m
+
         return m
     except ImportError:
         import pysnmp.hlapi.asyncio as m
+
         return m
 
 

--- a/tests/contracts/test_pysnmp_contract.py
+++ b/tests/contracts/test_pysnmp_contract.py
@@ -29,6 +29,7 @@ def _import_hlapi():
             nextCmd,
             setCmd,
         )
+
         return "v6"
     except ImportError:
         from pysnmp.hlapi.asyncio import (  # noqa: F401
@@ -43,6 +44,7 @@ def _import_hlapi():
             nextCmd,
             setCmd,
         )
+
         return "v5"
 
 
@@ -58,6 +60,7 @@ def test_get_cmd_is_callable():
     except ImportError:
         from pysnmp.hlapi.asyncio import getCmd
     import inspect
+
     assert callable(getCmd)
     # getCmd muss mindestens snmpEngine, authData, transportTarget, contextData, *varBinds annehmen
     sig = inspect.signature(getCmd)
@@ -136,12 +139,22 @@ def test_usm_user_data_no_auth():
     assert usm is not None
 
 
+def _import_auth_constants():
+    """Auth/priv constants moved from hlapi to hlapi.asyncio in pysnmp 6.x."""
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import usmHMACMD5AuthProtocol, usmDESPrivProtocol  # noqa: F401
+        return usmHMACMD5AuthProtocol, usmDESPrivProtocol
+    except ImportError:
+        from pysnmp.hlapi.asyncio import usmHMACMD5AuthProtocol, usmDESPrivProtocol  # noqa: F401
+        return usmHMACMD5AuthProtocol, usmDESPrivProtocol
+
+
 def test_usm_user_data_auth_no_priv():
     try:
         from pysnmp.hlapi.v3arch.asyncio import UsmUserData
     except ImportError:
         from pysnmp.hlapi.asyncio import UsmUserData
-    from pysnmp.hlapi import usmHMACMD5AuthProtocol
+    usmHMACMD5AuthProtocol, _ = _import_auth_constants()
     usm = UsmUserData("testuser", authKey="authpass", authProtocol=usmHMACMD5AuthProtocol)
     assert usm is not None
 
@@ -151,7 +164,7 @@ def test_usm_user_data_auth_priv():
         from pysnmp.hlapi.v3arch.asyncio import UsmUserData
     except ImportError:
         from pysnmp.hlapi.asyncio import UsmUserData
-    from pysnmp.hlapi import usmHMACMD5AuthProtocol, usmDESPrivProtocol
+    usmHMACMD5AuthProtocol, usmDESPrivProtocol = _import_auth_constants()
     usm = UsmUserData(
         "testuser",
         authKey="authpass",
@@ -191,34 +204,39 @@ def test_object_type_with_oid():
 
 
 # ---------------------------------------------------------------------------
-# Auth/Priv protocol constants — hlapi top-level
+# Auth/Priv protocol constants — in pysnmp 6.x moved to hlapi.asyncio
 # ---------------------------------------------------------------------------
 
 
+def _hlapi_asyncio():
+    try:
+        import pysnmp.hlapi.v3arch.asyncio as m
+        return m
+    except ImportError:
+        import pysnmp.hlapi.asyncio as m
+        return m
+
+
 def test_auth_protocol_md5():
-    from pysnmp.hlapi import usmHMACMD5AuthProtocol
-    assert usmHMACMD5AuthProtocol is not None
+    assert _hlapi_asyncio().usmHMACMD5AuthProtocol is not None
 
 
 def test_auth_protocol_sha():
-    from pysnmp.hlapi import usmHMACSHAAuthProtocol
-    assert usmHMACSHAAuthProtocol is not None
+    assert _hlapi_asyncio().usmHMACSHAAuthProtocol is not None
 
 
 def test_priv_protocol_des():
-    from pysnmp.hlapi import usmDESPrivProtocol
-    assert usmDESPrivProtocol is not None
+    assert _hlapi_asyncio().usmDESPrivProtocol is not None
 
 
 def test_priv_protocol_aes128():
-    from pysnmp.hlapi import usmAesCfb128Protocol
-    assert usmAesCfb128Protocol is not None
+    assert _hlapi_asyncio().usmAesCfb128Protocol is not None
 
 
 def test_no_auth_no_priv_protocols():
-    from pysnmp.hlapi import usmNoAuthProtocol, usmNoPrivProtocol
-    assert usmNoAuthProtocol is not None
-    assert usmNoPrivProtocol is not None
+    m = _hlapi_asyncio()
+    assert m.usmNoAuthProtocol is not None
+    assert m.usmNoPrivProtocol is not None
 
 
 # ---------------------------------------------------------------------------
@@ -228,17 +246,20 @@ def test_no_auth_no_priv_protocols():
 
 def test_integer32_importable():
     from pysnmp.proto.rfc1902 import Integer32
+
     v = Integer32(42)
     assert int(v) == 42
 
 
 def test_octet_string_importable():
     from pysnmp.proto.rfc1902 import OctetString
+
     v = OctetString(b"hello")
     assert v is not None
 
 
 def test_value_pretty_print():
     from pysnmp.proto.rfc1902 import Integer32, OctetString
+
     assert Integer32(99).prettyPrint() == "99"
     assert OctetString(b"test").prettyPrint() == "test"

--- a/tests/contracts/test_pysnmp_contract.py
+++ b/tests/contracts/test_pysnmp_contract.py
@@ -1,0 +1,244 @@
+"""Contract test für pysnmp — verifiziert die genauen Import-Pfade und API-Signaturen,
+die obs/adapters/snmp/adapter.py verwendet.
+
+Schlägt sofort fehl, wenn ein Dependency-Upgrade die API verändert,
+statt erst beim Laufzeit-Fehler im Adapter zu scheitern.
+"""
+
+import pytest
+
+pysnmp = pytest.importorskip("pysnmp", reason="pysnmp nicht installiert")
+
+# ---------------------------------------------------------------------------
+# hlapi Import-Pfad (v5: hlapi.asyncio, v6.2+: hlapi.v3arch.asyncio)
+# ---------------------------------------------------------------------------
+
+
+def _import_hlapi():
+    """Importiert hlapi-Symbole — probiert v6-Pfad zuerst, fällt auf v5 zurück."""
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import (  # noqa: F401
+            CommunityData,
+            ContextData,
+            ObjectIdentity,
+            ObjectType,
+            SnmpEngine,
+            UdpTransportTarget,
+            UsmUserData,
+            getCmd,
+            nextCmd,
+            setCmd,
+        )
+        return "v6"
+    except ImportError:
+        from pysnmp.hlapi.asyncio import (  # noqa: F401
+            CommunityData,
+            ContextData,
+            ObjectIdentity,
+            ObjectType,
+            SnmpEngine,
+            UdpTransportTarget,
+            UsmUserData,
+            getCmd,
+            nextCmd,
+            setCmd,
+        )
+        return "v5"
+
+
+def test_hlapi_importable():
+    path = _import_hlapi()
+    assert path in ("v5", "v6")
+
+
+def test_get_cmd_is_callable():
+    _import_hlapi()
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import getCmd
+    except ImportError:
+        from pysnmp.hlapi.asyncio import getCmd
+    import inspect
+    assert callable(getCmd)
+    # getCmd muss mindestens snmpEngine, authData, transportTarget, contextData, *varBinds annehmen
+    sig = inspect.signature(getCmd)
+    params = list(sig.parameters.keys())
+    assert len(params) >= 4
+
+
+def test_set_cmd_is_callable():
+    _import_hlapi()
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import setCmd
+    except ImportError:
+        from pysnmp.hlapi.asyncio import setCmd
+    assert callable(setCmd)
+
+
+def test_next_cmd_is_callable():
+    _import_hlapi()
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import nextCmd
+    except ImportError:
+        from pysnmp.hlapi.asyncio import nextCmd
+    assert callable(nextCmd)
+
+
+# ---------------------------------------------------------------------------
+# SnmpEngine
+# ---------------------------------------------------------------------------
+
+
+def test_snmp_engine_instantiable():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import SnmpEngine
+    except ImportError:
+        from pysnmp.hlapi.asyncio import SnmpEngine
+    engine = SnmpEngine()
+    assert engine is not None
+
+
+# ---------------------------------------------------------------------------
+# CommunityData — v1/v2c
+# ---------------------------------------------------------------------------
+
+
+def test_community_data_v2c():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import CommunityData
+    except ImportError:
+        from pysnmp.hlapi.asyncio import CommunityData
+    # mpModel=1 → SNMPv2c
+    cd = CommunityData("public", mpModel=1)
+    assert cd is not None
+
+
+def test_community_data_v1():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import CommunityData
+    except ImportError:
+        from pysnmp.hlapi.asyncio import CommunityData
+    # mpModel=0 → SNMPv1
+    cd = CommunityData("private", mpModel=0)
+    assert cd is not None
+
+
+# ---------------------------------------------------------------------------
+# UsmUserData — SNMPv3
+# ---------------------------------------------------------------------------
+
+
+def test_usm_user_data_no_auth():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import UsmUserData
+    except ImportError:
+        from pysnmp.hlapi.asyncio import UsmUserData
+    usm = UsmUserData("testuser")
+    assert usm is not None
+
+
+def test_usm_user_data_auth_no_priv():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import UsmUserData
+    except ImportError:
+        from pysnmp.hlapi.asyncio import UsmUserData
+    from pysnmp.hlapi import usmHMACMD5AuthProtocol
+    usm = UsmUserData("testuser", authKey="authpass", authProtocol=usmHMACMD5AuthProtocol)
+    assert usm is not None
+
+
+def test_usm_user_data_auth_priv():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import UsmUserData
+    except ImportError:
+        from pysnmp.hlapi.asyncio import UsmUserData
+    from pysnmp.hlapi import usmHMACMD5AuthProtocol, usmDESPrivProtocol
+    usm = UsmUserData(
+        "testuser",
+        authKey="authpass",
+        privKey="privpass",
+        authProtocol=usmHMACMD5AuthProtocol,
+        privProtocol=usmDESPrivProtocol,
+    )
+    assert usm is not None
+
+
+# ---------------------------------------------------------------------------
+# UdpTransportTarget — host/port/timeout/retries
+# ---------------------------------------------------------------------------
+
+
+def test_udp_transport_target():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import UdpTransportTarget
+    except ImportError:
+        from pysnmp.hlapi.asyncio import UdpTransportTarget
+    t = UdpTransportTarget(("192.168.1.1", 161), timeout=5, retries=1)
+    assert t is not None
+
+
+# ---------------------------------------------------------------------------
+# ObjectType / ObjectIdentity
+# ---------------------------------------------------------------------------
+
+
+def test_object_type_with_oid():
+    try:
+        from pysnmp.hlapi.v3arch.asyncio import ObjectIdentity, ObjectType
+    except ImportError:
+        from pysnmp.hlapi.asyncio import ObjectIdentity, ObjectType
+    ot = ObjectType(ObjectIdentity("1.3.6.1.2.1.1.1.0"))
+    assert ot is not None
+
+
+# ---------------------------------------------------------------------------
+# Auth/Priv protocol constants — hlapi top-level
+# ---------------------------------------------------------------------------
+
+
+def test_auth_protocol_md5():
+    from pysnmp.hlapi import usmHMACMD5AuthProtocol
+    assert usmHMACMD5AuthProtocol is not None
+
+
+def test_auth_protocol_sha():
+    from pysnmp.hlapi import usmHMACSHAAuthProtocol
+    assert usmHMACSHAAuthProtocol is not None
+
+
+def test_priv_protocol_des():
+    from pysnmp.hlapi import usmDESPrivProtocol
+    assert usmDESPrivProtocol is not None
+
+
+def test_priv_protocol_aes128():
+    from pysnmp.hlapi import usmAesCfb128Protocol
+    assert usmAesCfb128Protocol is not None
+
+
+def test_no_auth_no_priv_protocols():
+    from pysnmp.hlapi import usmNoAuthProtocol, usmNoPrivProtocol
+    assert usmNoAuthProtocol is not None
+    assert usmNoPrivProtocol is not None
+
+
+# ---------------------------------------------------------------------------
+# rfc1902 value types — verwendet in _encode_write_value
+# ---------------------------------------------------------------------------
+
+
+def test_integer32_importable():
+    from pysnmp.proto.rfc1902 import Integer32
+    v = Integer32(42)
+    assert int(v) == 42
+
+
+def test_octet_string_importable():
+    from pysnmp.proto.rfc1902 import OctetString
+    v = OctetString(b"hello")
+    assert v is not None
+
+
+def test_value_pretty_print():
+    from pysnmp.proto.rfc1902 import Integer32, OctetString
+    assert Integer32(99).prettyPrint() == "99"
+    assert OctetString(b"test").prettyPrint() == "test"


### PR DESCRIPTION
## Summary

- Adds a full **SNMP adapter** supporting SNMPv1, SNMPv2c and SNMPv3 (noAuthNoPriv / authNoPriv / authPriv)
- Implements **polling** (configurable interval per binding), **SET writes**, and an **OID-Walk** discovery endpoint with pagination (50 OIDs per page)
- Adds a complete **SNMP binding form** in `BindingForm.vue` with an independent Walk root OID field so walking works regardless of the configured binding OID
- Auth-Key and Privacy-Key fields rendered as `password` inputs
- Contract tests for pysnmp 6.2.6 API surface in `tests/contracts/test_pysnmp_contract.py`
- Adapter unit tests with mocked pysnmp in `tests/adapters/test_snmp_adapter.py`

## What changed

| Area | Change |
|---|---|
| `obs/adapters/snmp/adapter.py` | New adapter; pysnmp 6.2.6 compatibility (hlapi.asyncio path, 1D/2D var_binds, native Python value types from lookupMib) |
| `obs/api/v1/adapters.py` | `/instances/{id}/snmp/walk` endpoint with host/oid/port/timeout/max_results/start_oid params |
| `gui/src/api/client.js` | `adapterApi.snmpWalk()` with pagination support |
| `gui/src/components/datapoints/BindingForm.vue` | Full SNMP section: host/port, OID field + independent walk-root input, paginated walk results list, data type selector, poll interval |
| `gui/src/views/AdaptersView.vue` | Hide "Test"-button for SNMP (not applicable) |
| `tests/adapters/test_snmp_adapter.py` | Unit tests: poll, write, walk, pagination, cancellation, v3 auth |
| `tests/contracts/test_pysnmp_contract.py` | Contract tests for all pysnmp symbols used by the adapter |

## pysnmp 6.2.6 notes for reviewers

- Import path is `pysnmp.hlapi.asyncio` (not `v3arch.asyncio` which doesn't exist in 6.2.6); try/except fallback covers both
- `getCmd` returns 1D `var_binds: [ObjectType]`; `nextCmd` returns 2D `[[ObjectType]]` — both are coroutines, not async generators
- Auth/priv protocol constants live in `pysnmp.hlapi.asyncio`, not `pysnmp.hlapi`
- `lookupMib=True` returns native Python types (int/str/bytes) — `prettyPrint()` is not available; handled via `_pretty()` helper

## Test plan

- [ ] Run `pytest tests/adapters/test_snmp_adapter.py tests/contracts/test_pysnmp_contract.py` — all pass without Docker
- [ ] Create an SNMP adapter instance (v2c, community=public) and connect to a real SNMP device
- [ ] Open a binding, use OID-Walk to discover OIDs, click an entry to populate the OID field
- [ ] Verify polling delivers values to the datapoint
- [ ] Test SNMPv3 with a device/simulator — confirm auth_key/priv_key render as password fields

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
