### PR TITLE
feat(logic): Logikblatt-Begriff + Aktivieren/Deaktivieren (#422)

### DIFF
--- a/gui/src/stores/logic.js
+++ b/gui/src/stores/logic.js
@@ -71,5 +71,14 @@ export const useLogicStore = defineStore('logic', () => {
     return data
   }
 
-  return { graphs, nodeTypes, loading, fetchNodeTypes, fetchGraphs, createGraph, saveGraph, deleteGraph, runGraph, renameGraph, duplicateGraph, importGraph }
+  async function toggleEnabled(id) {
+    const g = graphs.value.find(g => g.id === id)
+    if (!g) return
+    const { data } = await logicApi.patchGraph(id, { enabled: !g.enabled })
+    const idx = graphs.value.findIndex(g => g.id === id)
+    if (idx !== -1) graphs.value[idx] = data
+    return data
+  }
+
+  return { graphs, nodeTypes, loading, fetchNodeTypes, fetchGraphs, createGraph, saveGraph, deleteGraph, runGraph, renameGraph, duplicateGraph, importGraph, toggleEnabled }
 })

--- a/gui/src/views/LogicView.vue
+++ b/gui/src/views/LogicView.vue
@@ -15,7 +15,11 @@
         <Spinner v-if="saving" size="sm" color="white" />
         Speichern
       </button>
-      <button v-if="activeGraphId" @click="runGraph" class="btn-secondary btn-sm text-green-400" data-testid="btn-run">
+      <button v-if="activeGraphId" @click="runGraph"
+        :class="['btn-secondary btn-sm', activeGraph?.enabled ? 'text-green-400' : 'text-slate-500 opacity-50 cursor-not-allowed']"
+        :disabled="!activeGraph?.enabled"
+        :title="activeGraph?.enabled ? 'Logikblatt ausführen' : 'Logikblatt ist deaktiviert — kein Ausführen möglich'"
+        data-testid="btn-run">
         &#9654; Ausführen
       </button>
       <button v-if="activeGraphId" @click="toggleDebug"
@@ -68,7 +72,7 @@
           v-model:nodes="nodes"
           v-model:edges="edges"
           :node-types="nodeTypeComponents"
-          :default-edge-options="{ type: 'smoothstep', animated: true, interactionWidth: 20, style: { stroke: '#475569', strokeWidth: 2 } }"
+          :default-edge-options="defaultEdgeOptions"
           :delete-key-code="['Backspace', 'Delete']"
           fit-view-on-init
           class="logic-canvas"
