### PR TITLE
fix: retry ioBroker Socket.IO via websocket

### DIFF
--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -335,18 +335,43 @@ class IoBrokerAdapter(AdapterBase):
             sio = self._build_socket()
             self._socket = sio
             try:
-                try:
-                    await sio.connect(self._connect_url, wait_timeout=10, **self._connect_kwargs)
-                except TypeError:
-                    v4_kwargs = dict(self._connect_kwargs)
-                    v4_kwargs.pop("auth", None)
-                    await sio.connect(self._connect_url, **v4_kwargs)
+                await self._connect_with_kwargs(sio, self._connect_kwargs)
                 return True
-            except Exception:
+            except Exception as exc:
+                if self._should_retry_with_websocket(exc):
+                    logger.warning(
+                        "ioBroker Socket.IO polling handshake failed; retrying with websocket transport"
+                    )
+                    fallback_kwargs = dict(self._connect_kwargs)
+                    fallback_kwargs["transports"] = ["websocket"]
+                    fallback_sio = self._build_socket()
+                    self._socket = fallback_sio
+                    try:
+                        await self._connect_with_kwargs(fallback_sio, fallback_kwargs)
+                        self._connect_kwargs = fallback_kwargs
+                        return True
+                    except Exception:
+                        if self._socket is fallback_sio:
+                            self._socket = None
+                        logger.exception("ioBroker Socket.IO websocket fallback failed")
+                        return False
                 if self._socket is sio:
                     self._socket = None
                 logger.exception("ioBroker Socket.IO connection failed")
                 return False
+
+    async def _connect_with_kwargs(self, sio: Any, connect_kwargs: dict[str, Any]) -> None:
+        assert self._connect_url is not None
+        try:
+            await sio.connect(self._connect_url, wait_timeout=10, **connect_kwargs)
+        except TypeError:
+            v4_kwargs = dict(connect_kwargs)
+            v4_kwargs.pop("auth", None)
+            await sio.connect(self._connect_url, **v4_kwargs)
+
+    @staticmethod
+    def _should_retry_with_websocket(exc: Exception) -> bool:
+        return "OPEN packet not returned by server" in str(exc)
 
     async def _reconnect_loop(self) -> None:
         assert self._cfg is not None

--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -339,9 +339,7 @@ class IoBrokerAdapter(AdapterBase):
                 return True
             except Exception as exc:
                 if self._should_retry_with_websocket(exc):
-                    logger.warning(
-                        "ioBroker Socket.IO polling handshake failed; retrying with websocket transport"
-                    )
+                    logger.warning("ioBroker Socket.IO polling handshake failed; retrying with websocket transport")
                     fallback_kwargs = dict(self._connect_kwargs)
                     fallback_kwargs["transports"] = ["websocket"]
                     fallback_sio = self._build_socket()

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -254,6 +254,48 @@ class TestSubscribe:
 
 class TestReconnect:
     @pytest.mark.asyncio
+    async def test_connect_socket_retries_open_packet_error_with_websocket(self, adapter):
+        adapter._connect_url = "http://192.168.1.50:8084"
+        adapter._connect_kwargs = {"socketio_path": "socket.io"}
+        polling_socket = MagicMock()
+        polling_socket.connect = AsyncMock(side_effect=Exception("OPEN packet not returned by server"))
+        websocket_socket = MagicMock()
+        websocket_socket.connect = AsyncMock()
+        adapter._build_socket = MagicMock(side_effect=[polling_socket, websocket_socket])
+
+        connected = await adapter._connect_socket()
+
+        assert connected is True
+        polling_socket.connect.assert_awaited_once_with(
+            "http://192.168.1.50:8084",
+            wait_timeout=10,
+            socketio_path="socket.io",
+        )
+        websocket_socket.connect.assert_awaited_once_with(
+            "http://192.168.1.50:8084",
+            wait_timeout=10,
+            socketio_path="socket.io",
+            transports=["websocket"],
+        )
+        assert adapter._socket is websocket_socket
+        assert adapter._connect_kwargs["transports"] == ["websocket"]
+
+    @pytest.mark.asyncio
+    async def test_connect_socket_does_not_retry_unrelated_errors(self, adapter):
+        adapter._connect_url = "http://192.168.1.50:8084"
+        adapter._connect_kwargs = {"socketio_path": "socket.io"}
+        socket = MagicMock()
+        socket.connect = AsyncMock(side_effect=Exception("connection refused"))
+        adapter._build_socket = MagicMock(return_value=socket)
+
+        connected = await adapter._connect_socket()
+
+        assert connected is False
+        assert adapter._build_socket.call_count == 1
+        socket.connect.assert_awaited_once()
+        assert adapter._socket is None
+
+    @pytest.mark.asyncio
     async def test_reconnect_loop_retries_until_connect_succeeds(self, adapter, monkeypatch):
         adapter._disconnect_requested = False
         adapter._cfg = adapter.config_schema(**{**adapter._config, "reconnect_interval_seconds": 1})


### PR DESCRIPTION
## Summary
- retry ioBroker Socket.IO connections with websocket transport when the polling handshake fails with `OPEN packet not returned by server`
- keep the existing default polling path for other installations
- add regression coverage for the websocket fallback and non-retry errors

## Test
- `pytest tests/adapters/test_iobroker.py -q`