### PR TITLE
fix(iobroker): disable engineio built-in reconnect + filter spurious queue-empty ERROR

### DIFF
--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -47,6 +47,20 @@ from obs.core.transformation import apply_source_type, apply_value_map
 logger = logging.getLogger(__name__)
 
 
+class _EngineIOQueueFilter(logging.Filter):
+    """Suppresses the spurious 'packet queue is empty' ERROR from python-engineio.
+
+    When the server stops sending, the read loop times out and puts None into the
+    packet queue as a disconnect signal.  The write loop receives None, clears the
+    queue, but then loops back and waits again instead of exiting — after another
+    timeout it logs an ERROR 'packet queue is empty'.  This is an internal
+    clean-up artifact, not a real application error.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "packet queue is empty" not in record.getMessage()
+
+
 class IoBrokerAdapterConfig(BaseModel):
     host: str = "iobroker.local"
     port: int = 8084
@@ -166,6 +180,7 @@ class IoBrokerAdapter(AdapterBase):
             "engineio.client",
         ):
             logging.getLogger(noisy_logger).setLevel(logging.WARNING)
+        logging.getLogger("engineio.client").addFilter(_EngineIOQueueFilter())
 
         self._socketio = socketio
         self._cfg = IoBrokerAdapterConfig(**self._config)
@@ -298,7 +313,10 @@ class IoBrokerAdapter(AdapterBase):
 
     def _build_socket(self) -> Any:
         assert self._socketio is not None
-        sio = self._socketio.AsyncClient(reconnection=True, logger=False, engineio_logger=False)
+        # reconnection=False: OBS owns the full reconnect cycle via _reconnect_loop.
+        # Leaving reconnection=True would create a second parallel reconnect mechanism
+        # that races with _reconnect_loop and can produce double-connect attempts.
+        sio = self._socketio.AsyncClient(reconnection=False, logger=False, engineio_logger=False)
         self._register_socket_handlers(sio)
         return sio
 

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -12,7 +12,7 @@ import pytest
 
 from obs.core.event_bus import AdapterStatusEvent, DataValueEvent
 from tests.adapters.conftest import make_binding
-from obs.adapters.iobroker.adapter import IoBrokerAdapter, _coerce_iobroker_value
+from obs.adapters.iobroker.adapter import IoBrokerAdapter, _EngineIOQueueFilter, _coerce_iobroker_value
 
 
 @pytest.fixture
@@ -406,6 +406,31 @@ class TestBrowseStates:
         assert [item["id"] for item in result] == ["system.adapter.hue.0.alive"]
         assert adapter._socket.call.await_args_list[0].args[1][2]["startkey"] == "alive."
         assert adapter._socket.call.await_args_list[1].args[1][2]["startkey"] == ""
+
+
+class TestBuildSocket:
+    def test_reconnection_is_disabled(self, adapter):
+        mock_sio = MagicMock()
+        adapter._socketio = MagicMock()
+        adapter._socketio.AsyncClient = MagicMock(return_value=mock_sio)
+
+        adapter._build_socket()
+
+        adapter._socketio.AsyncClient.assert_called_once()
+        _, kwargs = adapter._socketio.AsyncClient.call_args
+        assert kwargs["reconnection"] is False
+
+    def test_engineio_queue_filter_passes_normal_messages(self):
+        f = _EngineIOQueueFilter()
+        record = MagicMock()
+        record.getMessage.return_value = "some other error"
+        assert f.filter(record) is True
+
+    def test_engineio_queue_filter_suppresses_queue_empty_error(self):
+        f = _EngineIOQueueFilter()
+        record = MagicMock()
+        record.getMessage.return_value = "packet queue is empty, aborting"
+        assert f.filter(record) is False
 
 
 class TestWrite:


### PR DESCRIPTION
## Problem

After an ioBroker disconnect two misleading symptoms appeared in the OBS logs:

1. **`ERROR engineio.client: packet queue is empty, aborting`** — this ERROR is a cascade artifact of a python-engineio internal bug.  When the server stops communicating, the read loop times out and puts `None` into the packet queue as a disconnect signal.  The write loop receives `None`, clears the queue buffer, but then **loops back and blocks again instead of exiting**.  On the next timeout it logs `ERROR packet queue is empty` — which looks like a real application error but is actually an internal clean-up race.

2. **Double reconnect attempts** — `AsyncClient(reconnection=True)` (the previous default) activates the python-socketio built-in retry loop, which races with OBS's own `_reconnect_loop`.  Both mechanisms fire independently after a disconnect and can produce simultaneous connect attempts.

## Fix

**Option 1 — filter the spurious ERROR:**  
Add `_EngineIOQueueFilter` on the `engineio.client` logger.  The filter suppresses only the specific "packet queue is empty" message; all other WARNING/ERROR output from engineio passes through unchanged.

**Option 3 — hand over reconnect control to OBS:**  
Change `reconnection=False` in `_build_socket()`.  OBS already has a complete, tested `_reconnect_loop` that owns the full reconnect cycle.  Disabling the library's built-in reconnect makes the architecture unambiguous: one mechanism, one path.

## Changes

- `obs/adapters/iobroker/adapter.py`
  - New module-level `_EngineIOQueueFilter` logging filter class
  - Install filter on `engineio.client` logger in `connect()` (once per adapter lifecycle, alongside the existing `setLevel` dampening)
  - `_build_socket()`: `reconnection=True` → `reconnection=False` (with explanatory comment)
- `tests/adapters/test_iobroker.py`
  - `TestBuildSocket::test_reconnection_is_disabled` — asserts the kwarg is `False`
  - `TestBuildSocket::test_engineio_queue_filter_passes_normal_messages`
  - `TestBuildSocket::test_engineio_queue_filter_suppresses_queue_empty_error`

## Test plan

- [x] All 28 ioBroker adapter unit tests pass (`pytest tests/adapters/test_iobroker.py`)
- [x] `ruff check` + `ruff format --check` pass clean
- [x] After deploying: ioBroker disconnect/reconnect cycle no longer produces `ERROR engineio.client` in the log viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)