@@ -226,6 +230,35 @@ const nodeTypeComponents = {
 // ── Active graph ───────────────────────────────────────────────────────────
 const activeGraphId = ref('')
 const activeGraph   = computed(() => store.graphs.find(g => g.id === activeGraphId.value))
+
+// ── Edge options — animated only when graph is enabled ─────────────────────
+const defaultEdgeOptions = computed(() => {
+  const enabled = activeGraph.value?.enabled !== false
+  return {
+    type: 'smoothstep',
+    animated: enabled,
+    interactionWidth: 20,
+    style: {
+      stroke: enabled ? '#475569' : '#64748b',
+      strokeDasharray: enabled ? undefined : '8 5',
+      strokeWidth: 2,
+    },
+  }
+})
+
+// Update existing edges reactively when enabled state changes
+watch(() => activeGraph.value?.enabled, (enabled) => {
+  const isEnabled = enabled !== false
+  edges.value = edges.value.map(e => ({
+    ...e,
+    animated: isEnabled,
+    style: {
+      stroke: isEnabled ? '#475569' : '#64748b',
+      strokeDasharray: isEnabled ? undefined : '8 5',
+      strokeWidth: 2,
+    },
+  }))
+})
 const saving        = ref(false)
 const statusMsg     = ref(null)
 const canvasWrapper = ref(null)
@@ -467,11 +500,12 @@ async function onImportFile(event) {
 
 // ── Connect handler — REQUIRED to actually create edges ────────────────────
 function onConnect(params) {
+  const opts = defaultEdgeOptions.value
   edges.value = addEdge({
     ...params,
-    type: 'smoothstep',
-    animated: true,
-    style: { stroke: '#475569', strokeWidth: 2 },
+    type: opts.type,
+    animated: opts.animated,
+    style: opts.style,
   }, edges.value)
 }
 

--- a/gui/src/views/LogicView.vue
+++ b/gui/src/views/LogicView.vue
@@ -4,11 +4,11 @@
     <div class="flex items-center gap-3 px-4 py-2 bg-surface-800 border-b border-slate-200 dark:border-slate-700/60 flex-shrink-0">
       <h2 class="text-sm font-bold text-slate-800 dark:text-slate-100">Logikmodul</h2>
       <div class="flex-1" />
-      <!-- Graph selector -->
+      <!-- Logikblatt selector -->
       <select v-model="activeGraphId" @change="loadGraph"
         class="input text-xs py-1 px-2 max-w-[200px]" data-testid="select-graph">
-        <option value="">— Graph wählen —</option>
-        <option v-for="g in store.graphs" :key="g.id" :value="g.id">{{ g.name }}</option>
+        <option value="">— Logikblatt wählen —</option>
+        <option v-for="g in store.graphs" :key="g.id" :value="g.id">{{ g.name }}{{ g.enabled ? '' : ' (deaktiviert)' }}</option>
       </select>
       <button @click="newGraph" class="btn-primary btn-sm">+ Neu</button>
       <button v-if="activeGraphId" @click="saveGraph" class="btn-secondary btn-sm" :disabled="saving">
@@ -23,16 +23,22 @@
         title="Debug-Modus: zeigt Werte nach Ausführen" data-testid="btn-debug">
         &#128270; Debug
       </button>
-      <button v-if="activeGraphId" @click="openRenameGraph" class="btn-secondary btn-sm" title="Graph umbenennen" data-testid="btn-rename">
+      <button v-if="activeGraphId" @click="doToggleEnabled"
+        :class="['btn-secondary btn-sm', activeGraph?.enabled ? 'text-green-400' : 'text-orange-400 ring-1 ring-orange-400/50']"
+        :title="activeGraph?.enabled ? 'Logikblatt deaktivieren' : 'Logikblatt aktivieren'"
+        data-testid="btn-toggle-enabled">
+        {{ activeGraph?.enabled ? '✓ Aktiv' : '⊘ Deaktiviert' }}
+      </button>
+      <button v-if="activeGraphId" @click="openRenameGraph" class="btn-secondary btn-sm" title="Logikblatt umbenennen" data-testid="btn-rename">
         ✏ Umbenennen
       </button>
-      <button v-if="activeGraphId" @click="doDuplicateGraph" class="btn-secondary btn-sm" title="Graph duplizieren" data-testid="btn-duplicate">
+      <button v-if="activeGraphId" @click="doDuplicateGraph" class="btn-secondary btn-sm" title="Logikblatt duplizieren" data-testid="btn-duplicate">
         ⧉ Duplizieren
       </button>
-      <button v-if="activeGraphId" @click="doExportGraph" class="btn-secondary btn-sm" title="Graph als JSON exportieren" data-testid="btn-export">
+      <button v-if="activeGraphId" @click="doExportGraph" class="btn-secondary btn-sm" title="Logikblatt als JSON exportieren" data-testid="btn-export">
         ↓ Exportieren
       </button>
-      <label class="btn-secondary btn-sm cursor-pointer" title="Graph aus JSON importieren" data-testid="btn-import">
+      <label class="btn-secondary btn-sm cursor-pointer" title="Logikblatt aus JSON importieren" data-testid="btn-import">
         ↑ Importieren
         <input type="file" accept=".json" class="hidden" @change="onImportFile" data-testid="input-import-file" />
       </label>
@@ -78,7 +84,7 @@
           <svg class="w-16 h-16 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M13 10V3L4 14h7v7l9-11h-7z"/>
           </svg>
-          <p class="text-sm">Graph wählen oder neu erstellen</p>
+          <p class="text-sm">Logikblatt wählen oder neu erstellen</p>
         </div>
       </div>
 
@@ -94,7 +100,7 @@
     </div>
 
     <!-- New Graph Modal -->
-    <Modal v-model="showNewGraph" title="Neuer Logic Graph" max-width="sm">
+    <Modal v-model="showNewGraph" title="Neues Logikblatt" max-width="sm">
       <form @submit.prevent="doCreateGraph" class="flex flex-col gap-4">
         <div class="form-group">
           <label class="label">Name</label>
@@ -112,7 +118,7 @@
     </Modal>
 
     <!-- Rename Graph Modal -->
-    <Modal v-model="showRenameGraph" title="Graph umbenennen" max-width="sm">
+    <Modal v-model="showRenameGraph" title="Logikblatt umbenennen" max-width="sm">
       <form @submit.prevent="doRenameGraph" class="flex flex-col gap-4">
         <div class="form-group">
           <label class="label">Name</label>
@@ -130,8 +136,8 @@
     </Modal>
 
     <ConfirmDialog v-model="showDeleteConfirm"
-      title="Logic Graph löschen"
-      message="Dieser Graph wird unwiderruflich gelöscht."
+      title="Logikblatt löschen"
+      message="Dieses Logikblatt wird unwiderruflich gelöscht."
       confirm-label="Löschen"
       @confirm="doDeleteGraph" />
   </div>
@@ -219,6 +225,7 @@ const nodeTypeComponents = {
 
 // ── Active graph ───────────────────────────────────────────────────────────
 const activeGraphId = ref('')
+const activeGraph   = computed(() => store.graphs.find(g => g.id === activeGraphId.value))
 const saving        = ref(false)
 const statusMsg     = ref(null)
 const canvasWrapper = ref(null)
@@ -256,7 +263,7 @@ async function saveGraph() {
         sourceHandle: e.sourceHandle, targetHandle: e.targetHandle
       })),
     })
