### PR TITLE
[Codex] Scope datapoint writes to referenced PAGE widgets

### DIFF
--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -11,6 +11,7 @@ POST   /api/v1/datapoints/{id}/value write value (fires DataValueEvent)
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -229,6 +230,26 @@ async def _resolve_page_access(db: Database, node_id: str) -> str:
     return "public"
 
 
+async def _page_allows_datapoint(db: Database, page_id: str, dp_id: uuid.UUID) -> bool:
+    """Return True iff page_id is a PAGE node and references dp_id in its widgets."""
+    row = await db.fetchone("SELECT type, page_config FROM visu_nodes WHERE id = ?", (page_id,))
+    if not row or row["type"] != "PAGE":
+        return False
+    page_config_raw = row["page_config"]
+    if not page_config_raw:
+        return False
+    try:
+        page_config = json.loads(page_config_raw)
+    except json.JSONDecodeError:
+        return False
+
+    dp_id_str = str(dp_id)
+    for widget in page_config.get("widgets", []):
+        if widget.get("datapoint_id") == dp_id_str or widget.get("status_datapoint_id") == dp_id_str:
+            return True
+    return False
+
+
 @router.post("/{dp_id}/value", status_code=status.HTTP_204_NO_CONTENT)
 async def write_value(
     dp_id: uuid.UUID,
@@ -270,6 +291,9 @@ async def write_value(
                 raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Valid session token required")
         else:  # user, unbekannt oder sonstige → 401
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+
+        if not await _page_allows_datapoint(db, page_id, dp_id):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Datapoint not available on page")
     else:
         # Benutzer ist eingeloggt — prüfe ob er Zugang zur Seite hat
         page_id = request.headers.get("X-Page-Id")


### PR DESCRIPTION
### Motivation

- The write path previously authorized unauthenticated writes solely from the effective access level resolved from `X-Page-Id`, allowing a public/protected page id to be reused to write arbitrary known datapoint IDs.  
- The intent is to bind page-context authorization to the actual page and the datapoints it exposes so that a page header cannot act as a bearer capability for unrelated datapoints.

### Description

- Added `import json` and a new helper `async def _page_allows_datapoint(db: Database, page_id: str, dp_id: uuid.UUID) -> bool` that verifies the `page_id` is a `PAGE` node, loads its `page_config`, and checks `widgets[*].datapoint_id` and `widgets[*].status_datapoint_id` for the target datapoint UUID.  
- Enforced the page-membership check in the unauthenticated write branch of `POST /api/v1/datapoints/{dp_id}/value` so that after access/session checks a missing membership results in `HTTP 403` instead of allowing the write.  
- The change is limited to `obs/api/v1/datapoints.py` and preserves the existing access rules (JWT/JWT-user checks unchanged) while preventing page-context abuse.

### Testing

- Ran `python -m compileall obs/api/v1/datapoints.py` and it succeeded.  
- Ran `pytest -q tests/integration/test_datapoints.py` in this environment and it could not complete due to a missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0393717d9c83298cb17f449549eb4b)
