### PR TITLE
fix(chart): WS-driven history chart updates (closes #408)

### DIFF
--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -23,7 +23,10 @@ const COLORS = ['#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899'
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+let refreshTimer: ReturnType<typeof setInterval> | null = null
 const seriesUnits = ref<string[]>([])
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000
 
 function fmtMs(ms: number): string {
   return new Date(ms).toLocaleString(undefined, {
@@ -177,12 +180,19 @@ onMounted(() => {
     },
   })
   loadData()
+  refreshTimer = setInterval(loadData, REFRESH_INTERVAL_MS)
 })
 
-watch(() => props.datapointId, loadData)
-watch(() => props.config, loadData, { deep: true })
+function reloadAndResetTimer() {
+  loadData()
+  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = setInterval(loadData, REFRESH_INTERVAL_MS) }
+}
+
+watch(() => props.datapointId, reloadAndResetTimer)
+watch(() => props.config, reloadAndResetTimer, { deep: true })
 
 onUnmounted(() => {
+  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null }
   chart?.destroy()
   chart = null
 })

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -140,9 +140,13 @@ watch(liveSeriesValues, (newVals, oldVals) => {
     if (oldVals?.[i] && val.t === oldVals[i]?.t) return  // gleicher Timestamp
     const ds = chart!.data.datasets[i]
     if (!ds) return
-    const px     = new Date(val.t).getTime()
+    const px  = new Date(val.t).getTime()
+    const pts = ds.data as { x: number; y: number }[]
+    // Nur anhängen wenn der neue Wert strikt neuer als der letzte Dataset-Punkt ist.
+    // Verhindert dass ein veralteter fetchInitialValues-Wert ungeordnet im Array landet
+    // und Chart.js eine Linie vom letzten History-Punkt zurück zu diesem Fehlpunkt zieht.
+    if (pts.length > 0 && pts[pts.length - 1].x >= px) return
     const cutoff = px - hours.value * 3_600_000
-    const pts    = ds.data as { x: number; y: number }[]
     pts.push({ x: px, y: Number(val.v) })
     while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
     if (px > newestX) newestX = px

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -25,8 +25,9 @@ interface SeriesDef { id: string; label: string; color: string; axis: 'y' | 'y1'
 const COLORS = ['#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899', '#06b6d4', '#f97316']
 
 const canvas = ref<HTMLCanvasElement | null>(null)
-let chart:   Chart | null = null
-let wsOff:   (() => void) | null = null
+let chart:        Chart | null = null
+let wsOff:        (() => void) | null = null
+let reloadTimer:  ReturnType<typeof setTimeout> | null = null
 const seriesUnits = ref<string[]>([])
 
 function fmtMs(ms: number): string {
@@ -182,26 +183,16 @@ onMounted(() => {
   })
   loadData()
 
-  // Direkt auf WS-Nachrichten hören — fetchInitialValues() geht über HTTP und
-  // landet hier NICHT, was das veralteter-Timestamp-Problem komplett ausschliesst.
+  // Auf WS-Nachrichten hören: wenn ein relevanter Datenpunkt eintrifft, wird
+  // loadData() nach einer kurzen Wartezeit (2 s, debounced) neu aufgerufen.
+  // Dadurch holt der Chart immer saubere, vollständige Daten vom Backend —
+  // ohne komplizierte In-Place-Mutation, die bei tension > 0 Artefakte erzeugt.
   wsOff = ws.onMessage((msg) => {
     if (!chart || props.editorMode) return
     if (!msg.id || msg.v === undefined) return
-    // buildSeriesDefs() hier aufrufen damit Config-Änderungen immer reflektiert werden
-    const idx = buildSeriesDefs().findIndex(d => d.id === (msg.id as string))
-    if (idx === -1) return
-    const ds = chart.data.datasets[idx]
-    if (!ds) return
-    const px  = new Date(msg.t as string).getTime()
-    const pts = ds.data as { x: number; y: number }[]
-    // Nur anhängen wenn wirklich neuer als letzter Dataset-Punkt
-    if (pts.length > 0 && pts[pts.length - 1].x >= px) return
-    const cutoff = px - hours.value * 3_600_000
-    pts.push({ x: px, y: Number(msg.v) })
-    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
-    const xAxis = chart.options.scales?.x as Record<string, unknown> | undefined
-    if (xAxis) { xAxis.min = cutoff; xAxis.max = px }
-    chart.update('none')
+    if (!buildSeriesDefs().some(d => d.id === (msg.id as string))) return
+    if (reloadTimer) clearTimeout(reloadTimer)
+    reloadTimer = setTimeout(() => { reloadTimer = null; loadData() }, 2_000)
   })
 })
 
@@ -210,6 +201,7 @@ watch(() => props.config, loadData, { deep: true })
 
 onUnmounted(() => {
   wsOff?.()
+  if (reloadTimer) { clearTimeout(reloadTimer); reloadTimer = null }
   chart?.destroy()
   chart = null
 })

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { Chart, LineController, LineElement, PointElement, LinearScale, Filler, Tooltip, Legend } from 'chart.js'
 import { history } from '@/api/client'
+import { useDatapointsStore } from '@/stores/datapoints'
 import type { DataPointValue } from '@/types'
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, Filler, Tooltip, Legend)
@@ -13,6 +14,8 @@ const props = defineProps<{
   editorMode: boolean
 }>()
 
+const dpStore = useDatapointsStore()
+
 const label = computed(() => (props.config.label as string | undefined) ?? '—')
 const hours = computed(() => (props.config.hours as number | undefined) ?? 24)
 
@@ -23,10 +26,7 @@ const COLORS = ['#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899'
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
-let refreshTimer: ReturnType<typeof setInterval> | null = null
 const seriesUnits = ref<string[]>([])
-
-const REFRESH_INTERVAL_MS = 5 * 60 * 1000
 
 function fmtMs(ms: number): string {
   return new Date(ms).toLocaleString(undefined, {
@@ -124,6 +124,36 @@ async function loadData() {
   chart.update()
 }
 
+// Aktuellen dpStore-Wert für jede konfigurierte Serie beobachten.
+// Da die Extra-Series via getExtraDatapointIds bereits abonniert sind,
+// liefert dpStore sofort neue Werte wenn ein WS-Update eintrifft.
+const liveSeriesValues = computed(() =>
+  buildSeriesDefs().map(s => dpStore.getValue(s.id)),
+)
+
+watch(liveSeriesValues, (newVals, oldVals) => {
+  if (!chart || props.editorMode) return
+  const cutoff = Date.now() - hours.value * 3_600_000
+  const now    = Date.now()
+  let changed  = false
+
+  newVals.forEach((val, i) => {
+    if (!val) return
+    if (oldVals?.[i] && val.t === oldVals[i]?.t) return  // gleicher Timestamp
+    const ds = chart!.data.datasets[i]
+    if (!ds) return
+    const pts = ds.data as { x: number; y: number }[]
+    pts.push({ x: new Date(val.t).getTime(), y: Number(val.v) })
+    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
+    changed = true
+  })
+
+  if (!changed) return
+  const xAxis = chart!.options.scales?.x as Record<string, unknown> | undefined
+  if (xAxis) { xAxis.min = cutoff; xAxis.max = now }
+  chart!.update('none')
+}, { deep: true })
+
 onMounted(() => {
   if (!canvas.value) return
   chart = new Chart(canvas.value, {
@@ -180,19 +210,12 @@ onMounted(() => {
     },
   })
   loadData()
-  refreshTimer = setInterval(loadData, REFRESH_INTERVAL_MS)
 })
 
-function reloadAndResetTimer() {
-  loadData()
-  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = setInterval(loadData, REFRESH_INTERVAL_MS) }
-}
-
-watch(() => props.datapointId, reloadAndResetTimer)
-watch(() => props.config, reloadAndResetTimer, { deep: true })
+watch(() => props.datapointId, loadData)
+watch(() => props.config, loadData, { deep: true })
 
 onUnmounted(() => {
-  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null }
   chart?.destroy()
   chart = null
 })

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { Chart, LineController, LineElement, PointElement, LinearScale, Filler, Tooltip, Legend } from 'chart.js'
 import { history } from '@/api/client'
-import { useDatapointsStore } from '@/stores/datapoints'
+import { useWebSocket } from '@/composables/useWebSocket'
 import type { DataPointValue } from '@/types'
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, Filler, Tooltip, Legend)
@@ -14,7 +14,7 @@ const props = defineProps<{
   editorMode: boolean
 }>()
 
-const dpStore = useDatapointsStore()
+const ws = useWebSocket()
 
 const label = computed(() => (props.config.label as string | undefined) ?? '—')
 const hours = computed(() => (props.config.hours as number | undefined) ?? 24)
@@ -25,7 +25,8 @@ interface SeriesDef { id: string; label: string; color: string; axis: 'y' | 'y1'
 const COLORS = ['#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899', '#06b6d4', '#f97316']
 
 const canvas = ref<HTMLCanvasElement | null>(null)
-let chart: Chart | null = null
+let chart:   Chart | null = null
+let wsOff:   (() => void) | null = null
 const seriesUnits = ref<string[]>([])
 
 function fmtMs(ms: number): string {
@@ -124,41 +125,6 @@ async function loadData() {
   chart.update()
 }
 
-// Aktuellen dpStore-Wert für jede konfigurierte Serie beobachten.
-// Da die Extra-Series via getExtraDatapointIds bereits abonniert sind,
-// liefert dpStore sofort neue Werte wenn ein WS-Update eintrifft.
-const liveSeriesValues = computed(() =>
-  buildSeriesDefs().map(s => dpStore.getValue(s.id)),
-)
-
-watch(liveSeriesValues, (newVals, oldVals) => {
-  if (!chart || props.editorMode) return
-  let newestX = 0
-
-  newVals.forEach((val, i) => {
-    if (!val) return
-    if (oldVals?.[i] && val.t === oldVals[i]?.t) return  // gleicher Timestamp
-    const ds = chart!.data.datasets[i]
-    if (!ds) return
-    const px  = new Date(val.t).getTime()
-    const pts = ds.data as { x: number; y: number }[]
-    // Nur anhängen wenn der neue Wert strikt neuer als der letzte Dataset-Punkt ist.
-    // Verhindert dass ein veralteter fetchInitialValues-Wert ungeordnet im Array landet
-    // und Chart.js eine Linie vom letzten History-Punkt zurück zu diesem Fehlpunkt zieht.
-    if (pts.length > 0 && pts[pts.length - 1].x >= px) return
-    const cutoff = px - hours.value * 3_600_000
-    pts.push({ x: px, y: Number(val.v) })
-    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
-    if (px > newestX) newestX = px
-  })
-
-  if (newestX === 0) return
-  const cutoff = newestX - hours.value * 3_600_000
-  const xAxis  = chart!.options.scales?.x as Record<string, unknown> | undefined
-  if (xAxis) { xAxis.min = cutoff; xAxis.max = newestX }
-  chart!.update('none')
-}, { deep: true })
-
 onMounted(() => {
   if (!canvas.value) return
   chart = new Chart(canvas.value, {
@@ -215,12 +181,35 @@ onMounted(() => {
     },
   })
   loadData()
+
+  // Direkt auf WS-Nachrichten hören — fetchInitialValues() geht über HTTP und
+  // landet hier NICHT, was das veralteter-Timestamp-Problem komplett ausschliesst.
+  wsOff = ws.onMessage((msg) => {
+    if (!chart || props.editorMode) return
+    if (!msg.id || msg.v === undefined) return
+    // buildSeriesDefs() hier aufrufen damit Config-Änderungen immer reflektiert werden
+    const idx = buildSeriesDefs().findIndex(d => d.id === (msg.id as string))
+    if (idx === -1) return
+    const ds = chart.data.datasets[idx]
+    if (!ds) return
+    const px  = new Date(msg.t as string).getTime()
+    const pts = ds.data as { x: number; y: number }[]
+    // Nur anhängen wenn wirklich neuer als letzter Dataset-Punkt
+    if (pts.length > 0 && pts[pts.length - 1].x >= px) return
+    const cutoff = px - hours.value * 3_600_000
+    pts.push({ x: px, y: Number(msg.v) })
+    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
+    const xAxis = chart.options.scales?.x as Record<string, unknown> | undefined
+    if (xAxis) { xAxis.min = cutoff; xAxis.max = px }
+    chart.update('none')
+  })
 })
 
 watch(() => props.datapointId, loadData)
 watch(() => props.config, loadData, { deep: true })
 
 onUnmounted(() => {
+  wsOff?.()
   chart?.destroy()
   chart = null
 })

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -133,24 +133,25 @@ const liveSeriesValues = computed(() =>
 
 watch(liveSeriesValues, (newVals, oldVals) => {
   if (!chart || props.editorMode) return
-  const cutoff = Date.now() - hours.value * 3_600_000
-  const now    = Date.now()
-  let changed  = false
+  let newestX = 0
 
   newVals.forEach((val, i) => {
     if (!val) return
     if (oldVals?.[i] && val.t === oldVals[i]?.t) return  // gleicher Timestamp
     const ds = chart!.data.datasets[i]
     if (!ds) return
-    const pts = ds.data as { x: number; y: number }[]
-    pts.push({ x: new Date(val.t).getTime(), y: Number(val.v) })
+    const px     = new Date(val.t).getTime()
+    const cutoff = px - hours.value * 3_600_000
+    const pts    = ds.data as { x: number; y: number }[]
+    pts.push({ x: px, y: Number(val.v) })
     while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
-    changed = true
+    if (px > newestX) newestX = px
   })
 
-  if (!changed) return
-  const xAxis = chart!.options.scales?.x as Record<string, unknown> | undefined
-  if (xAxis) { xAxis.min = cutoff; xAxis.max = now }
+  if (newestX === 0) return
+  const cutoff = newestX - hours.value * 3_600_000
+  const xAxis  = chart!.options.scales?.x as Record<string, unknown> | undefined
+  if (xAxis) { xAxis.min = cutoff; xAxis.max = newestX }
   chart!.update('none')
 }, { deep: true })
 

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -217,14 +217,16 @@ async function updateMiniChart() {
 }
 
 // Neuen WS-Wert in Mini- und Modal-Chart einhängen, ohne History neu zu laden.
-// xAxis.max = pt.x (Zeitstempel des Werts), nicht Date.now() — sonst entsteht
-// ein Lückenbereich rechts, der bei fill:true als dunkles Dreieck erscheint.
+// Wichtig: nur anhängen wenn pt.x strikt neuer als der letzte vorhandene Punkt ist —
+// sonst landet ein veralteter fetchInitialValues-Wert ungeordnet im Array und
+// Chart.js zieht eine Linie vom letzten History-Punkt zurück zu diesem Fehlpunkt.
 function appendLivePoint(val: { t: string; v: unknown }) {
   const pt     = { x: new Date(val.t).getTime(), y: Number(val.v) }
   const cutoff = pt.x - historyHours.value * 3_600_000
 
   if (miniChart) {
     const pts = miniChart.data.datasets[0].data as { x: number; y: number }[]
+    if (pts.length > 0 && pts[pts.length - 1].x >= pt.x) return
     pts.push(pt)
     while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
     const xAxis = miniChart.options.scales?.x as any
@@ -234,6 +236,7 @@ function appendLivePoint(val: { t: string; v: unknown }) {
 
   if (modalChart && modalOpen.value) {
     const pts = modalChart.data.datasets[0].data as { x: number; y: number }[]
+    if (pts.length > 0 && pts[pts.length - 1].x >= pt.x) return
     pts.push(pt)
     while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
     const xAxis = modalChart.options.scales?.x as any

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -172,9 +172,13 @@ const secondaryDisplay = computed(() => {
 const canvasEl      = ref<HTMLCanvasElement | null>(null)
 const modalOpen     = ref(false)
 const modalCanvasEl = ref<HTMLCanvasElement | null>(null)
-let miniChart:  Chart | null = null
-let modalChart: Chart | null = null
+let miniChart:    Chart | null = null
+let modalChart:   Chart | null = null
 let histUnit = ''
+let miniRefreshTimer:  ReturnType<typeof setInterval> | null = null
+let modalRefreshTimer: ReturnType<typeof setInterval> | null = null
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000
 
 function fmtMs(ms: number): string {
   return new Date(ms).toLocaleString(undefined, {
@@ -231,12 +235,28 @@ onMounted(() => {
     },
   })
   updateMiniChart()
+  miniRefreshTimer = setInterval(updateMiniChart, REFRESH_INTERVAL_MS)
 })
 
-watch(() => [props.datapointId, historyHours.value], updateMiniChart)
+watch(() => [props.datapointId, historyHours.value], () => {
+  updateMiniChart()
+  if (miniRefreshTimer) { clearInterval(miniRefreshTimer); miniRefreshTimer = setInterval(updateMiniChart, REFRESH_INTERVAL_MS) }
+})
+
+async function updateModalChart() {
+  if (!modalChart) return
+  const { pts, minMs, maxMs } = await fetchPoints()
+  modalChart.data.datasets[0].data = pts
+  const xAxis = modalChart.options.scales?.x as any
+  if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
+  modalChart.update()
+}
 
 watch(modalOpen, async (open) => {
-  if (!open) { modalChart?.destroy(); modalChart = null; return }
+  if (!open) {
+    if (modalRefreshTimer) { clearInterval(modalRefreshTimer); modalRefreshTimer = null }
+    modalChart?.destroy(); modalChart = null; return
+  }
   await new Promise<void>(r => setTimeout(r, 50))
   if (!modalCanvasEl.value) return
   const { pts, minMs, maxMs } = await fetchPoints()
@@ -267,9 +287,15 @@ watch(modalOpen, async (open) => {
       },
     },
   })
+  modalRefreshTimer = setInterval(updateModalChart, REFRESH_INTERVAL_MS)
 })
 
-onUnmounted(() => { miniChart?.destroy(); modalChart?.destroy() })
+onUnmounted(() => {
+  if (miniRefreshTimer)  { clearInterval(miniRefreshTimer);  miniRefreshTimer  = null }
+  if (modalRefreshTimer) { clearInterval(modalRefreshTimer); modalRefreshTimer = null }
+  miniChart?.destroy()
+  modalChart?.destroy()
+})
 
 const quality = computed(() => props.value?.q ?? null)
 </script>

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -216,18 +216,19 @@ async function updateMiniChart() {
   miniChart.update()
 }
 
-// Neuen WS-Wert in Mini- und Modal-Chart einhängen, ohne History neu zu laden
+// Neuen WS-Wert in Mini- und Modal-Chart einhängen, ohne History neu zu laden.
+// xAxis.max = pt.x (Zeitstempel des Werts), nicht Date.now() — sonst entsteht
+// ein Lückenbereich rechts, der bei fill:true als dunkles Dreieck erscheint.
 function appendLivePoint(val: { t: string; v: unknown }) {
   const pt     = { x: new Date(val.t).getTime(), y: Number(val.v) }
-  const cutoff = Date.now() - historyHours.value * 3_600_000
-  const now    = Date.now()
+  const cutoff = pt.x - historyHours.value * 3_600_000
 
   if (miniChart) {
     const pts = miniChart.data.datasets[0].data as { x: number; y: number }[]
     pts.push(pt)
     while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
     const xAxis = miniChart.options.scales?.x as any
-    if (xAxis) { xAxis.min = cutoff; xAxis.max = now }
+    if (xAxis) { xAxis.min = cutoff; xAxis.max = pt.x }
     miniChart.update('none')
   }
 
@@ -236,7 +237,7 @@ function appendLivePoint(val: { t: string; v: unknown }) {
     pts.push(pt)
     while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
     const xAxis = modalChart.options.scales?.x as any
-    if (xAxis) { xAxis.min = cutoff; xAxis.max = now }
+    if (xAxis) { xAxis.min = cutoff; xAxis.max = pt.x }
     modalChart.update('none')
   }
 }

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -172,13 +172,9 @@ const secondaryDisplay = computed(() => {
 const canvasEl      = ref<HTMLCanvasElement | null>(null)
 const modalOpen     = ref(false)
 const modalCanvasEl = ref<HTMLCanvasElement | null>(null)
-let miniChart:    Chart | null = null
-let modalChart:   Chart | null = null
+let miniChart:  Chart | null = null
+let modalChart: Chart | null = null
 let histUnit = ''
-let miniRefreshTimer:  ReturnType<typeof setInterval> | null = null
-let modalRefreshTimer: ReturnType<typeof setInterval> | null = null
-
-const REFRESH_INTERVAL_MS = 5 * 60 * 1000
 
 function fmtMs(ms: number): string {
   return new Date(ms).toLocaleString(undefined, {
@@ -200,9 +196,9 @@ function makeDataset(color: string) {
 
 async function fetchPoints() {
   if (!props.datapointId || props.editorMode) return { pts: [], minMs: 0, maxMs: 0 }
-  const now     = new Date()
+  const now      = new Date()
   const fromDate = new Date(now.getTime() - historyHours.value * 3_600_000)
-  const data    = await history.query(props.datapointId, fromDate.toISOString(), now.toISOString())
+  const data     = await history.query(props.datapointId, fromDate.toISOString(), now.toISOString())
   histUnit = data[0]?.u ?? ''
   return {
     pts:   data.map(d => ({ x: new Date(d.ts).getTime(), y: Number(d.v) })),
@@ -220,6 +216,37 @@ async function updateMiniChart() {
   miniChart.update()
 }
 
+// Neuen WS-Wert in Mini- und Modal-Chart einhängen, ohne History neu zu laden
+function appendLivePoint(val: { t: string; v: unknown }) {
+  const pt     = { x: new Date(val.t).getTime(), y: Number(val.v) }
+  const cutoff = Date.now() - historyHours.value * 3_600_000
+  const now    = Date.now()
+
+  if (miniChart) {
+    const pts = miniChart.data.datasets[0].data as { x: number; y: number }[]
+    pts.push(pt)
+    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
+    const xAxis = miniChart.options.scales?.x as any
+    if (xAxis) { xAxis.min = cutoff; xAxis.max = now }
+    miniChart.update('none')
+  }
+
+  if (modalChart && modalOpen.value) {
+    const pts = modalChart.data.datasets[0].data as { x: number; y: number }[]
+    pts.push(pt)
+    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
+    const xAxis = modalChart.options.scales?.x as any
+    if (xAxis) { xAxis.min = cutoff; xAxis.max = now }
+    modalChart.update('none')
+  }
+}
+
+watch(() => props.value, (newVal, oldVal) => {
+  if (mode.value !== 'history' || !newVal || props.editorMode) return
+  if (oldVal && newVal.t === oldVal.t) return  // gleicher Timestamp → kein neuer Wert
+  appendLivePoint(newVal)
+})
+
 onMounted(() => {
   if (mode.value !== 'history' || !canvasEl.value) return
   miniChart = new Chart(canvasEl.value, {
@@ -235,28 +262,12 @@ onMounted(() => {
     },
   })
   updateMiniChart()
-  miniRefreshTimer = setInterval(updateMiniChart, REFRESH_INTERVAL_MS)
 })
 
-watch(() => [props.datapointId, historyHours.value], () => {
-  updateMiniChart()
-  if (miniRefreshTimer) { clearInterval(miniRefreshTimer); miniRefreshTimer = setInterval(updateMiniChart, REFRESH_INTERVAL_MS) }
-})
-
-async function updateModalChart() {
-  if (!modalChart) return
-  const { pts, minMs, maxMs } = await fetchPoints()
-  modalChart.data.datasets[0].data = pts
-  const xAxis = modalChart.options.scales?.x as any
-  if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
-  modalChart.update()
-}
+watch(() => [props.datapointId, historyHours.value], updateMiniChart)
 
 watch(modalOpen, async (open) => {
-  if (!open) {
-    if (modalRefreshTimer) { clearInterval(modalRefreshTimer); modalRefreshTimer = null }
-    modalChart?.destroy(); modalChart = null; return
-  }
+  if (!open) { modalChart?.destroy(); modalChart = null; return }
   await new Promise<void>(r => setTimeout(r, 50))
   if (!modalCanvasEl.value) return
   const { pts, minMs, maxMs } = await fetchPoints()
@@ -287,15 +298,9 @@ watch(modalOpen, async (open) => {
       },
     },
   })
-  modalRefreshTimer = setInterval(updateModalChart, REFRESH_INTERVAL_MS)
 })
 
-onUnmounted(() => {
-  if (miniRefreshTimer)  { clearInterval(miniRefreshTimer);  miniRefreshTimer  = null }
-  if (modalRefreshTimer) { clearInterval(modalRefreshTimer); modalRefreshTimer = null }
-  miniChart?.destroy()
-  modalChart?.destroy()
-})
+onUnmounted(() => { miniChart?.destroy(); modalChart?.destroy() })
 
 const quality = computed(() => props.value?.q ?? null)
 </script>

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -4,6 +4,7 @@ import { Chart, LineController, LineElement, PointElement, LinearScale, Filler, 
 import { history } from '@/api/client'
 import { useIcons } from '@/composables/useIcons'
 import { useDatapointsStore } from '@/stores/datapoints'
+import { useWebSocket } from '@/composables/useWebSocket'
 import type { DataPointValue } from '@/types'
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, Filler, Tooltip)
@@ -169,11 +170,14 @@ const secondaryDisplay = computed(() => {
 
 // ── History chart ──────────────────────────────────────────────────────────────
 
+const ws = useWebSocket()
+
 const canvasEl      = ref<HTMLCanvasElement | null>(null)
 const modalOpen     = ref(false)
 const modalCanvasEl = ref<HTMLCanvasElement | null>(null)
-let miniChart:  Chart | null = null
-let modalChart: Chart | null = null
+let miniChart:   Chart | null = null
+let modalChart:  Chart | null = null
+let wsOff:       (() => void) | null = null
 let histUnit = ''
 
 function fmtMs(ms: number): string {
@@ -245,13 +249,15 @@ function appendLivePoint(val: { t: string; v: unknown }) {
   }
 }
 
-watch(() => props.value, (newVal, oldVal) => {
-  if (mode.value !== 'history' || !newVal || props.editorMode) return
-  if (oldVal && newVal.t === oldVal.t) return  // gleicher Timestamp → kein neuer Wert
-  appendLivePoint(newVal)
-})
-
 onMounted(() => {
+  // Direkt auf WS-Nachrichten hören — fetchInitialValues() läuft über HTTP und
+  // landet hier NICHT, vermeidet so das veraltete-Timestamp-Problem.
+  wsOff = ws.onMessage((msg) => {
+    if (mode.value !== 'history' || props.editorMode) return
+    if (!msg.id || msg.v === undefined || msg.id !== props.datapointId) return
+    appendLivePoint({ t: msg.t as string, v: msg.v })
+  })
+
   if (mode.value !== 'history' || !canvasEl.value) return
   miniChart = new Chart(canvasEl.value, {
     type: 'line',
@@ -304,7 +310,7 @@ watch(modalOpen, async (open) => {
   })
 })
 
-onUnmounted(() => { miniChart?.destroy(); modalChart?.destroy() })
+onUnmounted(() => { wsOff?.(); miniChart?.destroy(); modalChart?.destroy() })
 
 const quality = computed(() => props.value?.q ?? null)
 </script>

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -175,9 +175,10 @@ const ws = useWebSocket()
 const canvasEl      = ref<HTMLCanvasElement | null>(null)
 const modalOpen     = ref(false)
 const modalCanvasEl = ref<HTMLCanvasElement | null>(null)
-let miniChart:   Chart | null = null
-let modalChart:  Chart | null = null
-let wsOff:       (() => void) | null = null
+let miniChart:    Chart | null = null
+let modalChart:   Chart | null = null
+let wsOff:        (() => void) | null = null
+let reloadTimer:  ReturnType<typeof setTimeout> | null = null
 let histUnit = ''
 
 function fmtMs(ms: number): string {
@@ -212,50 +213,32 @@ async function fetchPoints() {
 }
 
 async function updateMiniChart() {
-  if (mode.value !== 'history' || !miniChart) return
+  if (mode.value !== 'history') return
   const { pts, minMs, maxMs } = await fetchPoints()
-  miniChart.data.datasets[0].data = pts
-  const xAxis = miniChart.options.scales?.x as any
-  if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
-  miniChart.update()
-}
-
-// Neuen WS-Wert in Mini- und Modal-Chart einhängen, ohne History neu zu laden.
-// Wichtig: nur anhängen wenn pt.x strikt neuer als der letzte vorhandene Punkt ist —
-// sonst landet ein veralteter fetchInitialValues-Wert ungeordnet im Array und
-// Chart.js zieht eine Linie vom letzten History-Punkt zurück zu diesem Fehlpunkt.
-function appendLivePoint(val: { t: string; v: unknown }) {
-  const pt     = { x: new Date(val.t).getTime(), y: Number(val.v) }
-  const cutoff = pt.x - historyHours.value * 3_600_000
-
   if (miniChart) {
-    const pts = miniChart.data.datasets[0].data as { x: number; y: number }[]
-    if (pts.length > 0 && pts[pts.length - 1].x >= pt.x) return
-    pts.push(pt)
-    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
+    miniChart.data.datasets[0].data = pts
     const xAxis = miniChart.options.scales?.x as any
-    if (xAxis) { xAxis.min = cutoff; xAxis.max = pt.x }
-    miniChart.update('none')
+    if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
+    miniChart.update()
   }
-
   if (modalChart && modalOpen.value) {
-    const pts = modalChart.data.datasets[0].data as { x: number; y: number }[]
-    if (pts.length > 0 && pts[pts.length - 1].x >= pt.x) return
-    pts.push(pt)
-    while (pts.length > 0 && pts[0].x < cutoff) pts.shift()
+    modalChart.data.datasets[0].data = pts
     const xAxis = modalChart.options.scales?.x as any
-    if (xAxis) { xAxis.min = cutoff; xAxis.max = pt.x }
-    modalChart.update('none')
+    if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
+    modalChart.update()
   }
 }
 
 onMounted(() => {
-  // Direkt auf WS-Nachrichten hören — fetchInitialValues() läuft über HTTP und
-  // landet hier NICHT, vermeidet so das veraltete-Timestamp-Problem.
+  // Auf WS-Nachrichten hören: wenn der eigene Datenpunkt aktualisiert wird,
+  // wird updateMiniChart() nach 2 s (debounced) aufgerufen. Das Backend hat
+  // den Wert bis dahin sicher gespeichert, sodass der Chart saubere Daten
+  // ohne Artefakte lädt.
   wsOff = ws.onMessage((msg) => {
     if (mode.value !== 'history' || props.editorMode) return
     if (!msg.id || msg.v === undefined || msg.id !== props.datapointId) return
-    appendLivePoint({ t: msg.t as string, v: msg.v })
+    if (reloadTimer) clearTimeout(reloadTimer)
+    reloadTimer = setTimeout(() => { reloadTimer = null; updateMiniChart() }, 2_000)
   })
 
   if (mode.value !== 'history' || !canvasEl.value) return
@@ -310,7 +293,12 @@ watch(modalOpen, async (open) => {
   })
 })
 
-onUnmounted(() => { wsOff?.(); miniChart?.destroy(); modalChart?.destroy() })
+onUnmounted(() => {
+  wsOff?.()
+  if (reloadTimer) { clearTimeout(reloadTimer); reloadTimer = null }
+  miniChart?.destroy()
+  modalChart?.destroy()
+})
 
 const quality = computed(() => props.value?.q ?? null)
 </script>


### PR DESCRIPTION
## Summary

- **Chart/Widget.vue** and **ValueDisplay/Widget.vue**: history charts now auto-update when new values arrive via WebSocket, without polling
- Replaced in-place array mutation with a debounced `loadData()` call (2 s after the last WS message) — eliminates the diagonal-line rendering artifact that plagued previous approaches

## What changed and why

### Root cause of the diagonal-line artifact
Previous approaches tried to append new WS points directly into the Chart.js dataset array in-place (`pts.push` / `pts.shift`). This conflicted with:
- `tension: 0.3` — bezier control points span the gap between the last historical measurement and the appended WS point, arcing through visually wrong positions
- `fill: true` — the fill polygon closes differently when `xAxis.min/max` shifts after each append

All guards (duplicate-timestamp check, `xAxis.max = pt.x` instead of `Date.now()`, switching from Vue reactive watchers to `ws.onMessage` directly) failed to fix the artifact because the root cause is Chart.js's bezier + fill interaction with in-place data mutation.

### Solution: debounced full reload
When a WS message arrives for a relevant datapointId, a 2-second debounced `loadData()` is scheduled. The backend has already persisted the value by then, so the history query returns a complete, correctly ordered dataset and Chart.js renders it cleanly without artifacts.

- Near-real-time updates: chart refreshes within ~2 s of each WS-received value
- Debouncing prevents flooding the history API when values change rapidly
- Multi-series Chart widget: a WS message for any configured series triggers the reload
- ValueDisplay modal chart: also refreshed by the debounced call if open at reload time

## Reviewer notes

- No changes to backend or API
- The `appendLivePoint` helper in ValueDisplay has been removed entirely
- `onUnmounted` now clears the reload timer to avoid stale callbacks after unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)
