### PR TITLE
[Codex] Harden LXC first-boot: generate per-container JWT secret and update docs

### DIFF
--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -418,6 +418,7 @@ jobs:
           set -euo pipefail
 
           MQTT_PASSWORD=$(python3 -c "import secrets, string; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))")
+          JWT_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(48))")
 
           mosquitto_passwd -c -b /etc/mosquitto/passwd obs "$MQTT_PASSWORD"
           chmod 640 /etc/mosquitto/passwd
@@ -432,6 +433,7 @@ jobs:
           OBS_MOSQUITTO__RELOAD_COMMAND=systemctl reload mosquitto
           OBS_MOSQUITTO__SERVICE_USERNAME=obs
           OBS_MOSQUITTO__SERVICE_PASSWORD=$MQTT_PASSWORD
+          OBS_SECURITY__JWT_SECRET=$JWT_SECRET
           EOF
           FIRSTBOOT
           chmod +x /opt/obs/obs-first-boot.sh

--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ Das LXC-Template enthält ein vollständiges Ubuntu 26.04-System mit **open brid
 **Standardzugang:** Benutzername `admin`, Passwort `admin`
 ⚠️ Das Passwort sofort nach der ersten Anmeldung ändern (Einstellungen → Passwort).
 
-**Konfiguration anpassen** (optional):
+**Sicherheitskonfiguration** (erforderlich):
 
 ```bash
 # Umgebungsvariablen in /etc/obs.env setzen, z. B.:
 OBS_MQTT__HOST=192.168.1.10
-OBS_SECURITY__JWT_SECRET=mein-geheimes-passwort
+# Wird im LXC-Template automatisch beim ersten Start gesetzt (zufällig, pro Container).
+# Nur bei manuellem Override setzen:
+OBS_SECURITY__JWT_SECRET=<mindestens-32-zufällige-zeichen>
 
 # Dienst neu starten
 systemctl restart obs


### PR DESCRIPTION
### Motivation
- Prevent LXC-deployed instances from using the public default JWT secret (`changeme`) which allows forged admin tokens when the service is network-reachable. 
- Ensure the LXC template produces a unique per-deployment `OBS_SECURITY__JWT_SECRET` so the service does not start with a weak default.

### Description
- Generate a random JWT secret during first-boot by adding `JWT_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(48))")` to the `obs-first-boot.sh` creation in `.github/workflows/lxc-template.yml`.
- Persist the generated value into the environment file by appending `OBS_SECURITY__JWT_SECRET=$JWT_SECRET` to `/etc/obs.env` in the LXC first-boot flow. 
- Update the Proxmox LXC quickstart in `README.md` to mark security configuration as required and document that the JWT secret is auto-generated on first boot with guidance for manual overrides.

### Testing
- Verified the template script now contains `JWT_SECRET` generation and that `OBS_SECURITY__JWT_SECRET` is written into the first-boot environment block using repository search (`rg`) and file inspection, and the checks succeeded. 
- Confirmed the `README.md` text was updated to show `Sicherheitskonfiguration` and the auto-generation guidance via direct file inspection. 
- No unit tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036829278083298ac89ebcf0cf57e5)
