### PR TITLE
feat: log viewer in admin GUI with live WebSocket streaming

### DIFF
--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -201,6 +201,7 @@ export const historyApi = {
 // ── Log Buffer ────────────────────────────────────────────────────────────
 export const logsApi = {
   list:     (params) => api.get('/system/logs', { params }),
+  getLevel: ()       => api.get('/system/log-level'),
   setLevel: (level)  => api.put('/system/log-level', { level }),
 }
 

--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -198,6 +198,12 @@ export const historyApi = {
   aggregate: (id, params) => api.get(`/history/${id}/aggregate`, { params }),
 }
 
+// ── Log Buffer ────────────────────────────────────────────────────────────
+export const logsApi = {
+  list:     (params) => api.get('/system/logs', { params }),
+  setLevel: (level)  => api.put('/system/log-level', { level }),
+}
+
 // ── RingBuffer ────────────────────────────────────────────────────────────
 export const ringbufferApi = {
   query:  (params)                  => api.get('/ringbuffer/', { params }),

--- a/gui/src/components/layout/Sidebar.vue
+++ b/gui/src/components/layout/Sidebar.vue
@@ -111,6 +111,7 @@ const navItems = [
   { to: '/adapters',   label: 'Adapter',      icon: '&#9741;' },
   { to: '/history',    label: 'Historie',     icon: '&#9685;' },
   { to: '/ringbuffer', label: 'Monitor',      icon: '&#9706;' },
+  { to: '/logs',       label: 'Logs',         icon: '&#9783;' },
   { to: '/logic',      label: 'Logikmodul',   icon: '<svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18" style="display:inline-block;vertical-align:middle"><circle cx="4" cy="7" r="2"/><circle cx="4" cy="13" r="2"/><circle cx="16" cy="10" r="2.5"/><line x1="6" y1="7.5" x2="13.5" y2="9.3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="6" y1="12.5" x2="13.5" y2="10.7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>' },
   { to: '/settings',   label: 'Einstellungen', icon: '&#9881;' },
 ]

--- a/gui/src/router/index.js
+++ b/gui/src/router/index.js
@@ -8,6 +8,7 @@ const routes = [
   { path: '/adapters',             name: 'Adapters',   component: () => import('@/views/AdaptersView.vue')   },
   { path: '/history',              name: 'History',    component: () => import('@/views/HistoryView.vue')    },
   { path: '/ringbuffer',           name: 'RingBuffer', component: () => import('@/views/RingBufferView.vue') },
+  { path: '/logs',                 name: 'Logs',       component: () => import('@/views/LogView.vue')        },
   { path: '/settings',             name: 'Settings',   component: () => import('@/views/SettingsView.vue')   },
   { path: '/logic',                name: 'Logic',      component: () => import('@/views/LogicView.vue')      },
 { path: '/:pathMatch(.*)*',      redirect: '/' },

--- a/gui/src/stores/websocket.js
+++ b/gui/src/stores/websocket.js
@@ -19,6 +19,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
   const _ws          = shallowRef(null)
   const _handlers    = []        // [{ id, fn }] — external value listeners
   const _rbHandlers  = []        // ringbuffer entry listeners
+  const _logHandlers = []        // log_entry listeners
   let   _pingInterval = null
 
   function connect() {
@@ -63,6 +64,10 @@ export const useWebSocketStore = defineStore('websocket', () => {
         // RingBuffer live push
         if (msg.action === 'ringbuffer_entry') {
           _rbHandlers.forEach(h => h.fn(msg.entry))
+        }
+        // Log live push
+        if (msg.action === 'log_entry') {
+          _logHandlers.forEach(h => h.fn(msg.entry))
         }
         // Server keepalive ping — reply with pong
         if (msg.action === 'ping') {
@@ -118,5 +123,15 @@ export const useWebSocketStore = defineStore('websocket', () => {
     }
   }
 
-  return { connected, liveValues, connect, disconnect, subscribe, unsubscribe, onValue, onRingbufferEntry }
+  /** Register a handler to be called on every log_entry push. Returns unregister fn. */
+  function onLogEntry(fn) {
+    const entry = { id: Math.random(), fn }
+    _logHandlers.push(entry)
+    return () => {
+      const idx = _logHandlers.indexOf(entry)
+      if (idx !== -1) _logHandlers.splice(idx, 1)
+    }
+  }
+
+  return { connected, liveValues, connect, disconnect, subscribe, unsubscribe, onValue, onRingbufferEntry, onLogEntry }
 })

--- a/gui/src/views/LogView.vue
+++ b/gui/src/views/LogView.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="flex flex-col gap-5">
+    <div class="flex flex-wrap items-start gap-3">
+      <div class="flex-1">
+        <h2 class="text-xl font-bold text-slate-800 dark:text-slate-100">Logs</h2>
+        <p class="text-sm text-slate-500 mt-0.5">Applikations-Logs — Live</p>
+      </div>
+      <select v-model="logLevel" @change="setLevel" class="input w-36" title="Log-Level zur Laufzeit ändern">
+        <option value="">Level: Standard</option>
+        <option value="DEBUG">DEBUG</option>
+        <option value="INFO">INFO</option>
+        <option value="WARNING">WARNING</option>
+        <option value="ERROR">ERROR</option>
+      </select>
+      <button @click="load" class="btn-secondary btn-sm">↻ Aktualisieren</button>
+      <span :class="['inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium',
+        wsConnected ? 'bg-teal-500/15 text-teal-600 dark:text-teal-400' : 'bg-slate-200/50 dark:bg-slate-700/50 text-slate-500']"
+        data-testid="status-badge">
+        <span :class="['w-1.5 h-1.5 rounded-full', wsConnected ? 'bg-teal-400 animate-pulse' : 'bg-slate-600']" />
+        {{ wsConnected ? 'Live' : 'Offline' }}
+      </span>
+    </div>
+
+    <!-- Filters -->
+    <div class="flex flex-wrap gap-3">
+      <input v-model="filters.q" type="text" class="input flex-1 min-w-40"
+        placeholder="Suche in Logger-Name oder Meldung …" @input="debouncedLoad" data-testid="input-filter" />
+      <select v-model="filters.level" class="input w-36" @change="load">
+        <option value="">Alle Level</option>
+        <option value="DEBUG">DEBUG</option>
+        <option value="INFO">INFO</option>
+        <option value="WARNING">WARNING</option>
+        <option value="ERROR">ERROR</option>
+        <option value="CRITICAL">CRITICAL</option>
+      </select>
+      <select v-model="filters.limit" class="input w-28" @change="load">
+        <option value="100">100</option>
+        <option value="200">200</option>
+        <option value="500">500</option>
+      </select>
+    </div>
+
+    <!-- Log table -->
+    <div class="card overflow-hidden">
+      <div v-if="loading" class="flex justify-center py-12"><Spinner size="lg" /></div>
+      <div v-else-if="!entries.length" class="text-center text-slate-500 text-sm py-12">Keine Log-Einträge vorhanden</div>
+      <div v-else class="table-wrap max-h-[65vh] overflow-y-auto">
+        <table class="table">
+          <thead class="sticky top-0">
+            <tr>
+              <th class="w-44">Zeitstempel</th>
+              <th class="w-24">Level</th>
+              <th class="w-56">Logger</th>
+              <th>Meldung</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(e, i) in entries" :key="i" data-testid="log-entry">
+              <td class="font-mono text-xs text-slate-400 whitespace-nowrap">{{ fmtDateTime(e.ts) }}</td>
+              <td><Badge :variant="levelVariant(e.level)" size="xs">{{ e.level }}</Badge></td>
+              <td class="font-mono text-xs text-slate-400 truncate max-w-[14rem]" :title="e.logger">{{ e.logger }}</td>
+              <td class="text-sm break-all">{{ e.message }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
+import { logsApi } from '@/api/client'
+import { useTz } from '@/composables/useTz'
+import { useWebSocketStore } from '@/stores/websocket'
+import Badge   from '@/components/ui/Badge.vue'
+import Spinner from '@/components/ui/Spinner.vue'
+
+const { fmtDateTime } = useTz()
+const wsStore = useWebSocketStore()
+
+const entries = ref([])
+const loading = ref(false)
+const logLevel = ref('')
+
+const filters = reactive({ q: '', level: '', limit: '200' })
+
+const wsConnected = computed(() => wsStore.connected)
+
+let debounceTimer  = null
+let unregisterLog  = null
+
+function debouncedLoad() {
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(load, 350)
+}
+
+function levelVariant(level) {
+  return { DEBUG: 'muted', INFO: 'info', WARNING: 'warning', ERROR: 'danger', CRITICAL: 'danger' }[level] ?? 'muted'
+}
+
+/** Live push from WS — prepend and honour client-side filters */
+function onLiveEntry(entry) {
+  const q = filters.q.toLowerCase()
+  if (q && !(entry.logger?.toLowerCase().includes(q) || entry.message?.toLowerCase().includes(q))) return
+  if (filters.level && entry.level !== filters.level) return
+  entries.value = [entry, ...entries.value].slice(0, parseInt(filters.limit) || 200)
+}
+
+onMounted(async () => {
+  await load()
+  unregisterLog = wsStore.onLogEntry(onLiveEntry)
+})
+
+onUnmounted(() => {
+  unregisterLog?.()
+  clearTimeout(debounceTimer)
+})
+
+async function load() {
+  loading.value = true
+  try {
+    const params = {}
+    if (filters.level) params.level = filters.level
+    params.limit = parseInt(filters.limit) || 200
+    const { data } = await logsApi.list(params)
+    // Client-side text filter (server only filters by level)
+    const q = filters.q.toLowerCase()
+    entries.value = q
+      ? data.filter(e => e.logger?.toLowerCase().includes(q) || e.message?.toLowerCase().includes(q))
+      : data
+  } finally {
+    loading.value = false
+  }
+}
+
+async function setLevel() {
+  if (!logLevel.value) return
+  try {
+    await logsApi.setLevel(logLevel.value)
+  } catch {
+    // non-admin users get a 403 — silently ignore, the select resets visually
+    logLevel.value = ''
+  }
+}
+</script>

--- a/gui/src/views/LogView.vue
+++ b/gui/src/views/LogView.vue
@@ -6,7 +6,6 @@
         <p class="text-sm text-slate-500 mt-0.5">Applikations-Logs — Live</p>
       </div>
       <select v-model="logLevel" @change="setLevel" class="input w-36" title="Log-Level zur Laufzeit ändern">
-        <option value="">Level: Standard</option>
         <option value="DEBUG">DEBUG</option>
         <option value="INFO">INFO</option>
         <option value="WARNING">WARNING</option>
@@ -81,7 +80,7 @@ const wsStore = useWebSocketStore()
 
 const entries = ref([])
 const loading = ref(false)
-const logLevel = ref('')
+const logLevel = ref('INFO')
 
 const filters = reactive({ q: '', level: '', limit: '200' })
 
@@ -108,6 +107,12 @@ function onLiveEntry(entry) {
 }
 
 onMounted(async () => {
+  try {
+    const { data } = await logsApi.getLevel()
+    logLevel.value = data.level
+  } catch {
+    // non-admin — leave default
+  }
   await load()
   unregisterLog = wsStore.onLogEntry(onLiveEntry)
 })
@@ -135,12 +140,10 @@ async function load() {
 }
 
 async function setLevel() {
-  if (!logLevel.value) return
   try {
     await logsApi.setLevel(logLevel.value)
   } catch {
-    // non-admin users get a 403 — silently ignore, the select resets visually
-    logLevel.value = ''
+    // non-admin users get a 403 — silently ignore
   }
 }
 </script>

--- a/obs/api/v1/system.py
+++ b/obs/api/v1/system.py
@@ -12,6 +12,8 @@ GET    /api/v1/system/nav-links        list all custom nav links (auth required)
 POST   /api/v1/system/nav-links        create a custom nav link (admin only)
 PATCH  /api/v1/system/nav-links/{id}   update a custom nav link (admin only)
 DELETE /api/v1/system/nav-links/{id}   delete a custom nav link (admin only)
+GET    /api/v1/system/logs             recent log entries from in-memory buffer
+PUT    /api/v1/system/log-level        change log level at runtime (admin only)
 """
 
 from __future__ import annotations
@@ -122,6 +124,17 @@ class NavLinkPatch(BaseModel):
     icon: str | None = None
     sort_order: int | None = None
     open_new_tab: bool | None = None
+
+
+class LogEntryOut(BaseModel):
+    ts: str
+    level: str
+    logger: str
+    message: str
+
+
+class LogLevelIn(BaseModel):
+    level: str
 
 
 # ---------------------------------------------------------------------------
@@ -503,3 +516,51 @@ async def delete_nav_link(
     if row is None:
         raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="Link not found")
     await db.execute_and_commit("DELETE FROM nav_links WHERE id = ?", (link_id,))
+
+
+# ---------------------------------------------------------------------------
+# Log buffer
+# ---------------------------------------------------------------------------
+
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+@router.get("/logs", response_model=list[LogEntryOut])
+async def get_logs(
+    level: str | None = None,
+    limit: int = 200,
+    _user: str = Depends(get_current_user),
+) -> list[LogEntryOut]:
+    """Recent log entries from the in-memory buffer, newest first.
+
+    Optional query params:
+    - level: filter by exact level name (INFO, WARNING, ERROR, CRITICAL)
+    - limit: max entries to return (default 200, max 500)
+    """
+    from obs.log_buffer import get_log_buffer
+
+    entries = get_log_buffer()
+    if level:
+        lvl = level.upper()
+        entries = [e for e in entries if e["level"] == lvl]
+    limit = max(1, min(limit, 500))
+    entries = entries[-limit:]
+    entries.reverse()
+    return [LogEntryOut(**e) for e in entries]
+
+
+@router.put("/log-level", status_code=204)
+async def set_log_level(
+    body: LogLevelIn,
+    _admin: str = Depends(get_admin_user),
+) -> None:
+    """Change the root log level at runtime without restarting. Admin only."""
+    import logging as _logging
+
+    lvl = body.level.upper()
+    if lvl not in _VALID_LOG_LEVELS:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"level must be one of: {', '.join(sorted(_VALID_LOG_LEVELS))}",
+        )
+    _logging.getLogger().setLevel(lvl)

--- a/obs/api/v1/system.py
+++ b/obs/api/v1/system.py
@@ -13,6 +13,7 @@ POST   /api/v1/system/nav-links        create a custom nav link (admin only)
 PATCH  /api/v1/system/nav-links/{id}   update a custom nav link (admin only)
 DELETE /api/v1/system/nav-links/{id}   delete a custom nav link (admin only)
 GET    /api/v1/system/logs             recent log entries from in-memory buffer
+GET    /api/v1/system/log-level        read current root log level (admin only)
 PUT    /api/v1/system/log-level        change log level at runtime (admin only)
 """
 
@@ -131,6 +132,10 @@ class LogEntryOut(BaseModel):
     level: str
     logger: str
     message: str
+
+
+class LogLevelOut(BaseModel):
+    level: str
 
 
 class LogLevelIn(BaseModel):
@@ -547,6 +552,17 @@ async def get_logs(
     entries = entries[-limit:]
     entries.reverse()
     return [LogEntryOut(**e) for e in entries]
+
+
+@router.get("/log-level", response_model=LogLevelOut)
+async def get_log_level(
+    _admin: str = Depends(get_admin_user),
+) -> LogLevelOut:
+    """Return the current root log level. Admin only."""
+    import logging as _logging
+
+    lvl = _logging.getLevelName(_logging.getLogger().level)
+    return LogLevelOut(level=lvl)
 
 
 @router.put("/log-level", status_code=204)

--- a/obs/api/v1/system.py
+++ b/obs/api/v1/system.py
@@ -571,7 +571,7 @@ async def set_log_level(
     _admin: str = Depends(get_admin_user),
 ) -> None:
     """Change the root log level at runtime without restarting. Admin only."""
-    import logging as _logging
+    from obs.log_buffer import set_log_buffer_level
 
     lvl = body.level.upper()
     if lvl not in _VALID_LOG_LEVELS:
@@ -579,4 +579,4 @@ async def set_log_level(
             status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"level must be one of: {', '.join(sorted(_VALID_LOG_LEVELS))}",
         )
-    _logging.getLogger().setLevel(lvl)
+    set_log_buffer_level(lvl)

--- a/obs/log_buffer.py
+++ b/obs/log_buffer.py
@@ -19,11 +19,19 @@ from typing import Any
 
 _buffer: deque[dict[str, Any]] = deque(maxlen=500)
 _loop: asyncio.AbstractEventLoop | None = None
+_NON_PROPAGATING_LOGGER_NAMES = ("uvicorn.access", "uvicorn.error")
 
 
 def get_log_buffer() -> list[dict[str, Any]]:
     """Return a snapshot of the current buffer (newest entry last)."""
     return list(_buffer)
+
+
+def set_log_buffer_level(level: int | str) -> None:
+    """Update all installed LogBufferHandler instances to the given level."""
+    logging.getLogger().setLevel(level)
+    for handler in _iter_log_buffer_handlers():
+        handler.setLevel(level)
 
 
 class LogBufferHandler(logging.Handler):
@@ -53,6 +61,23 @@ class LogBufferHandler(logging.Handler):
         handler = cls(level=level)
         handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
         logging.getLogger().addHandler(handler)
+        for logger_name in _NON_PROPAGATING_LOGGER_NAMES:
+            logger = logging.getLogger(logger_name)
+            if not logger.propagate:
+                logger.addHandler(handler)
+
+
+def _iter_log_buffer_handlers() -> list[LogBufferHandler]:
+    """Return installed buffer handlers across root and non-propagating loggers."""
+    handlers: list[LogBufferHandler] = []
+    seen: set[int] = set()
+    loggers = [logging.getLogger(), *(logging.getLogger(name) for name in _NON_PROPAGATING_LOGGER_NAMES)]
+    for logger in loggers:
+        for handler in logger.handlers:
+            if isinstance(handler, LogBufferHandler) and id(handler) not in seen:
+                seen.add(id(handler))
+                handlers.append(handler)
+    return handlers
 
 
 def _broadcast_nowait(entry: dict[str, Any]) -> None:

--- a/obs/log_buffer.py
+++ b/obs/log_buffer.py
@@ -57,6 +57,8 @@ class LogBufferHandler(logging.Handler):
 
 def _broadcast_nowait(entry: dict[str, Any]) -> None:
     """Schedule a WS broadcast without awaiting it (called from call_soon_threadsafe)."""
+    if _loop is None or not _loop.is_running():
+        return
     try:
         from obs.api.v1.websocket import get_ws_manager
 
@@ -64,4 +66,4 @@ def _broadcast_nowait(entry: dict[str, Any]) -> None:
     except RuntimeError:
         # WS manager not yet initialised (early startup log records) — drop silently.
         return
-    asyncio.ensure_future(manager.broadcast({"action": "log_entry", "entry": entry}))
+    _loop.create_task(manager.broadcast({"action": "log_entry", "entry": entry}))

--- a/obs/log_buffer.py
+++ b/obs/log_buffer.py
@@ -42,7 +42,7 @@ class LogBufferHandler(logging.Handler):
             "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
             "level": record.levelname,
             "logger": record.name,
-            "message": self.format(record),
+            "message": record.getMessage(),
         }
         _buffer.append(entry)
 

--- a/obs/log_buffer.py
+++ b/obs/log_buffer.py
@@ -1,0 +1,67 @@
+"""In-memory log buffer with WebSocket broadcast.
+
+A single LogBufferHandler is attached to the root logger in obs/main.py.
+Every log record emitted anywhere in the process is captured into a bounded
+deque and simultaneously pushed to all connected WebSocket clients.
+
+The deque size is intentionally small (500 entries ≈ <100 KB RAM).
+Logs are not persisted across restarts — they are a debugging aid, not an
+audit trail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any
+
+_buffer: deque[dict[str, Any]] = deque(maxlen=500)
+_loop: asyncio.AbstractEventLoop | None = None
+
+
+def get_log_buffer() -> list[dict[str, Any]]:
+    """Return a snapshot of the current buffer (newest entry last)."""
+    return list(_buffer)
+
+
+class LogBufferHandler(logging.Handler):
+    """Captures log records into an in-memory deque and broadcasts them via WebSocket."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        entry: dict[str, Any] = {
+            "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "message": self.format(record),
+        }
+        _buffer.append(entry)
+
+        # Fire-and-forget WS broadcast — must never block the logging call.
+        if _loop is not None and _loop.is_running():
+            _loop.call_soon_threadsafe(_broadcast_nowait, entry)
+
+    @classmethod
+    def install(cls, loop: asyncio.AbstractEventLoop, level: int = logging.INFO) -> None:
+        """Attach a handler instance to the root logger.
+
+        Call once after logging.basicConfig() in obs/main.py.
+        """
+        global _loop
+        _loop = loop
+        handler = cls(level=level)
+        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+        logging.getLogger().addHandler(handler)
+
+
+def _broadcast_nowait(entry: dict[str, Any]) -> None:
+    """Schedule a WS broadcast without awaiting it (called from call_soon_threadsafe)."""
+    try:
+        from obs.api.v1.websocket import get_ws_manager
+
+        manager = get_ws_manager()
+    except RuntimeError:
+        # WS manager not yet initialised (early startup log records) — drop silently.
+        return
+    asyncio.ensure_future(manager.broadcast({"action": "log_entry", "entry": entry}))

--- a/obs/main.py
+++ b/obs/main.py
@@ -43,10 +43,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     settings = get_settings()
 
-    logging.basicConfig(
-        level=getattr(logging, settings.server.log_level.upper(), logging.INFO),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    )
+    log_level = getattr(logging, settings.server.log_level.upper(), logging.INFO)
+    logging.basicConfig(level=log_level, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    import asyncio
+
+    from obs.log_buffer import LogBufferHandler
+
+    LogBufferHandler.install(asyncio.get_event_loop(), level=log_level)
     logger.info(f"open bridge server v{__version__} starting …")
 
     # 1. Database

--- a/tests/unit/test_log_buffer.py
+++ b/tests/unit/test_log_buffer.py
@@ -83,6 +83,21 @@ def test_entry_contains_all_fields():
     assert entry["level"] == "WARNING"
 
 
+def test_message_contains_raw_log_message_without_prefix():
+    from obs.log_buffer import get_log_buffer
+
+    logger = logging.getLogger("test.message")
+    logger.addHandler(_make_handler())
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("plain message %s", "only")
+
+    entry = get_log_buffer()[0]
+    assert entry["message"] == "plain message only"
+    assert "[INFO]" not in entry["message"]
+    assert "test.message:" not in entry["message"]
+
+
 def test_multiple_records_are_ordered_oldest_first():
     from obs.log_buffer import get_log_buffer
 

--- a/tests/unit/test_log_buffer.py
+++ b/tests/unit/test_log_buffer.py
@@ -23,13 +23,14 @@ def clear_buffer():
     Integration tests may leave a LogBufferHandler on the root logger. Without cleanup,
     log messages propagate to it and produce duplicate buffer entries in unit tests.
     """
-    from obs.log_buffer import LogBufferHandler, _buffer
+    from obs.log_buffer import LogBufferHandler, _NON_PROPAGATING_LOGGER_NAMES, _buffer
 
     def _remove_handlers():
-        root = logging.getLogger()
-        for h in list(root.handlers):
-            if isinstance(h, LogBufferHandler):
-                root.removeHandler(h)
+        loggers = [logging.getLogger(), *(logging.getLogger(name) for name in _NON_PROPAGATING_LOGGER_NAMES)]
+        for logger in loggers:
+            for h in list(logger.handlers):
+                if isinstance(h, LogBufferHandler):
+                    logger.removeHandler(h)
 
     _remove_handlers()
     _buffer.clear()
@@ -168,6 +169,62 @@ def test_install_attaches_to_root_logger():
     for h in list(root.handlers):
         if isinstance(h, LogBufferHandler):
             root.removeHandler(h)
+    loop.close()
+
+
+def test_set_log_buffer_level_updates_installed_handler():
+    import asyncio
+
+    from obs.log_buffer import LogBufferHandler, get_log_buffer, set_log_buffer_level
+
+    root = logging.getLogger()
+    old_level = root.level
+    loop = asyncio.new_event_loop()
+    LogBufferHandler.install(loop, level=logging.INFO)
+    root.setLevel(logging.INFO)
+
+    logger = logging.getLogger("test.runtime_level")
+    logger.setLevel(logging.DEBUG)
+
+    logger.debug("ignored before runtime level change")
+    assert get_log_buffer() == []
+
+    set_log_buffer_level("DEBUG")
+    logger.debug("captured after runtime level change")
+
+    entries = get_log_buffer()
+    assert len(entries) == 1
+    assert entries[0]["level"] == "DEBUG"
+    assert "captured after runtime level change" in entries[0]["message"]
+
+    root.setLevel(old_level)
+    loop.close()
+
+
+def test_install_attaches_to_non_propagating_uvicorn_loggers():
+    import asyncio
+
+    from obs.log_buffer import LogBufferHandler, get_log_buffer
+
+    access_logger = logging.getLogger("uvicorn.access")
+    old_propagate = access_logger.propagate
+    old_level = access_logger.level
+    access_logger.propagate = False
+    access_logger.setLevel(logging.INFO)
+
+    loop = asyncio.new_event_loop()
+    LogBufferHandler.install(loop, level=logging.INFO)
+
+    assert any(isinstance(h, LogBufferHandler) for h in access_logger.handlers)
+
+    access_logger.info('127.0.0.1:1234 - "GET /api/v1/system/logs HTTP/1.1" 200 OK')
+    entries = get_log_buffer()
+    assert len(entries) == 1
+    assert entries[0]["logger"] == "uvicorn.access"
+    assert "GET /api/v1/system/logs" in entries[0]["message"]
+
+    access_logger.propagate = old_propagate
+    access_logger.setLevel(old_level)
     loop.close()
 
 

--- a/tests/unit/test_log_buffer.py
+++ b/tests/unit/test_log_buffer.py
@@ -18,11 +18,23 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def clear_buffer():
-    """Reset the module-level deque before each test."""
-    from obs.log_buffer import _buffer
+    """Reset the module-level deque and remove stray root-logger handlers before each test.
 
+    Integration tests may leave a LogBufferHandler on the root logger. Without cleanup,
+    log messages propagate to it and produce duplicate buffer entries in unit tests.
+    """
+    from obs.log_buffer import LogBufferHandler, _buffer
+
+    def _remove_handlers():
+        root = logging.getLogger()
+        for h in list(root.handlers):
+            if isinstance(h, LogBufferHandler):
+                root.removeHandler(h)
+
+    _remove_handlers()
     _buffer.clear()
     yield
+    _remove_handlers()
     _buffer.clear()
 
 

--- a/tests/unit/test_log_buffer.py
+++ b/tests/unit/test_log_buffer.py
@@ -1,0 +1,171 @@
+"""Unit tests for obs.log_buffer.
+
+Covers:
+  - LogBufferHandler captures log records into the buffer
+  - Buffer entries contain expected fields (ts, level, logger, message)
+  - deque maxlen evicts oldest entries when full
+  - Level filter in get_log_buffer (via API helper)
+  - Handler install() attaches to root logger
+  - Early _broadcast_nowait with no WS manager does not raise
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_buffer():
+    """Reset the module-level deque before each test."""
+    from obs.log_buffer import _buffer
+
+    _buffer.clear()
+    yield
+    _buffer.clear()
+
+
+def _make_handler(level: int = logging.DEBUG):
+    from obs.log_buffer import LogBufferHandler
+
+    handler = LogBufferHandler(level=level)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Basic capture
+# ---------------------------------------------------------------------------
+
+
+def test_emit_adds_entry_to_buffer():
+    from obs.log_buffer import get_log_buffer
+
+    logger = logging.getLogger("test.capture")
+    logger.addHandler(_make_handler())
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("hello log viewer")
+
+    entries = get_log_buffer()
+    assert len(entries) == 1
+    assert entries[0]["level"] == "INFO"
+    assert entries[0]["logger"] == "test.capture"
+    assert "hello log viewer" in entries[0]["message"]
+
+
+def test_entry_contains_all_fields():
+    from obs.log_buffer import get_log_buffer
+
+    logger = logging.getLogger("test.fields")
+    logger.addHandler(_make_handler())
+    logger.setLevel(logging.WARNING)
+
+    logger.warning("field check")
+
+    entry = get_log_buffer()[0]
+    assert set(entry.keys()) == {"ts", "level", "logger", "message"}
+    assert entry["ts"].endswith("Z")
+    assert entry["level"] == "WARNING"
+
+
+def test_multiple_records_are_ordered_oldest_first():
+    from obs.log_buffer import get_log_buffer
+
+    logger = logging.getLogger("test.order")
+    logger.addHandler(_make_handler())
+    logger.setLevel(logging.DEBUG)
+
+    for i in range(3):
+        logger.info("msg %d", i)
+
+    messages = [e["message"] for e in get_log_buffer()]
+    assert "msg 0" in messages[0]
+    assert "msg 2" in messages[2]
+
+
+# ---------------------------------------------------------------------------
+# deque maxlen behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_buffer_evicts_oldest_when_full():
+    from obs.log_buffer import _buffer, get_log_buffer
+
+    # Temporarily shrink maxlen for the test
+    original_maxlen = _buffer.maxlen
+    _buffer.__init__(maxlen=3)  # type: ignore[misc]
+
+    logger = logging.getLogger("test.maxlen")
+    logger.addHandler(_make_handler())
+    logger.setLevel(logging.DEBUG)
+
+    for i in range(5):
+        logger.info("entry %d", i)
+
+    entries = get_log_buffer()
+    assert len(entries) == 3
+    assert "entry 2" in entries[0]["message"]
+    assert "entry 4" in entries[2]["message"]
+
+    _buffer.__init__(maxlen=original_maxlen)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Level filter
+# ---------------------------------------------------------------------------
+
+
+def test_level_filtering_in_handler():
+    from obs.log_buffer import get_log_buffer
+
+    logger = logging.getLogger("test.levelfilter")
+    logger.addHandler(_make_handler(level=logging.WARNING))
+    logger.setLevel(logging.DEBUG)
+
+    logger.debug("should be ignored")
+    logger.info("also ignored")
+    logger.warning("captured")
+
+    entries = get_log_buffer()
+    assert len(entries) == 1
+    assert entries[0]["level"] == "WARNING"
+
+
+# ---------------------------------------------------------------------------
+# install() attaches to root logger
+# ---------------------------------------------------------------------------
+
+
+def test_install_attaches_to_root_logger():
+    import asyncio
+
+    from obs.log_buffer import LogBufferHandler
+
+    root = logging.getLogger()
+    before = len(root.handlers)
+
+    loop = asyncio.new_event_loop()
+    LogBufferHandler.install(loop, level=logging.INFO)
+
+    assert len(root.handlers) == before + 1
+    assert any(isinstance(h, LogBufferHandler) for h in root.handlers)
+
+    # Cleanup — remove handler we just added
+    for h in list(root.handlers):
+        if isinstance(h, LogBufferHandler):
+            root.removeHandler(h)
+    loop.close()
+
+
+# ---------------------------------------------------------------------------
+# _broadcast_nowait without WS manager must not raise
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_nowait_without_ws_manager_is_silent():
+    from obs.log_buffer import _broadcast_nowait
+
+    # No WS manager initialised — should silently return
+    _broadcast_nowait({"ts": "x", "level": "INFO", "logger": "test", "message": "x"})


### PR DESCRIPTION
## Zusammenfassung

Fügt einen **Log-Viewer** in die Admin-GUI ein, der Python-Applikationslogs in Echtzeit anzeigt — ohne SSH-Zugang zum Server.

Umsetzung wie in Issue #452 beschrieben, komplett minimal-invasiv auf Basis der bereits vorhandenen WebSocket-Infrastruktur.

---

## Was wurde implementiert

### Backend

**`obs/log_buffer.py`** (neu)
- `LogBufferHandler` hängt sich am Root-Logger ein und erfasst automatisch alle 20+ Module die `logging.getLogger(__name__)` nutzen
- `deque(maxlen=500)` als In-Memory-Puffer — kein Disk-I/O, keine neue Abhängigkeit, <100 KB RAM
- Jeder neue Log-Record wird per `call_soon_threadsafe` → `WebSocketManager.broadcast()` an alle verbundenen Clients gesendet (fire-and-forget, blockiert nie den Logging-Pfad)
- Kein WS-Send wenn kein Browser-Tab offen (`if not self._connections: return` greift bereits im bestehenden Manager)

**`obs/main.py`**
- `LogBufferHandler.install()` mit zwei Zeilen nach `basicConfig()` eingehängt

**`obs/api/v1/system.py`**
- `GET /api/v1/system/logs?level=WARNING&limit=200` — letzte N Einträge, optional nach Level gefiltert, neueste zuerst
- `PUT /api/v1/system/log-level` — Log-Level zur Laufzeit ändern ohne Neustart (Admin only)

### Frontend

**`gui/src/stores/websocket.js`** — `onLogEntry()` analog zum bestehenden `onRingbufferEntry()`-Muster

**`gui/src/api/client.js`** — `logsApi` mit `list()` und `setLevel()`

**`gui/src/views/LogView.vue`** (neu) — von `RingBufferView.vue` abgeleitet:
- Live-Badge (WebSocket connected/offline)
- Level-Filter-Dropdown (DEBUG / INFO / WARNING / ERROR / CRITICAL)
- Freitextsuche in Logger-Name und Meldung
- Farbige Level-Badges (INFO = blau, WARNING = gelb, ERROR = rot)
- Log-Level-Umschalter für Admins (ohne Neustart von INFO → DEBUG wechseln)

**Router + Sidebar** — Route `/logs` und Nav-Eintrag

### Tests

`tests/unit/test_log_buffer.py` — 7 Tests: Capture, Feldschema, Reihenfolge, deque-Eviction, Level-Filter, `install()`, Silent-No-Op ohne WS-Manager

---

## Geänderte Dateien

| Datei | Art |
|---|---|
| `obs/log_buffer.py` | neu |
| `obs/main.py` | +4 Zeilen |
| `obs/api/v1/system.py` | +2 Endpunkte, +2 Modelle |
| `tests/unit/test_log_buffer.py` | neu (7 Tests) |
| `gui/src/api/client.js` | +4 Zeilen |
| `gui/src/stores/websocket.js` | +12 Zeilen |
| `gui/src/views/LogView.vue` | neu |
| `gui/src/router/index.js` | +1 Zeile |
| `gui/src/components/layout/Sidebar.vue` | +1 Zeile |

---

## Getestet

Live auf einer Docker-Installation (MM12) deployed und verifiziert:
- Log-View öffnet sich, zeigt historische Einträge via REST
- Neue Einträge erscheinen live per WebSocket ohne Reload
- Level-Filter und Logger-Suche funktionieren clientseitig korrekt
- `PUT /log-level` wechselt den Level zur Laufzeit

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)