### PR TITLE
[Codex] fix(auth): require admin for datapoint and logic mutations

### DIFF
--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -17,7 +17,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, field_serializer
 
-from obs.api.auth import get_current_user, optional_current_user
+from obs.api.auth import get_admin_user, get_current_user, optional_current_user
 from obs.api.v1.sessions import validate_session
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -139,7 +139,7 @@ async def list_datapoints(
 @router.post("/", response_model=DataPointOut, status_code=status.HTTP_201_CREATED)
 async def create_datapoint(
     body: DataPointCreate,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
 ) -> DataPointOut:
     from obs.models.types import DataTypeRegistry
 
@@ -168,7 +168,7 @@ async def get_datapoint(
 async def update_datapoint(
     dp_id: uuid.UUID,
     body: DataPointUpdate,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
 ) -> DataPointOut:
     reg = get_registry()
     if reg.get(dp_id) is None:
@@ -188,7 +188,7 @@ async def update_datapoint(
 @router.delete("/{dp_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_datapoint(
     dp_id: uuid.UUID,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
 ) -> None:
     reg = get_registry()
     if reg.get(dp_id) is None:

--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
-from obs.api.auth import get_current_user
+from obs.api.auth import get_admin_user, get_current_user
 from obs.db.database import Database, get_db
 from obs.logic.models import (
     FlowData,
@@ -69,7 +69,7 @@ async def list_graphs(
 @router.post("/graphs", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def create_graph(
     body: LogicGraphCreate,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -114,7 +114,7 @@ async def get_graph(
 async def update_graph_full(
     graph_id: str,
     body: LogicGraphCreate,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -150,7 +150,7 @@ async def update_graph_full(
 async def update_graph_partial(
     graph_id: str,
     body: LogicGraphUpdate,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -184,7 +184,7 @@ async def update_graph_partial(
 @router.delete("/graphs/{graph_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> None:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -202,7 +202,7 @@ async def delete_graph(
 @router.post("/graphs/import", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def import_graph(
     body: LogicGraphImport,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     if body.obs_export != "logic_graph":
@@ -276,7 +276,7 @@ async def import_graph(
 @router.post("/graphs/{graph_id}/run", status_code=status.HTTP_200_OK)
 async def run_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> dict:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -298,7 +298,7 @@ async def run_graph(
 )
 async def duplicate_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _admin: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     row = await db.fetchone("SELECT * FROM logic_graphs WHERE id=?", (graph_id,))


### PR DESCRIPTION
### Motivation
- Fix a privilege-escalation regression where legacy non-admin `demo/demo` accounts could reach privileged GUI routes and call backend mutation endpoints that only required any authenticated user.  
- Ensure authorization is enforced server-side so frontend containment removal cannot unlock create/update/delete/run actions for non-admin users.  

### Description
- Require the `get_admin_user` dependency for datapoint mutation endpoints (`POST /api/v1/datapoints/`, `PATCH /api/v1/datapoints/{id}`, `DELETE /api/v1/datapoints/{id}`) by importing `get_admin_user` in `obs/api/v1/datapoints.py` and switching those endpoints to depend on it.  
- Require the `get_admin_user` dependency for logic mutation/execution endpoints (`POST /api/v1/logic/graphs`, `PUT/PATCH /api/v1/logic/graphs/{id}`, `DELETE /api/v1/logic/graphs/{id}`, `POST /api/v1/logic/graphs/import`, `POST /api/v1/logic/graphs/{id}/run`, `POST /api/v1/logic/graphs/{id}/duplicate`) by importing `get_admin_user` in `obs/api/v1/logic.py` and switching those endpoints to depend on it.  
- Preserve existing authenticated read behavior by leaving list/get/export endpoints using `get_current_user` or `optional_current_user`.  
- Committed the change with the message `fix(auth): restrict datapoint and logic mutations to admins`.  

### Testing
- Ran `pytest -q tests/integration/test_auth.py tests/integration/test_datapoints.py tests/integration/test_duplication.py` to validate auth/datapoints/logic flows, but the run failed to start due to a missing test dependency: `ModuleNotFoundError: No module named 'pytest_asyncio'`.  
- Verified the code modifications and diffs (`git diff`) and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037c9d53948329841ebbe6e14f5e21)
