### PR TITLE
feat: Verlauf Widget variabler Zeitbereich (#413)

### DIFF
--- a/frontend/src/widgets/Chart/Config.vue
+++ b/frontend/src/widgets/Chart/Config.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { reactive, watch } from 'vue'
 import DataPointPicker from '@/components/DataPointPicker.vue'
+import { TIME_RANGE_PRESETS, DEFAULT_TIME_RANGE } from './timeRangePresets'
 
 type Axis = 'left' | 'right'
 
@@ -13,7 +14,7 @@ interface Series {
 
 interface Cfg {
   label: string
-  hours: number
+  time_range: string
   primary_color: string
   primary_axis: Axis
   series: Series[]
@@ -34,9 +35,14 @@ function normalizeSeries(raw: unknown): Series[] {
   }))
 }
 
+function resolveTimeRange(raw: Record<string, unknown>): string {
+  if (raw.time_range && typeof raw.time_range === 'string') return raw.time_range as string
+  return DEFAULT_TIME_RANGE
+}
+
 const cfg = reactive<Cfg>({
   label:         (props.modelValue.label         as string) ?? '',
-  hours:         (props.modelValue.hours         as number) ?? 24,
+  time_range:    resolveTimeRange(props.modelValue),
   primary_color: (props.modelValue.primary_color as string) ?? '#3b82f6',
   primary_axis:  (props.modelValue.primary_axis  as Axis)   ?? 'left',
   series:        normalizeSeries(props.modelValue.series),
@@ -44,7 +50,7 @@ const cfg = reactive<Cfg>({
 
 watch(cfg, () => emit('update:modelValue', {
   label:         cfg.label,
-  hours:         cfg.hours,
+  time_range:    cfg.time_range,
   primary_color: cfg.primary_color,
   primary_axis:  cfg.primary_axis,
   series:        cfg.series.map(s => ({ ...s })),
@@ -76,14 +82,13 @@ function removeSeries(i: number) {
 
     <!-- Zeitraum -->
     <div>
-      <label class="block text-xs text-gray-400 mb-1">Zeitraum (Stunden)</label>
-      <input
-        v-model.number="cfg.hours"
-        type="number"
-        min="1"
-        max="720"
-        class="w-32 bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
-      />
+      <label class="block text-xs text-gray-400 mb-1">Standard-Zeitbereich</label>
+      <select
+        v-model="cfg.time_range"
+        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+      >
+        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+      </select>
     </div>
 
     <!-- Primäre Reihe -->

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -4,6 +4,7 @@ import { Chart, LineController, LineElement, PointElement, LinearScale, Filler, 
 import { history } from '@/api/client'
 import { useWebSocket } from '@/composables/useWebSocket'
 import type { DataPointValue } from '@/types'
+import { TIME_RANGE_PRESETS, DEFAULT_TIME_RANGE, resolveTimeRange } from './timeRangePresets'
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, Filler, Tooltip, Legend)
 
@@ -17,7 +18,18 @@ const props = defineProps<{
 const ws = useWebSocket()
 
 const label = computed(() => (props.config.label as string | undefined) ?? '—')
-const hours = computed(() => (props.config.hours as number | undefined) ?? 24)
+
+function configTimeRange(config: Record<string, unknown>): string {
+  if (config.time_range && typeof config.time_range === 'string') return config.time_range as string
+  return DEFAULT_TIME_RANGE
+}
+
+const selectedTimeRange = ref(configTimeRange(props.config))
+
+// Reset to config default when the configured default changes
+watch(() => props.config.time_range, () => {
+  selectedTimeRange.value = configTimeRange(props.config)
+})
 
 // 'y' = linke Achse, 'y1' = rechte Achse (Chart.js Achsen-IDs)
 interface SeriesDef { id: string; label: string; color: string; axis: 'y' | 'y1' }
@@ -70,11 +82,10 @@ async function loadData() {
   const defs = buildSeriesDefs()
   if (defs.length === 0 || !chart) return
 
-  const now      = new Date()
-  const fromDate = new Date(now.getTime() - hours.value * 3_600_000)
+  const { from: fromDate, to: toDate } = resolveTimeRange(selectedTimeRange.value)
 
   const results = await Promise.all(
-    defs.map(s => history.query(s.id, fromDate.toISOString(), now.toISOString())),
+    defs.map(s => history.query(s.id, fromDate.toISOString(), toDate.toISOString())),
   )
 
   seriesUnits.value = results.map(r => r[0]?.u ?? '')
@@ -100,7 +111,7 @@ async function loadData() {
 
   // X-Achse
   const xAxis = chart.options.scales?.x as Record<string, unknown> | undefined
-  if (xAxis) { xAxis.min = fromDate.getTime(); xAxis.max = now.getTime() }
+  if (xAxis) { xAxis.min = fromDate.getTime(); xAxis.max = toDate.getTime() }
 
   // Linke Y-Achse
   const yLeft = chart.options.scales?.y as Record<string, unknown> | undefined
@@ -198,6 +209,7 @@ onMounted(() => {
 
 watch(() => props.datapointId, loadData)
 watch(() => props.config, loadData, { deep: true })
+watch(selectedTimeRange, loadData)
 
 onUnmounted(() => {
   wsOff?.()
@@ -209,7 +221,17 @@ onUnmounted(() => {
 
 <template>
   <div class="flex flex-col h-full p-3">
-    <span class="text-xs text-gray-400 mb-1 truncate">{{ label }}</span>
+    <div class="flex items-center justify-between gap-2 mb-1 min-w-0">
+      <span class="text-xs text-gray-400 truncate">{{ label }}</span>
+      <select
+        v-if="!editorMode"
+        v-model="selectedTimeRange"
+        class="shrink-0 text-xs bg-gray-800 border border-gray-700 rounded px-1.5 py-0.5 text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
+        title="Zeitbereich wählen"
+      >
+        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+      </select>
+    </div>
     <div class="flex-1 min-h-0">
       <canvas v-if="!editorMode" ref="canvas" />
       <div v-else class="flex items-center justify-center h-full text-gray-600 text-sm">

--- a/frontend/src/widgets/Chart/index.ts
+++ b/frontend/src/widgets/Chart/index.ts
@@ -11,7 +11,7 @@ WidgetRegistry.register({
   defaultW: 6, defaultH: 4,
   component: Widget,
   configComponent: Config,
-  defaultConfig: { label: '', hours: 24, primary_color: '#3b82f6', primary_axis: 'left', series: [] },
+  defaultConfig: { label: '', time_range: 'last_24h', primary_color: '#3b82f6', primary_axis: 'left', series: [] },
   compatibleTypes: ['FLOAT', 'INTEGER'],
   getExtraDatapointIds: (config) => {
     const series = config.series as Array<{ dp_id?: string }> | undefined

--- a/frontend/src/widgets/Chart/timeRangePresets.ts
+++ b/frontend/src/widgets/Chart/timeRangePresets.ts
@@ -1,0 +1,98 @@
+export interface TimeRangePreset {
+  value: string
+  label: string
+}
+
+export const TIME_RANGE_PRESETS: TimeRangePreset[] = [
+  { value: 'last_5m',    label: 'Letzte 5 Minuten' },
+  { value: 'last_15m',   label: 'Letzte 15 Minuten' },
+  { value: 'last_30m',   label: 'Letzte 30 Minuten' },
+  { value: 'last_1h',    label: 'Letzte 1 Stunde' },
+  { value: 'last_3h',    label: 'Letzte 3 Stunden' },
+  { value: 'last_6h',    label: 'Letzte 6 Stunden' },
+  { value: 'last_12h',   label: 'Letzte 12 Stunden' },
+  { value: 'last_24h',   label: 'Letzte 24 Stunden' },
+  { value: 'last_2d',    label: 'Letzte 2 Tage' },
+  { value: 'last_7d',    label: 'Letzte 7 Tage' },
+  { value: 'last_30d',   label: 'Letzte 30 Tage' },
+  { value: 'last_90d',   label: 'Letzte 90 Tage' },
+  { value: 'today',      label: 'Heute bis jetzt' },
+  { value: 'this_week',  label: 'Diese Woche bis jetzt' },
+  { value: 'this_month', label: 'Diesen Monat bis jetzt' },
+  { value: 'yesterday',  label: 'Gestern' },
+  { value: 'last_week',  label: 'Letzte Woche' },
+  { value: 'last_month', label: 'Letzter Monat' },
+]
+
+export const DEFAULT_TIME_RANGE = 'last_24h'
+
+export function resolveTimeRange(preset: string): { from: Date; to: Date } {
+  const now = new Date()
+
+  switch (preset) {
+    case 'last_5m':  return { from: new Date(now.getTime() -  5 * 60_000), to: now }
+    case 'last_15m': return { from: new Date(now.getTime() - 15 * 60_000), to: now }
+    case 'last_30m': return { from: new Date(now.getTime() - 30 * 60_000), to: now }
+    case 'last_1h':  return { from: new Date(now.getTime() -  1 * 3_600_000), to: now }
+    case 'last_3h':  return { from: new Date(now.getTime() -  3 * 3_600_000), to: now }
+    case 'last_6h':  return { from: new Date(now.getTime() -  6 * 3_600_000), to: now }
+    case 'last_12h': return { from: new Date(now.getTime() - 12 * 3_600_000), to: now }
+    case 'last_24h': return { from: new Date(now.getTime() - 24 * 3_600_000), to: now }
+    case 'last_2d':  return { from: new Date(now.getTime() -  2 * 86_400_000), to: now }
+    case 'last_7d':  return { from: new Date(now.getTime() -  7 * 86_400_000), to: now }
+    case 'last_30d': return { from: new Date(now.getTime() - 30 * 86_400_000), to: now }
+    case 'last_90d': return { from: new Date(now.getTime() - 90 * 86_400_000), to: now }
+
+    case 'today': {
+      const from = new Date(now)
+      from.setHours(0, 0, 0, 0)
+      return { from, to: now }
+    }
+
+    case 'this_week': {
+      // Week starts on Monday (ISO 8601)
+      const from = new Date(now)
+      const daysFromMonday = (now.getDay() + 6) % 7
+      from.setDate(from.getDate() - daysFromMonday)
+      from.setHours(0, 0, 0, 0)
+      return { from, to: now }
+    }
+
+    case 'this_month': {
+      const from = new Date(now.getFullYear(), now.getMonth(), 1)
+      return { from, to: now }
+    }
+
+    case 'yesterday': {
+      const from = new Date(now)
+      from.setDate(from.getDate() - 1)
+      from.setHours(0, 0, 0, 0)
+      const to = new Date(from)
+      to.setHours(23, 59, 59, 999)
+      return { from, to }
+    }
+
+    case 'last_week': {
+      // Previous full Monday–Sunday week
+      const daysFromMonday = (now.getDay() + 6) % 7
+      const thisMonday = new Date(now)
+      thisMonday.setDate(thisMonday.getDate() - daysFromMonday)
+      thisMonday.setHours(0, 0, 0, 0)
+      const from = new Date(thisMonday)
+      from.setDate(from.getDate() - 7)
+      const to = new Date(thisMonday)
+      to.setDate(to.getDate() - 1)
+      to.setHours(23, 59, 59, 999)
+      return { from, to }
+    }
+
+    case 'last_month': {
+      const from = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+      const to   = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999)
+      return { from, to }
+    }
+
+    default:
+      return { from: new Date(now.getTime() - 24 * 3_600_000), to: now }
+  }
+}

--- a/frontend/src/widgets/ValueDisplay/Config.vue
+++ b/frontend/src/widgets/ValueDisplay/Config.vue
@@ -2,6 +2,7 @@
 import { reactive, watch } from 'vue'
 import IconPicker from '@/components/IconPicker.vue'
 import DataPointPicker from '@/components/DataPointPicker.vue'
+import { TIME_RANGE_PRESETS, DEFAULT_TIME_RANGE } from '@/widgets/Chart/timeRangePresets'
 
 type CondFn = 'eq' | 'lt' | 'lte' | 'gt' | 'gte'
 type DisplayMode = 'value' | 'history' | 'icon_only'
@@ -23,7 +24,7 @@ interface Cfg {
   label: string
   mode: DisplayMode
   rules: Rule[]
-  history_hours: number
+  history_time_range: string
   secondary_dp_id: string
   secondary_label: string
   secondary_decimals: number
@@ -95,11 +96,16 @@ function normalizeRules(raw: Partial<Rule>[] | undefined): Rule[] {
 
 // ── Reactive config ───────────────────────────────────────────────────────────
 
+function resolveHistoryTimeRange(raw: Record<string, unknown>): string {
+  if (raw.history_time_range && typeof raw.history_time_range === 'string') return raw.history_time_range as string
+  return DEFAULT_TIME_RANGE
+}
+
 const cfg = reactive<Cfg>({
   label:              (props.modelValue.label              as string)      ?? '',
   mode:               (props.modelValue.mode               as DisplayMode) ?? 'value',
   rules:              normalizeRules(props.modelValue.rules as Partial<Rule>[] | undefined),
-  history_hours:      (props.modelValue.history_hours      as number)      ?? 24,
+  history_time_range: resolveHistoryTimeRange(props.modelValue),
   secondary_dp_id:    (props.modelValue.secondary_dp_id    as string)      ?? '',
   secondary_label:    (props.modelValue.secondary_label    as string)      ?? '',
   secondary_decimals: (props.modelValue.secondary_decimals as number)      ?? 1,
@@ -107,13 +113,13 @@ const cfg = reactive<Cfg>({
 
 watch(cfg, () => {
   emit('update:modelValue', {
-    label:              cfg.label,
-    mode:               cfg.mode,
-    rules:              cfg.rules,
-    history_hours:      cfg.mode === 'history' ? cfg.history_hours : undefined,
-    secondary_dp_id:    cfg.mode === 'value' && cfg.secondary_dp_id ? cfg.secondary_dp_id : undefined,
-    secondary_label:    cfg.mode === 'value' && cfg.secondary_dp_id ? cfg.secondary_label : undefined,
-    secondary_decimals: cfg.mode === 'value' && cfg.secondary_dp_id ? cfg.secondary_decimals : undefined,
+    label:               cfg.label,
+    mode:                cfg.mode,
+    rules:               cfg.rules,
+    history_time_range:  cfg.mode === 'history' ? cfg.history_time_range : undefined,
+    secondary_dp_id:     cfg.mode === 'value' && cfg.secondary_dp_id ? cfg.secondary_dp_id : undefined,
+    secondary_label:     cfg.mode === 'value' && cfg.secondary_dp_id ? cfg.secondary_label : undefined,
+    secondary_decimals:  cfg.mode === 'value' && cfg.secondary_dp_id ? cfg.secondary_decimals : undefined,
   })
 }, { deep: true })
 
@@ -403,16 +409,15 @@ function dupRule(i: number) {
       </template>
     </div>
 
-    <!-- ── History hours (history mode only) ─────────────────────────────── -->
+    <!-- ── History time range (history mode only) ───────────────────────── -->
     <div v-if="cfg.mode === 'history'" class="border-t border-gray-700 pt-3">
-      <label class="block text-xs text-gray-400 mb-1">Zeitraum (Stunden)</label>
-      <input
-        v-model.number="cfg.history_hours"
-        type="number"
-        min="1"
-        max="720"
-        class="w-28 bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
-      />
+      <label class="block text-xs text-gray-400 mb-1">Standard-Zeitbereich</label>
+      <select
+        v-model="cfg.history_time_range"
+        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+      >
+        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+      </select>
     </div>
 
   </div>

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -6,6 +6,7 @@ import { useIcons } from '@/composables/useIcons'
 import { useDatapointsStore } from '@/stores/datapoints'
 import { useWebSocket } from '@/composables/useWebSocket'
 import type { DataPointValue } from '@/types'
+import { TIME_RANGE_PRESETS, DEFAULT_TIME_RANGE, resolveTimeRange } from '@/widgets/Chart/timeRangePresets'
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, Filler, Tooltip)
 
@@ -42,10 +43,20 @@ const { getSvg, isSvgIcon, svgIconName } = useIcons()
 const mode          = computed<DisplayMode>(() => (props.config.mode as DisplayMode | undefined) ?? 'value')
 const widgetLabel   = computed(() => (props.config.label as string | undefined) ?? '')
 const rules         = computed<Rule[]>(() => (props.config.rules as Rule[] | undefined) ?? [])
-const historyHours  = computed(() => (props.config.history_hours as number | undefined) ?? 24)
 const secondaryDpId = computed(() => (props.config.secondary_dp_id as string | undefined) ?? '')
 const secLabel      = computed(() => (props.config.secondary_label as string | undefined) ?? '')
 const secDecimals   = computed(() => (props.config.secondary_decimals as number | undefined) ?? 1)
+
+function configHistoryTimeRange(config: Record<string, unknown>): string {
+  if (config.history_time_range && typeof config.history_time_range === 'string') return config.history_time_range as string
+  return DEFAULT_TIME_RANGE
+}
+
+const selectedTimeRange = ref(configHistoryTimeRange(props.config))
+
+watch(() => props.config.history_time_range, () => {
+  selectedTimeRange.value = configHistoryTimeRange(props.config)
+})
 
 // ── Rule evaluation ────────────────────────────────────────────────────────────
 
@@ -201,14 +212,13 @@ function makeDataset(color: string) {
 
 async function fetchPoints() {
   if (!props.datapointId || props.editorMode) return { pts: [], minMs: 0, maxMs: 0 }
-  const now      = new Date()
-  const fromDate = new Date(now.getTime() - historyHours.value * 3_600_000)
-  const data     = await history.query(props.datapointId, fromDate.toISOString(), now.toISOString())
+  const { from: fromDate, to: toDate } = resolveTimeRange(selectedTimeRange.value)
+  const data = await history.query(props.datapointId, fromDate.toISOString(), toDate.toISOString())
   histUnit = data[0]?.u ?? ''
   return {
     pts:   data.map(d => ({ x: new Date(d.ts).getTime(), y: Number(d.v) })),
     minMs: fromDate.getTime(),
-    maxMs: now.getTime(),
+    maxMs: toDate.getTime(),
   }
 }
 
@@ -257,7 +267,8 @@ onMounted(() => {
   updateMiniChart()
 })
 
-watch(() => [props.datapointId, historyHours.value], updateMiniChart)
+watch(() => props.datapointId, updateMiniChart)
+watch(selectedTimeRange, updateMiniChart)
 
 watch(modalOpen, async (open) => {
   if (!open) { modalChart?.destroy(); modalChart = null; return }
@@ -344,7 +355,18 @@ const quality = computed(() => props.value?.q ?? null)
 
   <!-- ── HISTORY MODE ───────────────────────────────────────────────────────── -->
   <div v-else-if="mode === 'history'" class="flex flex-col items-center h-full p-2 select-none">
-    <span v-if="widgetLabel" class="text-xs text-gray-500 dark:text-gray-400 truncate w-full text-center shrink-0 mb-1">{{ widgetLabel }}</span>
+    <div class="flex items-center justify-between gap-1 w-full shrink-0 mb-1 min-w-0">
+      <span v-if="widgetLabel" class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ widgetLabel }}</span>
+      <span v-else class="shrink-0" />
+      <select
+        v-if="!editorMode"
+        v-model="selectedTimeRange"
+        class="shrink-0 text-xs bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
+        title="Zeitbereich wählen"
+      >
+        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+      </select>
+    </div>
 
     <!-- Icon: 3 flex shares, no circle -->
     <div class="min-h-0 flex items-center justify-center w-full" style="flex: 3; aspect-ratio: 1; max-width: 100%">
@@ -417,11 +439,11 @@ const quality = computed(() => props.value?.q ?? null)
       @click.self="modalOpen = false"
     >
       <div class="bg-white dark:bg-gray-900 rounded-xl shadow-2xl p-4 w-[90vw] max-w-2xl h-[60vh] flex flex-col">
-        <div class="flex items-center justify-between mb-3 shrink-0">
-          <div class="flex items-center gap-2">
+        <div class="flex items-center justify-between mb-3 shrink-0 gap-3">
+          <div class="flex items-center gap-2 min-w-0">
             <span
               v-if="activeIcon && !isSvgIcon(activeIcon)"
-              class="text-2xl leading-none select-none"
+              class="text-2xl leading-none select-none shrink-0"
               :style="{ color: activeColor }"
             >{{ activeIcon }}</span>
             <span
@@ -430,12 +452,21 @@ const quality = computed(() => props.value?.q ?? null)
               :style="{ color: activeColor }"
               v-html="coloredSvg"
             />
-            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ widgetLabel || 'Verlauf' }}</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200 truncate">{{ widgetLabel || 'Verlauf' }}</span>
           </div>
-          <button
-            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 text-xl leading-none"
-            @click="modalOpen = false"
-          >✕</button>
+          <div class="flex items-center gap-2 shrink-0">
+            <select
+              v-model="selectedTimeRange"
+              class="text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
+              title="Zeitbereich wählen"
+            >
+              <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+            </select>
+            <button
+              class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 text-xl leading-none"
+              @click="modalOpen = false"
+            >✕</button>
+          </div>
         </div>
         <div class="flex-1 min-h-0">
           <canvas ref="modalCanvasEl" class="w-full h-full" />

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -52,11 +52,8 @@ function configHistoryTimeRange(config: Record<string, unknown>): string {
   return DEFAULT_TIME_RANGE
 }
 
-const selectedTimeRange = ref(configHistoryTimeRange(props.config))
-
-watch(() => props.config.history_time_range, () => {
-  selectedTimeRange.value = configHistoryTimeRange(props.config)
-})
+// Zeitbereich nur für das Modal — wird beim Öffnen auf den Config-Wert zurückgesetzt
+const modalTimeRange = ref(configHistoryTimeRange(props.config))
 
 // ── Rule evaluation ────────────────────────────────────────────────────────────
 
@@ -210,9 +207,9 @@ function makeDataset(color: string) {
   }
 }
 
-async function fetchPoints() {
+async function fetchPoints(timeRange: string) {
   if (!props.datapointId || props.editorMode) return { pts: [], minMs: 0, maxMs: 0 }
-  const { from: fromDate, to: toDate } = resolveTimeRange(selectedTimeRange.value)
+  const { from: fromDate, to: toDate } = resolveTimeRange(timeRange)
   const data = await history.query(props.datapointId, fromDate.toISOString(), toDate.toISOString())
   histUnit = data[0]?.u ?? ''
   return {
@@ -222,21 +219,25 @@ async function fetchPoints() {
   }
 }
 
+// Mini-Chart: immer den konfigurierten Zeitbereich verwenden
 async function updateMiniChart() {
   if (mode.value !== 'history') return
-  const { pts, minMs, maxMs } = await fetchPoints()
-  if (miniChart) {
-    miniChart.data.datasets[0].data = pts
-    const xAxis = miniChart.options.scales?.x as any
-    if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
-    miniChart.update()
-  }
-  if (modalChart && modalOpen.value) {
-    modalChart.data.datasets[0].data = pts
-    const xAxis = modalChart.options.scales?.x as any
-    if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
-    modalChart.update()
-  }
+  const { pts, minMs, maxMs } = await fetchPoints(configHistoryTimeRange(props.config))
+  if (!miniChart) return
+  miniChart.data.datasets[0].data = pts
+  const xAxis = miniChart.options.scales?.x as any
+  if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
+  miniChart.update()
+}
+
+// Modal-Chart: den im Modal gewählten Zeitbereich verwenden
+async function updateModalChart() {
+  if (!modalChart || !modalOpen.value) return
+  const { pts, minMs, maxMs } = await fetchPoints(modalTimeRange.value)
+  modalChart.data.datasets[0].data = pts
+  const xAxis = modalChart.options.scales?.x as any
+  if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
+  modalChart.update()
 }
 
 onMounted(() => {
@@ -248,7 +249,11 @@ onMounted(() => {
     if (mode.value !== 'history' || props.editorMode) return
     if (!msg.id || msg.v === undefined || msg.id !== props.datapointId) return
     if (reloadTimer) clearTimeout(reloadTimer)
-    reloadTimer = setTimeout(() => { reloadTimer = null; updateMiniChart() }, 2_000)
+    reloadTimer = setTimeout(() => {
+      reloadTimer = null
+      updateMiniChart()
+      updateModalChart()
+    }, 2_000)
   })
 
   if (mode.value !== 'history' || !canvasEl.value) return
@@ -268,13 +273,16 @@ onMounted(() => {
 })
 
 watch(() => props.datapointId, updateMiniChart)
-watch(selectedTimeRange, updateMiniChart)
+watch(() => props.config.history_time_range, updateMiniChart)
+watch(modalTimeRange, updateModalChart)
 
 watch(modalOpen, async (open) => {
   if (!open) { modalChart?.destroy(); modalChart = null; return }
+  // Zeitbereich im Modal auf den aktuellen Config-Default zurücksetzen
+  modalTimeRange.value = configHistoryTimeRange(props.config)
   await new Promise<void>(r => setTimeout(r, 50))
   if (!modalCanvasEl.value) return
-  const { pts, minMs, maxMs } = await fetchPoints()
+  const { pts, minMs, maxMs } = await fetchPoints(modalTimeRange.value)
   modalChart = new Chart(modalCanvasEl.value, {
     type: 'line',
     data: { datasets: [{ ...makeDataset(activeColor.value), data: pts }] },
@@ -355,18 +363,7 @@ const quality = computed(() => props.value?.q ?? null)
 
   <!-- ── HISTORY MODE ───────────────────────────────────────────────────────── -->
   <div v-else-if="mode === 'history'" class="flex flex-col items-center h-full p-2 select-none">
-    <div class="flex items-center justify-between gap-1 w-full shrink-0 mb-1 min-w-0">
-      <span v-if="widgetLabel" class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ widgetLabel }}</span>
-      <span v-else class="shrink-0" />
-      <select
-        v-if="!editorMode"
-        v-model="selectedTimeRange"
-        class="shrink-0 text-xs bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
-        title="Zeitbereich wählen"
-      >
-        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
-      </select>
-    </div>
+    <span v-if="widgetLabel" class="text-xs text-gray-500 dark:text-gray-400 truncate w-full text-center shrink-0 mb-1">{{ widgetLabel }}</span>
 
     <!-- Icon: 3 flex shares, no circle -->
     <div class="min-h-0 flex items-center justify-center w-full" style="flex: 3; aspect-ratio: 1; max-width: 100%">
@@ -456,7 +453,7 @@ const quality = computed(() => props.value?.q ?? null)
           </div>
           <div class="flex items-center gap-2 shrink-0">
             <select
-              v-model="selectedTimeRange"
+              v-model="modalTimeRange"
               class="text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
               title="Zeitbereich wählen"
             >

--- a/tests/gui/visu/verlauf-zeitbereich.spec.ts
+++ b/tests/gui/visu/verlauf-zeitbereich.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'crypto'
+import { apiPost, apiPut, apiDelete } from '../helpers'
+
+/**
+ * E2E-Tests für das Verlaufs-Widget mit variablem Zeitbereich (Issue #413).
+ *
+ * Getestete Szenarien:
+ *   1. Standard-Zeitbereich aus Config wird im Dropdown angezeigt
+ *   2. Dropdown enthält alle 18 Zeitbereich-Optionen
+ *   3. Auswahl eines anderen Zeitbereichs aktualisiert das Chart (kein Absturz)
+ *   4. Rückwärtskompatibilität: Widget ohne time_range (nur hours) zeigt last_24h
+ */
+
+// ─── Hilfsfunktionen ─────────────────────────────────────────────────────────
+
+async function createFloatDP(suffix: string) {
+  return await apiPost('/api/v1/datapoints', {
+    name: `E2E-ChartZeit-${suffix}-${Date.now()}`,
+    data_type: 'FLOAT',
+    unit: '°C',
+    tags: [],
+  }) as { id: string }
+}
+
+async function createVisuPage() {
+  return await apiPost('/api/v1/visu/nodes', {
+    name: `E2E-ChartZeit-Page-${Date.now()}`,
+    type: 'PAGE',
+    order: 999,
+    access: 'public',
+  }) as { id: string }
+}
+
+async function pushValue(dpId: string, value: number) {
+  await apiPost(`/api/v1/datapoints/${dpId}/value`, { value })
+}
+
+async function buildChartPage(
+  pageId: string,
+  widgetId: string,
+  dpId: string,
+  config: Record<string, unknown>,
+) {
+  await apiPut(`/api/v1/visu/pages/${pageId}`, {
+    grid_cols: 12,
+    grid_row_height: 80,
+    grid_cell_width: 80,
+    background: null,
+    widgets: [
+      {
+        id: widgetId,
+        name: 'E2E Chart Zeitbereich',
+        type: 'Chart',
+        datapoint_id: dpId,
+        status_datapoint_id: null,
+        x: 0, y: 0, w: 8, h: 4,
+        config,
+      },
+    ],
+  })
+}
+
+// ─── Test 1: Konfigurierter Standard-Zeitbereich wird im Dropdown angezeigt ──
+
+test('Verlauf-Widget: Standard-Zeitbereich "Letzte 1 Stunde" aus Config wird angezeigt', async ({ page }) => {
+  const dp = await createFloatDP('default-tr')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 21.5)
+  await buildChartPage(pageId, widgetId, dp.id, {
+    label: 'Zeitbereich-Test',
+    time_range: 'last_1h',
+    primary_color: '#3b82f6',
+    primary_axis: 'left',
+    series: [],
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    // Dropdown muss sichtbar sein
+    const select = page.locator('select[title="Zeitbereich wählen"]')
+    await expect(select).toBeVisible()
+
+    // Ausgewählter Wert muss dem Config-Default entsprechen
+    await expect(select).toHaveValue('last_1h')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 2: Dropdown enthält alle 18 Zeitbereich-Optionen ───────────────────
+
+test('Verlauf-Widget: Dropdown enthält alle 18 Zeitbereich-Optionen', async ({ page }) => {
+  const dp = await createFloatDP('options')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 20.0)
+  await buildChartPage(pageId, widgetId, dp.id, {
+    label: 'Optionen-Test',
+    time_range: 'last_24h',
+    primary_color: '#3b82f6',
+    primary_axis: 'left',
+    series: [],
+  })
+
+  const expectedValues = [
+    'last_5m', 'last_15m', 'last_30m',
+    'last_1h', 'last_3h', 'last_6h', 'last_12h', 'last_24h',
+    'last_2d', 'last_7d', 'last_30d', 'last_90d',
+    'today', 'this_week', 'this_month',
+    'yesterday', 'last_week', 'last_month',
+  ]
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]')
+    await expect(select).toBeVisible()
+
+    const optionCount = await select.locator('option').count()
+    expect(optionCount).toBe(expectedValues.length)
+
+    for (const val of expectedValues) {
+      await expect(select.locator(`option[value="${val}"]`)).toBeAttached()
+    }
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 3: Auswahl eines anderen Zeitbereichs löst Neuladung aus ───────────
+
+test('Verlauf-Widget: Auswahl eines anderen Zeitbereichs aktualisiert Chart ohne Fehler', async ({ page }) => {
+  const dp = await createFloatDP('switch-tr')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 18.0)
+  await buildChartPage(pageId, widgetId, dp.id, {
+    label: 'Wechsel-Test',
+    time_range: 'last_24h',
+    primary_color: '#3b82f6',
+    primary_axis: 'left',
+    series: [],
+  })
+
+  const errors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()) })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+
+    const canvas = page.locator('canvas').first()
+    await expect(canvas).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]')
+    await expect(select).toBeVisible()
+
+    // Zeitbereich auf "Letzte 7 Tage" wechseln
+    await select.selectOption('last_7d')
+    await expect(select).toHaveValue('last_7d')
+
+    // Kurz warten, damit die Neuladung stattfindet
+    await page.waitForTimeout(1000)
+
+    // Canvas muss noch sichtbar und fehlerfrei sein
+    await expect(canvas).toBeVisible()
+    const chartErrors = errors.filter(e =>
+      e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),
+    )
+    expect(chartErrors).toHaveLength(0)
+
+    // Nochmals wechseln — auf "Heute bis jetzt"
+    await select.selectOption('today')
+    await expect(select).toHaveValue('today')
+    await page.waitForTimeout(500)
+    await expect(canvas).toBeVisible()
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 4: Rückwärtskompatibilität — alte Config ohne time_range ───────────
+
+test('Verlauf-Widget: alte Config ohne time_range fällt auf last_24h zurück', async ({ page }) => {
+  const dp = await createFloatDP('compat')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 25.0)
+
+  // Alte Config-Struktur mit "hours" statt "time_range"
+  await buildChartPage(pageId, widgetId, dp.id, {
+    label: 'Compat-Test',
+    hours: 24,
+    primary_color: '#3b82f6',
+    primary_axis: 'left',
+    series: [],
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]')
+    await expect(select).toBeVisible()
+
+    // Fallback auf last_24h
+    await expect(select).toHaveValue('last_24h')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})

--- a/tests/gui/visu/wertanzeige-zeitbereich.spec.ts
+++ b/tests/gui/visu/wertanzeige-zeitbereich.spec.ts
@@ -1,0 +1,319 @@
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'crypto'
+import { apiPost, apiPut, apiDelete } from '../helpers'
+
+/**
+ * E2E-Tests für die Verlaufsansicht des Wertanzeige-Widgets mit variablem
+ * Zeitbereich (analog Issue #413, Verlauf-Widget).
+ *
+ * Getestete Szenarien:
+ *   1. Standard-Zeitbereich aus Config wird im Widget-Dropdown angezeigt
+ *   2. Dropdown enthält alle 18 Zeitbereich-Optionen
+ *   3. Auswahl eines anderen Zeitbereichs aktualisiert das Chart ohne Fehler
+ *   4. Zeitbereich-Dropdown ist auch im Modal vorhanden und funktioniert
+ *   5. Rückwärtskompatibilität: Widget ohne history_time_range zeigt last_24h
+ *   6. Automatische Aktualisierung via WebSocket: neuer Wert aktualisiert den Chart
+ */
+
+// ─── Hilfsfunktionen ─────────────────────────────────────────────────────────
+
+async function createFloatDP(suffix: string) {
+  return await apiPost('/api/v1/datapoints', {
+    name: `E2E-ValDisp-${suffix}-${Date.now()}`,
+    data_type: 'FLOAT',
+    unit: '°C',
+    record_history: true,
+    tags: [],
+  }) as { id: string }
+}
+
+async function createVisuPage() {
+  return await apiPost('/api/v1/visu/nodes', {
+    name: `E2E-ValDisp-Page-${Date.now()}`,
+    type: 'PAGE',
+    order: 999,
+    access: 'public',
+  }) as { id: string }
+}
+
+async function pushValue(dpId: string, value: number) {
+  await apiPost(`/api/v1/datapoints/${dpId}/value`, { value })
+}
+
+async function buildValueDisplayPage(
+  pageId: string,
+  widgetId: string,
+  dpId: string,
+  config: Record<string, unknown>,
+) {
+  await apiPut(`/api/v1/visu/pages/${pageId}`, {
+    grid_cols: 12,
+    grid_row_height: 80,
+    grid_cell_width: 80,
+    background: null,
+    widgets: [
+      {
+        id: widgetId,
+        name: 'E2E ValueDisplay Zeitbereich',
+        type: 'ValueDisplay',
+        datapoint_id: dpId,
+        status_datapoint_id: null,
+        x: 0, y: 0, w: 4, h: 3,
+        config,
+      },
+    ],
+  })
+}
+
+const DEFAULT_RULES = [
+  { fn: 'default', threshold: '', icon: '🌡️', color: '#3b82f6', output_type: 'value', calculation: '', prefix: '', text: '', decimals: 1, postfix: '' },
+]
+
+// ─── Test 1: Standard-Zeitbereich aus Config wird im Dropdown angezeigt ──────
+
+test('Wertanzeige-Verlauf: Standard-Zeitbereich "Letzte 3 Stunden" wird angezeigt', async ({ page }) => {
+  const dp = await createFloatDP('default-tr')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 22.0)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'Zeitbereich-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_time_range: 'last_3h',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]').first()
+    await expect(select).toBeVisible()
+    await expect(select).toHaveValue('last_3h')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 2: Dropdown enthält alle 18 Optionen ───────────────────────────────
+
+test('Wertanzeige-Verlauf: Dropdown enthält alle 18 Zeitbereich-Optionen', async ({ page }) => {
+  const dp = await createFloatDP('options')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 20.0)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'Optionen-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_time_range: 'last_24h',
+  })
+
+  const expectedValues = [
+    'last_5m', 'last_15m', 'last_30m',
+    'last_1h', 'last_3h', 'last_6h', 'last_12h', 'last_24h',
+    'last_2d', 'last_7d', 'last_30d', 'last_90d',
+    'today', 'this_week', 'this_month',
+    'yesterday', 'last_week', 'last_month',
+  ]
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]').first()
+    await expect(select).toBeVisible()
+
+    const optionCount = await select.locator('option').count()
+    expect(optionCount).toBe(expectedValues.length)
+
+    for (const val of expectedValues) {
+      await expect(select.locator(`option[value="${val}"]`)).toBeAttached()
+    }
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 3: Auswahl eines anderen Zeitbereichs löst Neuladung aus ───────────
+
+test('Wertanzeige-Verlauf: Auswahl eines anderen Zeitbereichs aktualisiert Chart', async ({ page }) => {
+  const dp = await createFloatDP('switch-tr')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 18.5)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'Wechsel-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_time_range: 'last_24h',
+  })
+
+  const errors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()) })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]').first()
+    await expect(select).toBeVisible()
+
+    // Auf "Letzte 7 Tage" wechseln
+    await select.selectOption('last_7d')
+    await expect(select).toHaveValue('last_7d')
+    await page.waitForTimeout(1000)
+    await expect(page.locator('canvas').first()).toBeVisible()
+
+    // Auf "Heute bis jetzt" wechseln
+    await select.selectOption('today')
+    await expect(select).toHaveValue('today')
+    await page.waitForTimeout(500)
+    await expect(page.locator('canvas').first()).toBeVisible()
+
+    const chartErrors = errors.filter(e =>
+      e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),
+    )
+    expect(chartErrors).toHaveLength(0)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 4: Zeitbereich-Dropdown im Modal vorhanden und funktionsfähig ──────
+
+test('Wertanzeige-Verlauf: Modal zeigt Zeitbereich-Dropdown und Wechsel funktioniert', async ({ page }) => {
+  const dp = await createFloatDP('modal-tr')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 19.0)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'Modal-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_time_range: 'last_1h',
+  })
+
+  const errors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()) })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    // Modal öffnen durch Klick auf den Mini-Chart
+    await page.locator('canvas').first().click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
+
+    // Modal-Canvas muss sichtbar sein
+    await expect(page.locator('[class*="fixed inset-0"] canvas')).toBeVisible()
+
+    // Dropdown im Modal muss vorhanden sein und den richtigen Wert zeigen
+    const modalSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
+    await expect(modalSelect).toBeVisible()
+    await expect(modalSelect).toHaveValue('last_1h')
+
+    // Zeitbereich im Modal wechseln
+    await modalSelect.selectOption('last_7d')
+    await expect(modalSelect).toHaveValue('last_7d')
+    await page.waitForTimeout(1000)
+
+    // Widget-Dropdown muss ebenfalls aktualisiert sein (gleicher State)
+    const widgetSelect = page.locator('select[title="Zeitbereich wählen"]').first()
+    await expect(widgetSelect).toHaveValue('last_7d')
+
+    // Modal schliessen
+    await page.keyboard.press('Escape')
+    await page.locator('button:has-text("✕")').click()
+
+    const chartErrors = errors.filter(e =>
+      e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),
+    )
+    expect(chartErrors).toHaveLength(0)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 5: Rückwärtskompatibilität — alte Config ohne history_time_range ───
+
+test('Wertanzeige-Verlauf: alte Config ohne history_time_range fällt auf last_24h zurück', async ({ page }) => {
+  const dp = await createFloatDP('compat')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 25.0)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'Compat-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_hours: 24, // alte Config-Struktur
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    const select = page.locator('select[title="Zeitbereich wählen"]').first()
+    await expect(select).toBeVisible()
+    await expect(select).toHaveValue('last_24h')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 6: Automatische Aktualisierung via WebSocket ───────────────────────
+
+test('Wertanzeige-Verlauf: Canvas bleibt nach WS-Aktualisierung sichtbar und fehlerfrei', async ({ page }) => {
+  const dp = await createFloatDP('ws-refresh')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 20.0)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'WS-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_time_range: 'last_1h',
+  })
+
+  const errors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()) })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    const canvas = page.locator('canvas').first()
+    await expect(canvas).toBeVisible({ timeout: 8000 })
+
+    // Neuen Wert via API senden (simuliert WS-Update)
+    await pushValue(dp.id, 21.5)
+
+    // Kurz warten — Widget wartet 2 s nach WS-Nachricht bevor es neu lädt
+    await page.waitForTimeout(3500)
+
+    // Canvas muss noch sichtbar und fehlerfrei sein
+    await expect(canvas).toBeVisible()
+    const chartErrors = errors.filter(e =>
+      e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),
+    )
+    expect(chartErrors).toHaveLength(0)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})

--- a/tests/gui/visu/wertanzeige-zeitbereich.spec.ts
+++ b/tests/gui/visu/wertanzeige-zeitbereich.spec.ts
@@ -6,13 +6,18 @@ import { apiPost, apiPut, apiDelete } from '../helpers'
  * E2E-Tests für die Verlaufsansicht des Wertanzeige-Widgets mit variablem
  * Zeitbereich (analog Issue #413, Verlauf-Widget).
  *
+ * Verhalten:
+ *   - Kleinformat-Widget: kein Zeitbereich-Dropdown, immer der Config-Wert
+ *   - Modal: Zeitbereich-Dropdown mit allen 18 Optionen
+ *
  * Getestete Szenarien:
- *   1. Standard-Zeitbereich aus Config wird im Widget-Dropdown angezeigt
- *   2. Dropdown enthält alle 18 Zeitbereich-Optionen
- *   3. Auswahl eines anderen Zeitbereichs aktualisiert das Chart ohne Fehler
- *   4. Zeitbereich-Dropdown ist auch im Modal vorhanden und funktioniert
- *   5. Rückwärtskompatibilität: Widget ohne history_time_range zeigt last_24h
- *   6. Automatische Aktualisierung via WebSocket: neuer Wert aktualisiert den Chart
+ *   1. Kleinformat zeigt keinen Zeitbereich-Dropdown
+ *   2. Modal: Dropdown vorhanden und zeigt den konfigurierten Standard
+ *   3. Modal: Dropdown enthält alle 18 Optionen
+ *   4. Modal: Zeitbereichswechsel aktualisiert Chart ohne Fehler
+ *   5. Modal: wird beim erneuten Öffnen auf Config-Default zurückgesetzt
+ *   6. Rückwärtskompatibilität: Widget ohne history_time_range zeigt last_24h im Modal
+ *   7. Automatische Aktualisierung via WebSocket
  */
 
 // ─── Hilfsfunktionen ─────────────────────────────────────────────────────────
@@ -69,17 +74,17 @@ const DEFAULT_RULES = [
   { fn: 'default', threshold: '', icon: '🌡️', color: '#3b82f6', output_type: 'value', calculation: '', prefix: '', text: '', decimals: 1, postfix: '' },
 ]
 
-// ─── Test 1: Standard-Zeitbereich aus Config wird im Dropdown angezeigt ──────
+// ─── Test 1: Kleinformat zeigt keinen Zeitbereich-Dropdown ───────────────────
 
-test('Wertanzeige-Verlauf: Standard-Zeitbereich "Letzte 3 Stunden" wird angezeigt', async ({ page }) => {
-  const dp = await createFloatDP('default-tr')
+test('Wertanzeige-Verlauf: Kleinformat zeigt kein Zeitbereich-Dropdown', async ({ page }) => {
+  const dp = await createFloatDP('no-dropdown')
   const visuNode = await createVisuPage()
   const pageId = visuNode.id
   const widgetId = randomUUID()
 
   await pushValue(dp.id, 22.0)
   await buildValueDisplayPage(pageId, widgetId, dp.id, {
-    label: 'Zeitbereich-Test',
+    label: 'Kein-Dropdown-Test',
     mode: 'history',
     rules: DEFAULT_RULES,
     history_time_range: 'last_3h',
@@ -89,19 +94,51 @@ test('Wertanzeige-Verlauf: Standard-Zeitbereich "Letzte 3 Stunden" wird angezeig
     await page.goto(`/visu/${pageId}`)
     await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
 
-    const select = page.locator('select[title="Zeitbereich wählen"]').first()
-    await expect(select).toBeVisible()
-    await expect(select).toHaveValue('last_3h')
+    // Im Kleinformat darf kein Dropdown sichtbar sein
+    await expect(page.locator('select[title="Zeitbereich wählen"]')).toHaveCount(0)
   } finally {
     await apiDelete(`/api/v1/visu/nodes/${pageId}`)
     await apiDelete(`/api/v1/datapoints/${dp.id}`)
   }
 })
 
-// ─── Test 2: Dropdown enthält alle 18 Optionen ───────────────────────────────
+// ─── Test 2: Modal zeigt Dropdown mit Config-Default ─────────────────────────
 
-test('Wertanzeige-Verlauf: Dropdown enthält alle 18 Zeitbereich-Optionen', async ({ page }) => {
-  const dp = await createFloatDP('options')
+test('Wertanzeige-Verlauf: Modal zeigt Dropdown mit konfiguriertem Standard', async ({ page }) => {
+  const dp = await createFloatDP('modal-default')
+  const visuNode = await createVisuPage()
+  const pageId = visuNode.id
+  const widgetId = randomUUID()
+
+  await pushValue(dp.id, 20.0)
+  await buildValueDisplayPage(pageId, widgetId, dp.id, {
+    label: 'Modal-Default-Test',
+    mode: 'history',
+    rules: DEFAULT_RULES,
+    history_time_range: 'last_3h',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
+
+    // Modal öffnen
+    await page.locator('canvas').first().click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
+
+    const modalSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
+    await expect(modalSelect).toBeVisible()
+    await expect(modalSelect).toHaveValue('last_3h')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+    await apiDelete(`/api/v1/datapoints/${dp.id}`)
+  }
+})
+
+// ─── Test 3: Modal-Dropdown enthält alle 18 Optionen ─────────────────────────
+
+test('Wertanzeige-Verlauf: Modal-Dropdown enthält alle 18 Zeitbereich-Optionen', async ({ page }) => {
+  const dp = await createFloatDP('modal-options')
   const visuNode = await createVisuPage()
   const pageId = visuNode.id
   const widgetId = randomUUID()
@@ -126,14 +163,17 @@ test('Wertanzeige-Verlauf: Dropdown enthält alle 18 Zeitbereich-Optionen', asyn
     await page.goto(`/visu/${pageId}`)
     await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
 
-    const select = page.locator('select[title="Zeitbereich wählen"]').first()
-    await expect(select).toBeVisible()
+    await page.locator('canvas').first().click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
 
-    const optionCount = await select.locator('option').count()
+    const modalSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
+    await expect(modalSelect).toBeVisible()
+
+    const optionCount = await modalSelect.locator('option').count()
     expect(optionCount).toBe(expectedValues.length)
 
     for (const val of expectedValues) {
-      await expect(select.locator(`option[value="${val}"]`)).toBeAttached()
+      await expect(modalSelect.locator(`option[value="${val}"]`)).toBeAttached()
     }
   } finally {
     await apiDelete(`/api/v1/visu/nodes/${pageId}`)
@@ -141,10 +181,10 @@ test('Wertanzeige-Verlauf: Dropdown enthält alle 18 Zeitbereich-Optionen', asyn
   }
 })
 
-// ─── Test 3: Auswahl eines anderen Zeitbereichs löst Neuladung aus ───────────
+// ─── Test 4: Zeitbereichswechsel im Modal aktualisiert Chart ─────────────────
 
-test('Wertanzeige-Verlauf: Auswahl eines anderen Zeitbereichs aktualisiert Chart', async ({ page }) => {
-  const dp = await createFloatDP('switch-tr')
+test('Wertanzeige-Verlauf: Zeitbereichswechsel im Modal aktualisiert Chart ohne Fehler', async ({ page }) => {
+  const dp = await createFloatDP('modal-switch')
   const visuNode = await createVisuPage()
   const pageId = visuNode.id
   const widgetId = randomUUID()
@@ -164,20 +204,22 @@ test('Wertanzeige-Verlauf: Auswahl eines anderen Zeitbereichs aktualisiert Chart
     await page.goto(`/visu/${pageId}`)
     await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
 
-    const select = page.locator('select[title="Zeitbereich wählen"]').first()
-    await expect(select).toBeVisible()
+    await page.locator('canvas').first().click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
+
+    const modalSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
+    await expect(modalSelect).toBeVisible()
 
     // Auf "Letzte 7 Tage" wechseln
-    await select.selectOption('last_7d')
-    await expect(select).toHaveValue('last_7d')
+    await modalSelect.selectOption('last_7d')
+    await expect(modalSelect).toHaveValue('last_7d')
     await page.waitForTimeout(1000)
-    await expect(page.locator('canvas').first()).toBeVisible()
+    await expect(page.locator('[class*="fixed inset-0"] canvas')).toBeVisible()
 
     // Auf "Heute bis jetzt" wechseln
-    await select.selectOption('today')
-    await expect(select).toHaveValue('today')
+    await modalSelect.selectOption('today')
+    await expect(modalSelect).toHaveValue('today')
     await page.waitForTimeout(500)
-    await expect(page.locator('canvas').first()).toBeVisible()
 
     const chartErrors = errors.filter(e =>
       e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),
@@ -189,67 +231,51 @@ test('Wertanzeige-Verlauf: Auswahl eines anderen Zeitbereichs aktualisiert Chart
   }
 })
 
-// ─── Test 4: Zeitbereich-Dropdown im Modal vorhanden und funktionsfähig ──────
+// ─── Test 5: Modal-Zeitbereich wird beim Öffnen auf Config-Default zurückgesetzt
 
-test('Wertanzeige-Verlauf: Modal zeigt Zeitbereich-Dropdown und Wechsel funktioniert', async ({ page }) => {
-  const dp = await createFloatDP('modal-tr')
+test('Wertanzeige-Verlauf: Modal-Dropdown wird beim erneuten Öffnen auf Config-Default zurückgesetzt', async ({ page }) => {
+  const dp = await createFloatDP('modal-reset')
   const visuNode = await createVisuPage()
   const pageId = visuNode.id
   const widgetId = randomUUID()
 
   await pushValue(dp.id, 19.0)
   await buildValueDisplayPage(pageId, widgetId, dp.id, {
-    label: 'Modal-Test',
+    label: 'Reset-Test',
     mode: 'history',
     rules: DEFAULT_RULES,
     history_time_range: 'last_1h',
   })
 
-  const errors: string[] = []
-  page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()) })
-
   try {
     await page.goto(`/visu/${pageId}`)
     await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
 
-    // Modal öffnen durch Klick auf den Mini-Chart
+    // Modal öffnen und Zeitbereich wechseln
     await page.locator('canvas').first().click()
     await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
-
-    // Modal-Canvas muss sichtbar sein
-    await expect(page.locator('[class*="fixed inset-0"] canvas')).toBeVisible()
-
-    // Dropdown im Modal muss vorhanden sein und den richtigen Wert zeigen
     const modalSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
-    await expect(modalSelect).toBeVisible()
-    await expect(modalSelect).toHaveValue('last_1h')
-
-    // Zeitbereich im Modal wechseln
     await modalSelect.selectOption('last_7d')
     await expect(modalSelect).toHaveValue('last_7d')
-    await page.waitForTimeout(1000)
-
-    // Widget-Dropdown muss ebenfalls aktualisiert sein (gleicher State)
-    const widgetSelect = page.locator('select[title="Zeitbereich wählen"]').first()
-    await expect(widgetSelect).toHaveValue('last_7d')
 
     // Modal schliessen
-    await page.keyboard.press('Escape')
     await page.locator('button:has-text("✕")').click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toHaveCount(0)
 
-    const chartErrors = errors.filter(e =>
-      e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),
-    )
-    expect(chartErrors).toHaveLength(0)
+    // Modal erneut öffnen — soll wieder auf Config-Default zeigen
+    await page.locator('canvas').first().click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
+    const resetSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
+    await expect(resetSelect).toHaveValue('last_1h')
   } finally {
     await apiDelete(`/api/v1/visu/nodes/${pageId}`)
     await apiDelete(`/api/v1/datapoints/${dp.id}`)
   }
 })
 
-// ─── Test 5: Rückwärtskompatibilität — alte Config ohne history_time_range ───
+// ─── Test 6: Rückwärtskompatibilität — alte Config ohne history_time_range ───
 
-test('Wertanzeige-Verlauf: alte Config ohne history_time_range fällt auf last_24h zurück', async ({ page }) => {
+test('Wertanzeige-Verlauf: alte Config ohne history_time_range zeigt last_24h im Modal', async ({ page }) => {
   const dp = await createFloatDP('compat')
   const visuNode = await createVisuPage()
   const pageId = visuNode.id
@@ -267,16 +293,19 @@ test('Wertanzeige-Verlauf: alte Config ohne history_time_range fällt auf last_2
     await page.goto(`/visu/${pageId}`)
     await expect(page.locator('canvas').first()).toBeVisible({ timeout: 8000 })
 
-    const select = page.locator('select[title="Zeitbereich wählen"]').first()
-    await expect(select).toBeVisible()
-    await expect(select).toHaveValue('last_24h')
+    await page.locator('canvas').first().click()
+    await expect(page.locator('[class*="fixed inset-0"]')).toBeVisible({ timeout: 3000 })
+
+    const modalSelect = page.locator('[class*="fixed inset-0"] select[title="Zeitbereich wählen"]')
+    await expect(modalSelect).toBeVisible()
+    await expect(modalSelect).toHaveValue('last_24h')
   } finally {
     await apiDelete(`/api/v1/visu/nodes/${pageId}`)
     await apiDelete(`/api/v1/datapoints/${dp.id}`)
   }
 })
 
-// ─── Test 6: Automatische Aktualisierung via WebSocket ───────────────────────
+// ─── Test 7: Automatische Aktualisierung via WebSocket ───────────────────────
 
 test('Wertanzeige-Verlauf: Canvas bleibt nach WS-Aktualisierung sichtbar und fehlerfrei', async ({ page }) => {
   const dp = await createFloatDP('ws-refresh')
@@ -303,10 +332,9 @@ test('Wertanzeige-Verlauf: Canvas bleibt nach WS-Aktualisierung sichtbar und feh
     // Neuen Wert via API senden (simuliert WS-Update)
     await pushValue(dp.id, 21.5)
 
-    // Kurz warten — Widget wartet 2 s nach WS-Nachricht bevor es neu lädt
+    // Widget wartet 2 s nach WS-Nachricht bevor es neu lädt
     await page.waitForTimeout(3500)
 
-    // Canvas muss noch sichtbar und fehlerfrei sein
     await expect(canvas).toBeVisible()
     const chartErrors = errors.filter(e =>
       e.toLowerCase().includes('chart') || e.toLowerCase().includes('cannot'),


### PR DESCRIPTION
## Summary

Schliesst Issue #413.

Beide Verlaufs-Widgets erhalten 18 vordefinierte Zeitbereiche (z.B. «Letzte 1 Stunde», «Letzte 7 Tage», «Gestern», «Letzter Monat») statt des bisherigen Zahlenfeldes «Zeitraum (Stunden)».

## Was hat sich geändert?

### Neues Modul: `frontend/src/widgets/Chart/timeRangePresets.ts`
- 18 Zeitbereich-Presets mit deutschen Labels
- `resolveTimeRange(preset)` berechnet `{ from, to }` korrekt (ISO-Woche ab Montag, Kalendermonat, etc.)
- Wird von beiden Widgets geteilt

### Verlauf-Widget (`Chart`)
- **Config**: «Zeitraum (Stunden)»-Eingabe durch «Standard-Zeitbereich»-Dropdown ersetzt
- **Widget**: Zeitbereich-Dropdown direkt neben dem Titel im Live-Modus sichtbar
- Auswahl aus dem Widget überschreibt den Config-Default nur für die aktuelle Session
- Rückwärtskompatibilität: alte Configs ohne `time_range` fallen auf `last_24h` zurück

### Wertanzeige-Widget (`ValueDisplay`) — Verlaufsmodus
- **Config**: gleicher Dropdown wie im Verlauf-Widget als Standard-Zeitbereich
- **Kleinformat-Widget**: kein Dropdown, zeigt immer den konfigurierten Wert
- **Modal (Vollansicht)**: Zeitbereich-Dropdown in der Kopfzeile; wird beim Öffnen auf den Config-Default zurückgesetzt; Änderungen gelten nur für die aktuelle Modal-Session
- Auto-Refresh via WebSocket aktualisiert Mini-Chart und Modal-Chart unabhängig voneinander
- Rückwärtskompatibilität: alte Configs mit `history_hours` fallen auf `last_24h` zurück

## Tests

- `tests/gui/visu/verlauf-zeitbereich.spec.ts` — 4 Playwright-Tests für das Verlauf-Widget
- `tests/gui/visu/wertanzeige-zeitbereich.spec.ts` — 7 Playwright-Tests für die Wertanzeige-Verlaufsansicht (inkl. Modal-Reset, WS-Auto-Refresh, Rückwärtskompatibilität)

## Reviewer-Hinweise

- `defaultConfig` in `Chart/index.ts`: `hours: 24` → `time_range: 'last_24h'`
- Das `time_range`-Feld im Verlauf-Widget und `history_time_range` im Wertanzeige-Widget werden nur dann in der Config gespeichert, wenn der Modus aktiv ist (kein Datenmüll bei anderen Modi)
