### PR TITLE
feat(dev): add instance banner and configurable host ports for parallel local stacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@ OBS_MQTT_PASSWORD=change-this-mqtt-service-password
 # ── Log level ───────────────────────────────────────────────────────────────
 OBS_LOG_LEVEL=INFO
 
+# ── Host ports for docker compose (optional) ───────────────────────────────
+# Useful for running multiple stacks side-by-side.
+# OBS_HTTP_HOST_PORT=8080
+# OBS_MQTT_HOST_PORT=1883
+# OBS_MQTT_WS_HOST_PORT=9001
+# OBS_INSTANCE_NAME=obs-main
+# OBS_INSTANCE_COLOR=emerald   # amber|emerald|red|blue|...
+
 # ── Database path (inside container: /data is the volume) ──────────────────
 # OBS_DATABASE__PATH=/data/obs.db
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@
 
 # ── Stage 1: build Vue Admin-GUI + Visu-Frontend ────────────────────────────
 FROM node:24-slim AS node-builder
+ARG VITE_INSTANCE_NAME=
+ARG VITE_INSTANCE_COLOR=amber
+ENV VITE_INSTANCE_NAME=${VITE_INSTANCE_NAME}
+ENV VITE_INSTANCE_COLOR=${VITE_INSTANCE_COLOR}
 
 # Admin-GUI (gui/ → ../gui_dist)
 WORKDIR /gui-src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
       - mosquitto_data:/mosquitto/data
       - mosquitto_log:/mosquitto/log
     ports:
-      - "1883:1883"     # MQTT plain
-      - "9001:9001"     # MQTT over WebSocket
+      - "${OBS_MQTT_HOST_PORT:-1883}:1883"     # MQTT plain
+      - "${OBS_MQTT_WS_HOST_PORT:-9001}:9001"  # MQTT over WebSocket
     healthcheck:
       test: ["CMD", "mosquitto_sub", "-t", "$$SYS/#", "-C", "1", "-i", "healthcheck",
              "-u", "${OBS_MQTT_USERNAME:-obs}", "-P", "${OBS_MQTT_PASSWORD:-changeme}",
@@ -54,6 +54,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        VITE_INSTANCE_NAME: ${OBS_INSTANCE_NAME:-}
+        VITE_INSTANCE_COLOR: ${OBS_INSTANCE_COLOR:-amber}
     restart: unless-stopped
     # Share Mosquitto's PID namespace → open bridge server can send SIGHUP to PID 1 (Mosquitto).
     pid: "service:mosquitto"
@@ -66,7 +69,7 @@ services:
       # Optional: mount a host config.yaml (overrides the one inside /data)
       # - ./config.yaml:/data/config.yaml:ro
     ports:
-      - "8080:8080"
+      - "${OBS_HTTP_HOST_PORT:-8080}:8080"
     environment:
       # ── MQTT service account (must match MQTT_SVC_USER/PASS above) ──────
       OBS_MQTT__HOST: mosquitto

--- a/gui/src/App.vue
+++ b/gui/src/App.vue
@@ -1,7 +1,12 @@
 <template>
-  <component :is="layout">
-    <router-view />
-  </component>
+  <div class="min-h-screen">
+    <div v-if="showRuntimeStrip" :class="runtimeStripClass">
+      {{ runtimeStripText }}
+    </div>
+    <component :is="layout">
+      <router-view />
+    </component>
+  </div>
 </template>
 
 <script setup>
@@ -19,6 +24,20 @@ const ws       = useWebSocketStore()
 const settings = useSettingsStore()
 
 const layout = computed(() => route.meta.public ? PlainLayout : AppLayout)
+const instanceName = (import.meta.env.VITE_INSTANCE_NAME || '').trim()
+const instanceColor = (import.meta.env.VITE_INSTANCE_COLOR || 'amber').trim().toLowerCase()
+const showRuntimeStrip = computed(() => !!instanceName)
+
+const runtimeStripText = computed(() => showRuntimeStrip.value ? `Instanz: ${instanceName}` : '')
+
+const runtimeStripClass = computed(() => {
+  const base = 'w-full py-1 px-3 text-center text-xs font-semibold tracking-wide text-white'
+  if (instanceColor === 'red') return `${base} bg-red-700`
+  if (instanceColor === 'green' || instanceColor === 'emerald') return `${base} bg-emerald-700`
+  if (instanceColor === 'blue') return `${base} bg-blue-700`
+  if (instanceColor === 'orange' || instanceColor === 'amber') return `${base} bg-amber-700`
+  return `${base} bg-slate-700`
+})
 
 onMounted(async () => {
   if (auth.isLoggedIn) {


### PR DESCRIPTION
## Summary
- add optional instance banner in GUI based on build args (`VITE_INSTANCE_NAME`, `VITE_INSTANCE_COLOR`)
- keep behavior non-invasive: banner is hidden when instance vars are not set
- make host ports configurable in `docker-compose.yml` for parallel local stacks (`OBS_HTTP_HOST_PORT`, `OBS_MQTT_HOST_PORT`, `OBS_MQTT_WS_HOST_PORT`)
- document optional env keys in `.env.example`

## Why
Running `main` and `dev` side-by-side locally currently needs clear visual/environment separation and non-conflicting ports.

<img width="1308" height="715" alt="Bildschirmfoto 2026-05-08 um 18 28 22" src="https://github.com/user-attachments/assets/43a5b702-5a8e-400e-b98e-c3cdea78f983" />

## Scope
Changed files:
- `.env.example`
- `Dockerfile`
- `docker-compose.yml`
- `gui/src/App.vue`

## Notes
- no backend behavior changes
- no DB/migration changes
- release-like behavior verified: with `OBS_INSTANCE_NAME` and `OBS_INSTANCE_COLOR` unset, no banner is rendered
