### PR TITLE
[Codex] fix(api): require admin or page-scoped auth for datapoint writes

### DIFF
--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -253,33 +253,30 @@ async def write_value(
     if reg.get(dp_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
 
-    if user is None:
-        page_id = request.headers.get("X-Page-Id")
-        if not page_id:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-
+    page_id = request.headers.get("X-Page-Id")
+    if page_id:
         access = await _resolve_page_access(db, page_id)
-
         if access == "readonly":
             raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Page is read-only")
-        if access == "public":
-            pass  # Erlaubt — keine weitere Prüfung nötig
-        elif access == "protected":
+        if access == "protected":
             session_token = request.headers.get("X-Session-Token")
             if not session_token or not validate_session(session_token, page_id):
                 raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Valid session token required")
-        else:  # user, unbekannt oder sonstige → 401
+        elif access == "user":
+            if user is None:
+                raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+            from obs.api.v1.visu import _check_user_access
+
+            if not await _check_user_access(db, page_id, user):
+                raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Zugriff verweigert")
+        elif access not in ("public",):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
     else:
-        # Benutzer ist eingeloggt — prüfe ob er Zugang zur Seite hat
-        page_id = request.headers.get("X-Page-Id")
-        if page_id:
-            access = await _resolve_page_access(db, page_id)
-            if access == "user":
-                from obs.api.v1.visu import _check_user_access
-
-                if not await _check_user_access(db, page_id, user):
-                    raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Zugriff verweigert")
+        if user is None:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+        row = await db.fetchone("SELECT is_admin FROM users WHERE username=?", (user,))
+        if not row or not row["is_admin"]:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Admin access required")
 
     event = DataValueEvent(
         datapoint_id=dp_id,


### PR DESCRIPTION
### Motivation
- The `POST /api/v1/datapoints/{dp_id}/value` endpoint allowed any authenticated bearer token or API key to publish `DataValueEvent`s and thus actuate writable bindings without page- or admin-level authorization, enabling low-privilege actuation of devices.
- The intent is to preserve visualization-driven writes while preventing arbitrary API-key/JWT-based device writes that bypass page access controls and admin checks.

### Description
- Hardened `obs/api/v1/datapoints.py` `write_value` handler to centralize authorization around the `X-Page-Id` header and page access model.`
- Enforced `readonly` pages to return `403`, validated `protected` pages via `X-Session-Token`, and required authenticated user + `_check_user_access` for `user` pages while allowing `public` pages.
- Added an explicit admin check for requests without a `X-Page-Id` context so that direct API writes require a user with `is_admin=1` and non-admin API key/JWT callers are denied.
- Preserved the existing `DataValueEvent` creation and `get_event_bus().publish(...)` behavior when authorization succeeds to keep downstream write routing unchanged.

### Testing
- Ran `python -m compileall -q obs/api/v1/datapoints.py`, which succeeded.
- Attempted `pytest -q tests/integration/test_datapoints.py -k value`, which failed in this environment due to a missing test dependency (`pytest_asyncio`).
- File modified: `obs/api/v1/datapoints.py` with authorization logic adjustments as described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038f3d8d8083299b36a250759415af)