-    showStatus(true, 'Graph gespeichert')
+    showStatus(true, 'Logikblatt gespeichert')
   } catch (err) {
     showStatus(false, err.response?.data?.detail ?? 'Fehler beim Speichern')
   } finally {
@@ -335,7 +342,7 @@ async function runGraph() {
   try {
     const { data } = await logicApi.runGraph(activeGraphId.value)
     const evalCount = Object.keys(data.outputs || {}).length
-    showStatus(true, `Graph ausgeführt — ${evalCount} Nodes evaluiert`)
+    showStatus(true, `Logikblatt ausgeführt — ${evalCount} Nodes evaluiert`)
     // Always update lastRunOutputs (needed for extractor config panels)
     lastRunOutputs.value = data.outputs || {}
     if (debugMode.value) applyDebugValues(data.outputs || {})
@@ -357,6 +364,17 @@ async function doCreateGraph() {
   nodes.value = []; edges.value = []
 }
 
+// ── Toggle enabled ─────────────────────────────────────────────────────────
+async function doToggleEnabled() {
+  if (!activeGraphId.value) return
+  try {
+    const updated = await store.toggleEnabled(activeGraphId.value)
+    showStatus(true, updated.enabled ? 'Logikblatt aktiviert' : 'Logikblatt deaktiviert')
+  } catch (err) {
+    showStatus(false, err.response?.data?.detail ?? 'Fehler beim Ändern des Status')
+  }
+}
+
 // ── Delete graph ───────────────────────────────────────────────────────────
 const showDeleteConfirm = ref(false)
 function confirmDeleteGraph() { showDeleteConfirm.value = true }
@@ -373,7 +391,7 @@ async function doDuplicateGraph() {
     const copy = await store.duplicateGraph(activeGraphId.value)
     activeGraphId.value = copy.id
     await loadGraph()
-    showStatus(true, `Graph dupliziert als „${copy.name}"`)
+    showStatus(true, `Logikblatt dupliziert als „${copy.name}"`)
   } catch (err) {
     showStatus(false, err.response?.data?.detail ?? 'Fehler beim Duplizieren')
   }
@@ -415,7 +433,7 @@ async function doRenameGraph() {
   try {
     await store.renameGraph(activeGraphId.value, renameGraphName.value.trim(), renameGraphDesc.value)
     showRenameGraph.value = false
-    showStatus(true, 'Graph umbenannt')
+    showStatus(true, 'Logikblatt umbenannt')
   } catch (err) {
     showStatus(false, err.response?.data?.detail ?? 'Fehler beim Umbenennen')
   }
@@ -438,9 +456,9 @@ async function onImportFile(event) {
       renameGraphName.value = imported.name
       renameGraphDesc.value = imported.description ?? ''
       showRenameGraph.value = true
-      showStatus(true, `Graph importiert – bitte umbenennen (Name bereits vorhanden)`)
+      showStatus(true, `Logikblatt importiert – bitte umbenennen (Name bereits vorhanden)`)
     } else {
-      showStatus(true, `Graph „${imported.name}" importiert`)
+      showStatus(true, `Logikblatt „${imported.name}" importiert`)
     }
   } catch (err) {
     showStatus(false, err?.response?.data?.detail ?? 'Ungültige oder fehlerhafte Export-Datei')

--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -280,9 +280,11 @@ async def run_graph(
     _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> dict:
-    row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
+    row = await db.fetchone("SELECT id, enabled FROM logic_graphs WHERE id=?", (graph_id,))
     if not row:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Graph nicht gefunden")
+    if not bool(row["enabled"]):
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "Logikblatt ist deaktiviert")
     try:
         from obs.logic.manager import get_logic_manager
 

--- a/obs/logic/manager.py
+++ b/obs/logic/manager.py
@@ -338,6 +338,8 @@ class LogicManager:
         if not entry:
             raise KeyError(f"Graph {graph_id} not in cache")
         name, enabled, flow = entry
+        if not enabled:
+            raise ValueError(f"Graph {graph_id} ist deaktiviert")
         return await self._execute_graph(graph_id, name, flow, {})
 
     async def _execute_graph(

--- a/tests/gui/visu/logic-editor.spec.ts
+++ b/tests/gui/visu/logic-editor.spec.ts
@@ -982,6 +982,47 @@ test('Logikblatt-Toggle: Button zeigt Aktiv-Status und deaktiviert das Blatt', a
   }
 })
 
+test('Deaktiviertes Logikblatt: Ausführen-Button ist disabled und Kanten sind gestrichelt', async ({ page }) => {
+  const graph = await apiPost('/api/v1/logic/graphs', {
+    name: `E2E-Disabled-Run-${Date.now()}`,
+    description: 'Playwright: disabled graph blocks run',
+    enabled: false,
+    flow_data: {
+      nodes: [
+        { id: 'c1', type: 'const_value', position: { x: 100, y: 100 }, data: { value: '1', data_type: 'number' } },
+        { id: 'c2', type: 'const_value', position: { x: 100, y: 200 }, data: { value: '2', data_type: 'number' } },
+      ],
+      edges: [
+        { id: 'e1', source: 'c1', target: 'c2', sourceHandle: 'value', targetHandle: 'value' },
+      ],
+    },
+  }) as { id: string }
+  const graphId = graph.id
+
+  try {
+    await page.goto('/logic')
+    await page.waitForLoadState('networkidle')
+    await page.selectOption('[data-testid="select-graph"]', graphId)
+    await page.waitForTimeout(800)
+
+    // Ausführen-Button muss disabled sein
+    const runBtn = page.locator('[data-testid="btn-run"]')
+    await expect(runBtn).toBeDisabled({ timeout: 5_000 })
+
+    // Toggle-Button zeigt "Deaktiviert"
+    const toggleBtn = page.locator('[data-testid="btn-toggle-enabled"]')
+    await expect(toggleBtn).toContainText('Deaktiviert')
+
+    // Kante muss stroke-dasharray haben (gestrichelt = nicht animiert)
+    const edgePath = page.locator('.vue-flow__edge-path').first()
+    await expect(edgePath).toBeVisible({ timeout: 5_000 })
+    const dasharray = await edgePath.getAttribute('style')
+    expect(dasharray).toContain('stroke-dasharray')
+  } finally {
+    await apiDelete(`/api/v1/logic/graphs/${graphId}`)
+  }
+})
+
 test('Logikblatt-Bezeichnung: Toolbar und Modals verwenden "Logikblatt" statt "Graph"', async ({ page }) => {
   await page.goto('/logic')
   await page.waitForLoadState('networkidle')

--- a/tests/gui/visu/logic-editor.spec.ts
+++ b/tests/gui/visu/logic-editor.spec.ts
@@ -938,3 +938,62 @@ test('json_extractor Config-Panel zeigt Preview-Bereich und Pfad-Eingabe', async
     await apiDelete(`/api/v1/logic/graphs/${graphId}`)
   }
 })
+
+// ---------------------------------------------------------------------------
+// Logikblatt aktivieren/deaktivieren (issue #422)
+// ---------------------------------------------------------------------------
+test('Logikblatt-Toggle: Button zeigt Aktiv-Status und deaktiviert das Blatt', async ({ page }) => {
+  const graph = await apiPost('/api/v1/logic/graphs', {
+    name: `E2E-Toggle-${Date.now()}`,
+    description: 'Playwright: toggle enabled',
+    enabled: true,
+    flow_data: { nodes: [], edges: [] },
+  }) as { id: string }
+  const graphId = graph.id
+
+  try {
+    await page.goto('/logic')
+    await page.waitForLoadState('networkidle')
+    await page.selectOption('[data-testid="select-graph"]', graphId)
+    await page.waitForTimeout(500)
+
+    // Initially the graph is active — button must show "Aktiv"
+    const toggleBtn = page.locator('[data-testid="btn-toggle-enabled"]')
+    await expect(toggleBtn).toBeVisible({ timeout: 5_000 })
+    await expect(toggleBtn).toContainText('Aktiv')
+
+    // Click to deactivate
+    await toggleBtn.click()
+    await page.waitForTimeout(500)
+
+    // Button must now show "Deaktiviert"
+    await expect(toggleBtn).toContainText('Deaktiviert')
+
+    // Dropdown entry must show "(deaktiviert)" suffix
+    const option = page.locator(`[data-testid="select-graph"] option[value="${graphId}"]`)
+    await expect(option).toContainText('(deaktiviert)')
+
+    // Click again to re-activate
+    await toggleBtn.click()
+    await page.waitForTimeout(500)
+    await expect(toggleBtn).toContainText('Aktiv')
+  } finally {
+    await apiDelete(`/api/v1/logic/graphs/${graphId}`)
+  }
+})
+
+test('Logikblatt-Bezeichnung: Toolbar und Modals verwenden "Logikblatt" statt "Graph"', async ({ page }) => {
+  await page.goto('/logic')
+  await page.waitForLoadState('networkidle')
+
+  // Dropdown placeholder
+  const select = page.locator('[data-testid="select-graph"]')
+  await expect(select).toContainText('Logikblatt wählen')
+
+  // Empty-canvas hint
+  await expect(page.getByText('Logikblatt wählen oder neu erstellen')).toBeVisible({ timeout: 5_000 })
+
+  // New-graph modal title
+  await page.click('button:has-text("+ Neu")')
+  await expect(page.getByText('Neues Logikblatt')).toBeVisible({ timeout: 3_000 })
+})

--- a/tests/integration/test_logic_toggle_enabled.py
+++ b/tests/integration/test_logic_toggle_enabled.py
@@ -1,0 +1,124 @@
+"""Integration tests — Logikblatt aktivieren/deaktivieren (issue #422).
+
+Verifies that:
+  1. A newly created logic graph has enabled=True by default.
+  2. PATCH /api/v1/logic/graphs/{id} with enabled=False deactivates the graph.
+  3. PATCH /api/v1/logic/graphs/{id} with enabled=True re-activates the graph.
+  4. The enabled flag is persisted and reflected in GET responses.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_graph(client, auth_headers, name: str) -> dict:
+    resp = await client.post(
+        "/api/v1/logic/graphs",
+        json={"name": name, "description": "", "enabled": True, "flow_data": {"nodes": [], "edges": []}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _get_graph(client, auth_headers, graph_id: str) -> dict:
+    resp = await client.get(f"/api/v1/logic/graphs/{graph_id}", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _patch_graph(client, auth_headers, graph_id: str, payload: dict) -> dict:
+    resp = await client.patch(f"/api/v1/logic/graphs/{graph_id}", json=payload, headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _cleanup(client, auth_headers, graph_id: str) -> None:
+    await client.delete(f"/api/v1/logic/graphs/{graph_id}", headers=auth_headers)
+
+
+@pytest.mark.asyncio
+async def test_new_graph_is_enabled_by_default(client, auth_headers):
+    """Neu erstellte Logikblätter sind standardmässig aktiv."""
+    ts = time.time()
+    graph = await _create_graph(client, auth_headers, f"IT-Toggle-Default-{ts}")
+    graph_id = graph["id"]
+    try:
+        assert graph["enabled"] is True
+        fetched = await _get_graph(client, auth_headers, graph_id)
+        assert fetched["enabled"] is True
+    finally:
+        await _cleanup(client, auth_headers, graph_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_false_deactivates_graph(client, auth_headers):
+    """PATCH enabled=False deaktiviert das Logikblatt."""
+    ts = time.time()
+    graph = await _create_graph(client, auth_headers, f"IT-Toggle-Disable-{ts}")
+    graph_id = graph["id"]
+    try:
+        updated = await _patch_graph(client, auth_headers, graph_id, {"enabled": False})
+        assert updated["enabled"] is False
+
+        fetched = await _get_graph(client, auth_headers, graph_id)
+        assert fetched["enabled"] is False
+    finally:
+        await _cleanup(client, auth_headers, graph_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_true_reactivates_graph(client, auth_headers):
+    """PATCH enabled=True re-aktiviert ein deaktiviertes Logikblatt."""
+    ts = time.time()
+    graph = await _create_graph(client, auth_headers, f"IT-Toggle-Reactivate-{ts}")
+    graph_id = graph["id"]
+    try:
+        await _patch_graph(client, auth_headers, graph_id, {"enabled": False})
+        updated = await _patch_graph(client, auth_headers, graph_id, {"enabled": True})
+        assert updated["enabled"] is True
+
+        fetched = await _get_graph(client, auth_headers, graph_id)
+        assert fetched["enabled"] is True
+    finally:
+        await _cleanup(client, auth_headers, graph_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_does_not_affect_name_or_flow(client, auth_headers):
+    """PATCH enabled ändert weder Name noch flow_data des Logikblatts."""
+    ts = time.time()
+    original_name = f"IT-Toggle-Preserve-{ts}"
+    graph = await _create_graph(client, auth_headers, original_name)
+    graph_id = graph["id"]
+    try:
+        updated = await _patch_graph(client, auth_headers, graph_id, {"enabled": False})
+        assert updated["name"] == original_name
+        assert updated["flow_data"]["nodes"] == []
+        assert updated["flow_data"]["edges"] == []
+    finally:
+        await _cleanup(client, auth_headers, graph_id)
+
+
+@pytest.mark.asyncio
+async def test_list_graphs_includes_enabled_field(client, auth_headers):
+    """GET /api/v1/logic/graphs gibt enabled-Feld für alle Logikblätter zurück."""
+    ts = time.time()
+    graph = await _create_graph(client, auth_headers, f"IT-Toggle-List-{ts}")
+    graph_id = graph["id"]
+    try:
+        await _patch_graph(client, auth_headers, graph_id, {"enabled": False})
+
+        resp = await client.get("/api/v1/logic/graphs", headers=auth_headers)
+        assert resp.status_code == 200
+        graphs = resp.json()
+        target = next((g for g in graphs if g["id"] == graph_id), None)
+        assert target is not None
+        assert target["enabled"] is False
+    finally:
+        await _cleanup(client, auth_headers, graph_id)

--- a/tests/integration/test_logic_toggle_enabled.py
+++ b/tests/integration/test_logic_toggle_enabled.py
@@ -106,6 +106,46 @@ async def test_patch_enabled_does_not_affect_name_or_flow(client, auth_headers):
 
 
 @pytest.mark.asyncio
+async def test_run_disabled_graph_returns_422(client, auth_headers):
+    """POST .../run auf einem deaktivierten Logikblatt liefert HTTP 422."""
+    ts = time.time()
+    graph = await _create_graph(client, auth_headers, f"IT-Toggle-Run-{ts}")
+    graph_id = graph["id"]
+    try:
+        # Deaktivieren
+        await _patch_graph(client, auth_headers, graph_id, {"enabled": False})
+
+        # Ausführen muss fehlschlagen
+        resp = await client.post(f"/api/v1/logic/graphs/{graph_id}/run", headers=auth_headers)
+        assert resp.status_code == 422, resp.text
+        assert "deaktiviert" in resp.json().get("detail", "").lower()
+    finally:
+        await _cleanup(client, auth_headers, graph_id)
+
+
+@pytest.mark.asyncio
+async def test_run_reactivated_graph_succeeds(client, auth_headers):
+    """Re-aktiviertes Logikblatt kann wieder ausgeführt werden."""
+    ts = time.time()
+    graph = await _create_graph(client, auth_headers, f"IT-Toggle-Rerun-{ts}")
+    graph_id = graph["id"]
+    try:
+        await _patch_graph(client, auth_headers, graph_id, {"enabled": False})
+        # Direkt nach Deaktivierung schlägt Run fehl
+        resp = await client.post(f"/api/v1/logic/graphs/{graph_id}/run", headers=auth_headers)
+        assert resp.status_code == 422
+
+        # Re-aktivieren
+        await _patch_graph(client, auth_headers, graph_id, {"enabled": True})
+
+        # Jetzt muss Run erfolgreich sein
+        resp2 = await client.post(f"/api/v1/logic/graphs/{graph_id}/run", headers=auth_headers)
+        assert resp2.status_code == 200, resp2.text
+    finally:
+        await _cleanup(client, auth_headers, graph_id)
+
+
+@pytest.mark.asyncio
 async def test_list_graphs_includes_enabled_field(client, auth_headers):
     """GET /api/v1/logic/graphs gibt enabled-Feld für alle Logikblätter zurück."""
     ts = time.time()


### PR DESCRIPTION
## Summary

Schliesst Issue #422.

- **Umbenennung**: Alle UI-Texte im Logikmodul ersetzen "Graph" durch "Logikblatt" (Dropdown, Tooltips, Modals, Statusmeldungen, ConfirmDialog).
- **Aktivieren/Deaktivieren**: Einzelne Logikblätter koennen als Ganzes deaktiviert werden -- deaktiviert bedeutet: kein Lesen, keine Verarbeitung, kein Schreiben.

## Was wurde geaendert?

### Frontend (gui/src/views/LogicView.vue, gui/src/stores/logic.js)
- Dropdown zeigt `(deaktiviert)` als Suffix fuer deaktivierte Blaetter.
- Neuer Toggle-Button "Aktiv / Deaktiviert" in der Toolbar (gruen/orange).
- Ausfuehren-Button ist `disabled` + ausgegraut wenn das Blatt deaktiviert ist.
- Kanten werden gestrichelt (`stroke-dasharray: 8 5`) und nicht animiert wenn deaktiviert.
- `defaultEdgeOptions` ist reaktiv (computed), Watcher aktualisiert bestehende Kanten sofort beim Togglen.
- Store: `toggleEnabled(id)` ruft `PATCH /enabled` auf.

### Backend (obs/api/v1/logic.py, obs/logic/manager.py)
- `POST /api/v1/logic/graphs/{id}/run` gibt HTTP 422 zurueck wenn `enabled=False`.
- `execute_graph()` im Manager prueft ebenfalls das enabled-Flag als zweite Absicherung.
- Timer-, Cron- und DataPoint-getriggerte Ausfuehrungen waren bereits geschuetzt (unveraendert).

### Tests
- `tests/integration/test_logic_toggle_enabled.py`: 7 Integrationstests (Default-Status, deaktivieren, re-aktivieren, Felder unveraendert, List-Endpoint, Run-Block, Re-Run nach Aktivierung).
- `tests/gui/visu/logic-editor.spec.ts`: 3 neue E2E-Tests (Toggle-Verhalten, disabled Button + gestrichelte Kante, Begriffspruefung).

## Test plan

- [ ] Logikmodul oeffnen: Dropdown zeigt "Logikblatt waehlen"
- [ ] Logikblatt oeffnen: Toggle-Button zeigt "Aktiv"
- [ ] Deaktivieren: Button wird orange "Deaktiviert", Kanten gestrichelt, Ausfuehren ausgegraut
- [ ] Ausfuehren-Klick auf deaktiviertem Blatt: kein Effekt (Button ist disabled)
- [ ] `POST /api/v1/logic/graphs/{id}/run` auf deaktiviertem Blatt: HTTP 422
- [ ] Re-aktivieren: Kanten fliessen wieder, Ausfuehren moeglich
- [ ] Integrationstests: `pytest -m integration tests/integration/test_logic_toggle_enabled.py`
- [ ] E2E-Tests: Playwright `logic-editor.spec.ts`

Generated with [Claude Code](https://claude.com/claude-code)
