### PR TITLE
Add CI-parity local lint entrypoint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,8 +30,5 @@ jobs:
       - name: Install requirements
         run: python3 -m pip install -r requirements_dev.txt
 
-      - name: Lint
-        run: python3 -m ruff check .
-
-      - name: Format
-        run: python3 -m ruff format . --check
+      - name: Lint (CI parity script)
+        run: ./tools/lint.sh --check

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -42,11 +42,11 @@ pytest tests/integration/
 # Run with coverage report
 pytest tests/ --cov=obs --cov-report=term-missing
 
-# Lint
-ruff check .
+# Lint (same checks as CI)
+./tools/lint.sh --check
 
-# Format
-ruff format .
+# Format + autofix
+./tools/lint.sh --fix
 
 # Docker Compose (full stack)
 docker compose up -d
@@ -231,7 +231,7 @@ One file per external library. Each test verifies the exact import paths and API
 
 ### Linting
 
-`ruff` is the sole linter/formatter. Config in `.ruff.toml`: line length 150, target Python 3.13. Tests have relaxed rules (no `assert` warnings, no type annotations required, no docstrings). Contract tests (`tests/contracts/`) additionally suppress E402 (module-level import not at top of file) because `pytest.importorskip()` must precede the library imports it guards — a standard pytest pattern.
+`ruff` is the sole linter/formatter. Config in `.ruff.toml`: line length 150, target Python 3.13. Run `./tools/lint.sh --check` for the exact same lint path as GitHub CI, or `./tools/lint.sh --fix` for local autofix. Tests have relaxed rules (no `assert` warnings, no type annotations required, no docstrings). Contract tests (`tests/contracts/`) additionally suppress E402 (module-level import not at top of file) because `pytest.importorskip()` must precede the library imports it guards — a standard pytest pattern.
 
 ## Release & CI
 

--- a/README.md
+++ b/README.md
@@ -1447,6 +1447,16 @@ pytest tests/unit/ tests/adapters/
 pytest tests/
 ```
 
+#### Lint lokal (identisch zu GitHub CI)
+
+```bash
+# Nur prüfen (gleiches Verhalten wie CI-Job)
+./tools/lint.sh --check
+
+# Mit Auto-Fix
+./tools/lint.sh --fix
+```
+
 ---
 
 ### Starten ohne Docker

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+MODE="${1:---check}"
+
+case "${MODE}" in
+  --check)
+    echo "Running CI-parity lint checks (ruff check + ruff format --check)"
+    python3 -m ruff check .
+    python3 -m ruff format . --check
+    ;;
+  --fix)
+    echo "Running autofix lint (ruff check --fix + ruff format)"
+    python3 -m ruff check . --fix
+    python3 -m ruff format .
+    ;;
+  *)
+    echo "Usage: $(basename "$0") [--check|--fix]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a shared lint entrypoint script at \Running CI-parity lint checks (ruff check + ruff format --check)
All checks passed!
142 files already formatted
- make CI call the shared script instead of duplicating lint/format commands
- document the exact CI-parity local lint command in docs

## Why
This ensures local lint can run through the exact same command path as GitHub CI, reducing future drift.

## Validation
- \Running CI-parity lint checks (ruff check + ruff format --check)
All checks passed!
142 files already formatted