### PR TITLE
feat: Hierarchy display depth, full-path tooltip, tree filter and drill-down (#443)

### DIFF
--- a/gui/src/components/HierarchyManager.vue
+++ b/gui/src/components/HierarchyManager.vue
@@ -42,7 +42,11 @@
           <svg class="w-4 h-4 text-blue-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h12M3 17h8"/>
           </svg>
-          <span class="font-semibold text-sm text-slate-800 dark:text-slate-100 flex-1">{{ tree.name }}</span>
+          <span
+            @click="toggleTree(tree.id)"
+            class="font-semibold text-sm text-slate-800 dark:text-slate-100 flex-1 cursor-pointer hover:text-blue-500 dark:hover:text-blue-400 transition-colors select-none">
+            {{ tree.name }}
+          </span>
           <span v-if="tree.description" class="text-xs text-slate-400 hidden sm:block">{{ tree.description }}</span>
           <button @click="toggleTree(tree.id)" class="btn-secondary btn-xs" :data-testid="`btn-expand-${tree.id}`">
             <svg class="w-3 h-3 transition-transform" :class="expandedTrees.has(tree.id) ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/gui/src/components/HierarchyManager.vue
+++ b/gui/src/components/HierarchyManager.vue
@@ -100,6 +100,17 @@
           <label class="label">Beschreibung</label>
           <input v-model="treeModal.description" type="text" class="input" placeholder="Optional" @keydown.enter="saveTree" />
         </div>
+        <div class="form-group">
+          <label class="label">Anzeigestart-Ebene</label>
+          <select v-model="treeModal.display_depth" class="input text-sm">
+            <option :value="0">0 — Ast-Name (Standard, z.B. "Gebäude")</option>
+            <option :value="1">1 — Erste Ebene (z.B. "EG" statt "Gebäude")</option>
+            <option :value="2">2 — Zweite Ebene (z.B. "Wohnzimmer")</option>
+            <option :value="3">3 — Dritte Ebene</option>
+            <option :value="4">4 — Vierte Ebene</option>
+          </select>
+          <p class="text-xs text-slate-500 mt-1">Bestimmt, welche Ebene im verkürzten Pfad-Tag angezeigt wird. Der vollständige Pfad ist stets als Tooltip sichtbar.</p>
+        </div>
         <div v-if="treeModal.msg" :class="['p-2 rounded text-sm', treeModal.msg.ok ? 'text-green-400' : 'text-red-400']">{{ treeModal.msg.text }}</div>
         <div class="flex gap-2 justify-end">
           <button @click="treeModal.open = false" class="btn-secondary">Abbrechen</button>
@@ -238,7 +249,7 @@ const msg         = ref(null)
 const treeNameInput = ref(null)
 const nodeNameInput = ref(null)
 
-const treeModal = reactive({ open: false, isEdit: false, id: null, name: '', description: '', saving: false, msg: null })
+const treeModal = reactive({ open: false, isEdit: false, id: null, name: '', description: '', display_depth: 0, saving: false, msg: null })
 const nodeModal = reactive({ open: false, isEdit: false, id: null, treeId: null, parentId: null, name: '', description: '', saving: false, msg: null })
 const etsModal  = reactive({ open: false, treeName: '', mode: 'groups', autoLink: true, saving: false, msg: null })
 
@@ -287,12 +298,12 @@ function toggleTree(treeId) {
 // ── Tree CRUD ──────────────────────────────────────────────────────────────
 
 function openCreateTree() {
-  Object.assign(treeModal, { open: true, isEdit: false, id: null, name: '', description: '', saving: false, msg: null })
+  Object.assign(treeModal, { open: true, isEdit: false, id: null, name: '', description: '', display_depth: 0, saving: false, msg: null })
   nextTick(() => treeNameInput.value?.focus())
 }
 
 function openEditTree(tree) {
-  Object.assign(treeModal, { open: true, isEdit: true, id: tree.id, name: tree.name, description: tree.description, saving: false, msg: null })
+  Object.assign(treeModal, { open: true, isEdit: true, id: tree.id, name: tree.name, description: tree.description, display_depth: tree.display_depth ?? 0, saving: false, msg: null })
   nextTick(() => treeNameInput.value?.focus())
 }
 
@@ -302,9 +313,9 @@ async function saveTree() {
   treeModal.msg = null
   try {
     if (treeModal.isEdit) {
-      await hierarchyApi.updateTree(treeModal.id, { name: treeModal.name, description: treeModal.description })
+      await hierarchyApi.updateTree(treeModal.id, { name: treeModal.name, description: treeModal.description, display_depth: treeModal.display_depth })
     } else {
-      await hierarchyApi.createTree({ name: treeModal.name, description: treeModal.description })
+      await hierarchyApi.createTree({ name: treeModal.name, description: treeModal.description, display_depth: treeModal.display_depth })
     }
     treeModal.open = false
     await loadTrees()

--- a/gui/src/components/HierarchyNodeTree.vue
+++ b/gui/src/components/HierarchyNodeTree.vue
@@ -20,7 +20,12 @@
         <svg class="w-3.5 h-3.5 text-slate-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h12M3 17h8"/>
         </svg>
-        <span class="text-sm text-slate-700 dark:text-slate-200 flex-1 truncate">{{ node.name }}</span>
+        <span
+          @click="node.children?.length && toggleExpand(node.id)"
+          :class="['text-sm text-slate-700 dark:text-slate-200 flex-1 truncate select-none',
+            node.children?.length ? 'cursor-pointer hover:text-blue-500 dark:hover:text-blue-400 transition-colors' : '']">
+          {{ node.name }}
+        </span>
         <span v-if="node.description" class="text-xs text-slate-400 hidden lg:block truncate max-w-24">{{ node.description }}</span>
 
         <!-- ── Reihenfolge ↑↓ (hover) ── -->

--- a/gui/src/components/datapoints/DataPointHierarchyCard.vue
+++ b/gui/src/components/datapoints/DataPointHierarchyCard.vue
@@ -13,8 +13,15 @@
       <div v-else class="flex flex-wrap gap-2">
         <div
           v-for="ref in linked" :key="ref.link_id"
-          class="flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full text-xs font-medium bg-blue-500/10 text-blue-700 dark:text-blue-300 border border-blue-500/20">
+          class="flex items-center gap-1 pl-2.5 pr-1.5 py-1 rounded-full text-xs font-medium bg-blue-500/10 text-blue-700 dark:text-blue-300 border border-blue-500/20"
+          :title="nodeFullPath(ref)">
           <span class="text-blue-400 dark:text-blue-500 font-normal">{{ ref.tree_name }}</span>
+          <template v-for="seg in (ref.node_path || [])" :key="seg.node_id">
+            <svg class="w-2 h-2 text-blue-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+            <span class="text-blue-500 dark:text-blue-400 font-normal">{{ seg.node_name }}</span>
+          </template>
           <svg class="w-2.5 h-2.5 text-blue-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
           </svg>
@@ -164,6 +171,11 @@ async function removeLink(ref) {
 }
 
 // ── Utils ─────────────────────────────────────────────────────────────────
+
+function nodeFullPath(ref) {
+  const parts = [ref.tree_name, ...(ref.node_path || []).map(n => n.node_name), ref.node_name]
+  return parts.join(' › ')
+}
 
 function showFeedback(text, ok) {
   feedback.value = { text, ok }

--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -119,20 +119,18 @@
           </button>
         </div>
 
-        <!-- Hierarchieknoten-Filter (Multi-Select mit Suche) -->
+        <!-- Hierarchieknoten-Filter (Multi-Select mit Suche, inkl. Baum-Filter) -->
         <div class="relative" ref="nodeFilterRef" data-testid="node-filter">
           <button
             @click="nodeDropOpen = !nodeDropOpen"
             :class="['input text-sm flex items-center gap-1.5 cursor-pointer select-none min-w-44',
-              filters.node_ids.length ? 'border-blue-500 bg-blue-500/5' : '']">
+              (filters.node_ids.length || filters.tree_ids.length) ? 'border-blue-500 bg-blue-500/5' : '']">
             <svg class="w-3.5 h-3.5 text-slate-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h12M3 17h8"/>
             </svg>
-            <span v-if="!filters.node_ids.length" class="text-slate-400 flex-1 text-left">Hierarchieknoten …</span>
+            <span v-if="!filters.node_ids.length && !filters.tree_ids.length" class="text-slate-400 flex-1 text-left">Hierarchieknoten …</span>
             <span v-else class="text-blue-600 dark:text-blue-400 font-medium flex-1 text-left text-xs truncate">
-              {{ filters.node_ids.length === 1
-                ? `${filters.node_ids[0].tree_name} › ${filters.node_ids[0].node_name}`
-                : `${filters.node_ids.length} Knoten` }}
+              {{ hierarchyFilterLabel }}
             </span>
             <svg class="w-3 h-3 text-slate-400 shrink-0 transition-transform" :class="nodeDropOpen ? 'rotate-180' : ''"
               fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -157,10 +155,26 @@
               />
             </div>
 
-            <!-- Currently selected nodes (shown when no search text) -->
-            <div v-if="filters.node_ids.length && !nodeSearchQ"
+            <!-- Currently selected trees + nodes (shown when no search text) -->
+            <div v-if="(filters.tree_ids.length || filters.node_ids.length) && !nodeSearchQ"
               class="border-b border-slate-100 dark:border-slate-700">
               <div class="px-3 py-1 text-xs text-slate-400 font-medium uppercase tracking-wide">Ausgewählt</div>
+              <!-- Selected trees -->
+              <button v-for="t in filters.tree_ids" :key="t.tree_id"
+                @click="toggleTreeFilter(t)"
+                class="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors">
+                <span class="flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center bg-blue-500 border-blue-500">
+                  <svg class="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/>
+                  </svg>
+                </span>
+                <svg class="w-3 h-3 text-blue-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h12M3 17h8"/>
+                </svg>
+                <span class="text-blue-600 dark:text-blue-400 font-medium truncate">{{ t.tree_name }}</span>
+                <span class="text-xs text-slate-400 ml-auto shrink-0">Ganzer Ast</span>
+              </button>
+              <!-- Selected nodes -->
               <button v-for="n in filters.node_ids" :key="n.node_id"
                 @click="toggleNode(n)"
                 class="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors">
@@ -200,31 +214,14 @@
               </button>
             </div>
 
-            <div v-if="filters.node_ids.length" class="border-t border-slate-100 dark:border-slate-700 p-1.5">
-              <button @click="clearFilter('node_ids')"
+            <div v-if="filters.node_ids.length || filters.tree_ids.length" class="border-t border-slate-100 dark:border-slate-700 p-1.5">
+              <button @click="clearHierarchyFilters"
                 class="w-full text-xs text-center text-slate-500 hover:text-red-500 transition-colors py-1">
                 Auswahl aufheben
               </button>
             </div>
           </div>
         </div>
-
-        <!-- Aktive Baum-Filter als Chips -->
-        <template v-if="filters.tree_ids.length">
-          <span
-            v-for="t in filters.tree_ids" :key="t.tree_id"
-            class="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border border-blue-500 bg-blue-500/10 text-blue-600 dark:text-blue-400">
-            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h12M3 17h8"/>
-            </svg>
-            {{ t.tree_name }}
-            <button @click="toggleTreeFilter(t)" class="ml-0.5 hover:text-red-500 transition-colors" title="Baum-Filter entfernen">
-              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-              </svg>
-            </button>
-          </span>
-        </template>
 
         <!-- Aktive Filter: Alle zurücksetzen -->
         <button v-if="hasActiveFilters" @click="clearAllFilters"
@@ -438,6 +435,18 @@ const hasActiveFilters = computed(() =>
   !!(filters.value.q || filters.value.tags.length || filters.value.quality || filters.value.type || filters.value.node_ids.length || filters.value.tree_ids.length)
 )
 
+const hierarchyFilterLabel = computed(() => {
+  const trees = filters.value.tree_ids
+  const nodes = filters.value.node_ids
+  const total = trees.length + nodes.length
+  if (total === 0) return ''
+  if (total === 1) {
+    if (trees.length === 1) return trees[0].tree_name
+    return `${nodes[0].tree_name} › ${nodes[0].node_name}`
+  }
+  return `${total} Filter`
+})
+
 // --------------------------------------------------------------------------
 // Lifecycle
 // --------------------------------------------------------------------------
@@ -565,6 +574,18 @@ function clearFilter(key) {
 
 function clearAllFilters() {
   filters.value = { q: '', tags: [], quality: '', type: '', node_ids: [], tree_ids: [] }
+  nodeSearchQ.value = ''
+  nodeResults.value = []
+  onSearch()
+}
+
+// --------------------------------------------------------------------------
+// Hierarchy (tree + node) filter helpers
+// --------------------------------------------------------------------------
+
+function clearHierarchyFilters() {
+  filters.value.node_ids = []
+  filters.value.tree_ids = []
   nodeSearchQ.value = ''
   nodeResults.value = []
   onSearch()

--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -254,21 +254,38 @@
                   {{ dp.name }}
                 </RouterLink>
                 <div v-if="dp.hierarchy_nodes?.length" class="flex flex-wrap gap-1 mt-1">
-                  <button
+                  <span
                     v-for="ref in dp.hierarchy_nodes"
                     :key="ref.node_id"
-                    @click.prevent="toggleNode({ node_id: ref.node_id, node_name: ref.node_name, tree_name: ref.tree_name })"
-                    :class="['inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs transition-colors',
-                      isNodeSelected(ref.node_id)
+                    :class="['inline-flex items-center gap-0.5 rounded text-xs transition-colors',
+                      isNodeSelected(ref.node_id) || isAncestorSelected(ref)
                         ? 'bg-blue-500/20 text-blue-600 dark:text-blue-300'
-                        : 'bg-slate-100 dark:bg-slate-700/60 text-slate-500 hover:bg-blue-500/10 hover:text-blue-500']"
-                    :title="`${isNodeSelected(ref.node_id) ? 'Filter entfernen' : 'Nach'} ${ref.tree_name} › ${ref.node_name} filtern`">
-                    <span class="opacity-70">{{ ref.tree_name }}</span>
-                    <svg class="w-2.5 h-2.5 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        : 'bg-slate-100 dark:bg-slate-700/60 text-slate-500']"
+                    :title="hierarchyFullPath(ref)">
+                    <!-- Anzeige-Start: Tree-Name oder konfigurierbarer Ancestor -->
+                    <span
+                      v-if="hierarchyDisplayAncestor(ref)"
+                      @click.prevent="toggleNode({ node_id: hierarchyDisplayAncestor(ref).node_id, node_name: hierarchyDisplayAncestor(ref).node_name, tree_name: ref.tree_name })"
+                      :class="['opacity-70 px-1.5 py-0.5 rounded-l cursor-pointer hover:bg-blue-500/20 hover:opacity-100 transition-colors',
+                        isNodeSelected(hierarchyDisplayAncestor(ref).node_id) ? 'opacity-100' : '']">
+                      {{ hierarchyDisplayAncestor(ref).node_name }}
+                    </span>
+                    <span
+                      v-else
+                      class="opacity-70 px-1.5 py-0.5 rounded-l">
+                      {{ ref.tree_name }}
+                    </span>
+                    <svg class="w-2.5 h-2.5 opacity-50 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                     </svg>
-                    <span>{{ ref.node_name }}</span>
-                  </button>
+                    <!-- Blatt-Knoten -->
+                    <span
+                      @click.prevent="toggleNode({ node_id: ref.node_id, node_name: ref.node_name, tree_name: ref.tree_name })"
+                      :class="['px-1.5 py-0.5 rounded-r cursor-pointer hover:bg-blue-500/20 transition-colors',
+                        isNodeSelected(ref.node_id) ? 'font-medium' : '']">
+                      {{ ref.node_name }}
+                    </span>
+                  </span>
                 </div>
               </td>
 
@@ -582,6 +599,26 @@ async function onSave(payload) {
 
 function confirmDelete(dp) { deleteTarget.value = dp; showConfirm.value = true }
 async function doDelete()  { await store.remove(deleteTarget.value.id) }
+
+// --------------------------------------------------------------------------
+// Hierarchy path helpers
+// --------------------------------------------------------------------------
+
+function hierarchyFullPath(ref) {
+  const parts = [ref.tree_name, ...(ref.node_path || []).map(n => n.node_name), ref.node_name]
+  return parts.join(' › ')
+}
+
+function hierarchyDisplayAncestor(ref) {
+  if (!ref.display_depth || ref.display_depth === 0) return null
+  const idx = ref.display_depth - 1
+  return ref.node_path?.[idx] ?? null
+}
+
+function isAncestorSelected(ref) {
+  const ancestor = hierarchyDisplayAncestor(ref)
+  return ancestor ? isNodeSelected(ancestor.node_id) : false
+}
 
 // --------------------------------------------------------------------------
 // Live value helpers

--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -209,6 +209,23 @@
           </div>
         </div>
 
+        <!-- Aktive Baum-Filter als Chips -->
+        <template v-if="filters.tree_ids.length">
+          <span
+            v-for="t in filters.tree_ids" :key="t.tree_id"
+            class="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border border-blue-500 bg-blue-500/10 text-blue-600 dark:text-blue-400">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h12M3 17h8"/>
+            </svg>
+            {{ t.tree_name }}
+            <button @click="toggleTreeFilter(t)" class="ml-0.5 hover:text-red-500 transition-colors" title="Baum-Filter entfernen">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+              </svg>
+            </button>
+          </span>
+        </template>
+
         <!-- Aktive Filter: Alle zurücksetzen -->
         <button v-if="hasActiveFilters" @click="clearAllFilters"
           class="text-xs text-slate-500 hover:text-red-500 dark:hover:text-red-400 transition-colors ml-auto flex items-center gap-1"
@@ -272,7 +289,9 @@
                     </span>
                     <span
                       v-else
-                      class="opacity-70 px-1.5 py-0.5 rounded-l">
+                      @click.prevent="toggleTreeFilter({ tree_id: ref.tree_id, tree_name: ref.tree_name })"
+                      :class="['opacity-70 px-1.5 py-0.5 rounded-l cursor-pointer hover:bg-blue-500/20 hover:opacity-100 transition-colors',
+                        isTreeSelected(ref.tree_id) ? 'opacity-100' : '']">
                       {{ ref.tree_name }}
                     </span>
                     <svg class="w-2.5 h-2.5 opacity-50 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -394,7 +413,7 @@ const qualityOptions = [
 const store = useDatapointStore()
 const ws    = useWebSocketStore()
 
-const filters      = ref({ q: '', tags: [], quality: '', type: '', node_ids: [] })
+const filters      = ref({ q: '', tags: [], quality: '', type: '', node_ids: [], tree_ids: [] })
 const showForm     = ref(false)
 const showConfirm  = ref(false)
 const editTarget   = ref(null)
@@ -416,7 +435,7 @@ let observer      = null
 let unsubWs       = null
 
 const hasActiveFilters = computed(() =>
-  !!(filters.value.q || filters.value.tags.length || filters.value.quality || filters.value.type || filters.value.node_ids.length)
+  !!(filters.value.q || filters.value.tags.length || filters.value.quality || filters.value.type || filters.value.node_ids.length || filters.value.tree_ids.length)
 )
 
 // --------------------------------------------------------------------------
@@ -432,6 +451,7 @@ onMounted(async () => {
       ...saved.filters,
       tags:     saved.filters?.tags     ?? [],
       node_ids: saved.filters?.node_ids ?? [],
+      tree_ids: saved.filters?.tree_ids ?? [],
     })
     store.clearScrollState()
     await store.search(apiFilters(), false)
@@ -500,6 +520,7 @@ function apiFilters() {
     quality: filters.value.quality,
     type:    filters.value.type,
     node_id: filters.value.node_ids.map(n => n.node_id).join(','),
+    tree_id: filters.value.tree_ids.map(t => t.tree_id).join(','),
   }
 }
 
@@ -532,6 +553,8 @@ function clearFilter(key) {
     filters.value.node_ids = []
     nodeSearchQ.value = ''
     nodeResults.value = []
+  } else if (key === 'tree_ids') {
+    filters.value.tree_ids = []
   } else if (key === 'tags') {
     filters.value.tags = []
   } else {
@@ -541,9 +564,24 @@ function clearFilter(key) {
 }
 
 function clearAllFilters() {
-  filters.value = { q: '', tags: [], quality: '', type: '', node_ids: [] }
+  filters.value = { q: '', tags: [], quality: '', type: '', node_ids: [], tree_ids: [] }
   nodeSearchQ.value = ''
   nodeResults.value = []
+  onSearch()
+}
+
+// --------------------------------------------------------------------------
+// Tree filter
+// --------------------------------------------------------------------------
+
+function isTreeSelected(tree_id) {
+  return filters.value.tree_ids.some(t => t.tree_id === tree_id)
+}
+
+function toggleTreeFilter(tree) {
+  const idx = filters.value.tree_ids.findIndex(t => t.tree_id === tree.tree_id)
+  if (idx === -1) filters.value.tree_ids.push({ tree_id: tree.tree_id, tree_name: tree.tree_name })
+  else filters.value.tree_ids.splice(idx, 1)
   onSearch()
 }
 

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -31,11 +31,18 @@ router = APIRouter(tags=["datapoints"])
 # ---------------------------------------------------------------------------
 
 
+class NodePathSegment(BaseModel):
+    node_id: str
+    node_name: str
+
+
 class HierarchyNodeRef(BaseModel):
     node_id: str
     node_name: str
     tree_id: str
     tree_name: str
+    node_path: list[NodePathSegment] = []
+    display_depth: int = 0
 
 
 class DataPointOut(BaseModel):

--- a/obs/api/v1/hierarchy.py
+++ b/obs/api/v1/hierarchy.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from obs.api.auth import get_current_user
+from obs.api.v1.datapoints import NodePathSegment
 from obs.db.database import Database, get_db
 
 router = APIRouter(tags=["hierarchy"])
@@ -57,6 +58,7 @@ class HierarchyTree(BaseModel):
     id: str
     name: str
     description: str
+    display_depth: int
     created_at: str
     updated_at: str
 
@@ -64,11 +66,13 @@ class HierarchyTree(BaseModel):
 class HierarchyTreeCreate(BaseModel):
     name: str
     description: str = ""
+    display_depth: int = 0
 
 
 class HierarchyTreeUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
+    display_depth: int | None = None
 
 
 class HierarchyNode(BaseModel):
@@ -129,6 +133,7 @@ class NodeRef(BaseModel):
     node_name: str
     tree_id: str
     tree_name: str
+    node_path: list[NodePathSegment] = []
 
 
 class NodeSearchResult(BaseModel):
@@ -162,6 +167,7 @@ def _row_to_tree(row: Any) -> HierarchyTree:
         id=row["id"],
         name=row["name"],
         description=row["description"],
+        display_depth=row["display_depth"] if row["display_depth"] is not None else 0,
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -220,8 +226,8 @@ async def create_tree(
     now = _now()
     tid = _new_id()
     await db.execute_and_commit(
-        "INSERT INTO hierarchy_trees (id, name, description, created_at, updated_at) VALUES (?,?,?,?,?)",
-        (tid, body.name, body.description, now, now),
+        "INSERT INTO hierarchy_trees (id, name, description, display_depth, created_at, updated_at) VALUES (?,?,?,?,?,?)",
+        (tid, body.name, body.description, body.display_depth, now, now),
     )
     row = await db.fetchone("SELECT * FROM hierarchy_trees WHERE id=?", (tid,))
     return _row_to_tree(row)
@@ -239,10 +245,11 @@ async def update_tree(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Hierarchiebaum nicht gefunden")
     name = body.name if body.name is not None else row["name"]
     desc = body.description if body.description is not None else row["description"]
+    depth = body.display_depth if body.display_depth is not None else (row["display_depth"] or 0)
     now = _now()
     await db.execute_and_commit(
-        "UPDATE hierarchy_trees SET name=?, description=?, updated_at=? WHERE id=?",
-        (name, desc, now, tree_id),
+        "UPDATE hierarchy_trees SET name=?, description=?, display_depth=?, updated_at=? WHERE id=?",
+        (name, desc, depth, now, tree_id),
     )
     row = await db.fetchone("SELECT * FROM hierarchy_trees WHERE id=?", (tree_id,))
     return _row_to_tree(row)
@@ -425,6 +432,26 @@ async def get_datapoint_nodes(
            ORDER BY ht.name, hn.name""",
         (dp_id,),
     )
+    node_ids = [r["node_id"] for r in rows]
+    node_paths: dict[str, list[NodePathSegment]] = {}
+    if node_ids:
+        ph = ",".join("?" * len(node_ids))
+        path_rows = await db.fetchall(
+            f"""WITH RECURSIVE anc(leaf_id, cur_id, cur_name, cur_parent, depth) AS (
+                SELECT id, id, name, parent_id, 0 FROM hierarchy_nodes WHERE id IN ({ph})
+                UNION ALL
+                SELECT a.leaf_id, hn2.id, hn2.name, hn2.parent_id, a.depth + 1
+                FROM anc a JOIN hierarchy_nodes hn2 ON hn2.id = a.cur_parent
+                WHERE a.cur_parent IS NOT NULL
+            )
+            SELECT leaf_id, cur_id, cur_name FROM anc WHERE depth > 0
+            ORDER BY leaf_id, depth DESC""",
+            node_ids,
+        )
+        for r in path_rows:
+            node_paths.setdefault(r["leaf_id"], []).append(
+                NodePathSegment(node_id=r["cur_id"], node_name=r["cur_name"])
+            )
     return [
         NodeRef(
             link_id=r["link_id"],
@@ -432,6 +459,7 @@ async def get_datapoint_nodes(
             node_name=r["node_name"],
             tree_id=r["tree_id"],
             tree_name=r["tree_name"],
+            node_path=node_paths.get(r["node_id"], []),
         )
         for r in rows
     ]

--- a/obs/api/v1/hierarchy.py
+++ b/obs/api/v1/hierarchy.py
@@ -449,9 +449,7 @@ async def get_datapoint_nodes(
             node_ids,
         )
         for r in path_rows:
-            node_paths.setdefault(r["leaf_id"], []).append(
-                NodePathSegment(node_id=r["cur_id"], node_name=r["cur_name"])
-            )
+            node_paths.setdefault(r["leaf_id"], []).append(NodePathSegment(node_id=r["cur_id"], node_name=r["cur_name"]))
     return [
         NodeRef(
             link_id=r["link_id"],

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -69,9 +69,7 @@ async def _add_hierarchy(items: list[DataPointOut], db: Database) -> None:
             node_ids,
         )
         for r in path_rows:
-            node_paths.setdefault(r["leaf_id"], []).append(
-                NodePathSegment(node_id=r["cur_id"], node_name=r["cur_name"])
-            )
+            node_paths.setdefault(r["leaf_id"], []).append(NodePathSegment(node_id=r["cur_id"], node_name=r["cur_name"]))
 
     by_dp: dict[str, list[HierarchyNodeRef]] = {}
     for r in rows:
@@ -97,6 +95,7 @@ async def search(
     adapter: str = Query("", description="Has binding with this adapter_type"),
     quality: str = Query("", description="Runtime quality filter: good | bad | uncertain"),
     node_id: str = Query("", description="Comma-separated node IDs — OR logic"),
+    tree_id: str = Query("", description="Comma-separated tree IDs — matches any node in these trees"),
     sort: str = Query("name", pattern="^(name|data_type|created_at|updated_at)$"),
     order: str = Query("asc", pattern="^(asc|desc)$"),
     page: int = Query(0, ge=0),
@@ -151,7 +150,7 @@ async def search(
 
         results = [dp for dp in results if _matches(dp)]
 
-    # 5. node_id filter (hierarchy — one query per node, OR logic)
+    # 5a. node_id filter (specific nodes — OR logic)
     if node_id:
         node_id_list = [n.strip() for n in node_id.split(",") if n.strip()]
         if node_id_list:
@@ -159,6 +158,21 @@ async def search(
             rows = await db.fetchall(
                 f"SELECT DISTINCT datapoint_id FROM hierarchy_datapoint_links WHERE node_id IN ({placeholders})",
                 node_id_list,
+            )
+            matched_ids = {r["datapoint_id"] for r in rows}
+            results = [dp for dp in results if str(dp.id) in matched_ids]
+
+    # 5b. tree_id filter (all nodes in these trees — OR logic)
+    if tree_id:
+        tree_id_list = [t.strip() for t in tree_id.split(",") if t.strip()]
+        if tree_id_list:
+            placeholders = ",".join("?" * len(tree_id_list))
+            rows = await db.fetchall(
+                f"""SELECT DISTINCT hdl.datapoint_id
+                    FROM hierarchy_datapoint_links hdl
+                    JOIN hierarchy_nodes hn ON hn.id = hdl.node_id
+                    WHERE hn.tree_id IN ({placeholders})""",
+                tree_id_list,
             )
             matched_ids = {r["datapoint_id"] for r in rows}
             results = [dp for dp in results if str(dp.id) in matched_ids]
@@ -198,6 +212,7 @@ async def search(
             "adapter": adapter,
             "quality": quality,
             "node_id": node_id,
+            "tree_id": tree_id,
             "sort": sort,
             "order": order,
         },

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from obs.api.auth import get_current_user
-from obs.api.v1.datapoints import _SORT_KEYS, DataPointOut, HierarchyNodeRef, _enrich
+from obs.api.v1.datapoints import _SORT_KEYS, DataPointOut, HierarchyNodeRef, NodePathSegment, _enrich
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
 
@@ -42,7 +42,7 @@ async def _add_hierarchy(items: list[DataPointOut], db: Database) -> None:
     placeholders = ",".join("?" * len(dp_ids))
     rows = await db.fetchall(
         f"""SELECT hdl.datapoint_id, hn.id AS node_id, hn.name AS node_name,
-                   ht.id AS tree_id, ht.name AS tree_name
+                   ht.id AS tree_id, ht.name AS tree_name, ht.display_depth
             FROM hierarchy_datapoint_links hdl
             JOIN hierarchy_nodes hn ON hn.id = hdl.node_id
             JOIN hierarchy_trees ht ON ht.id = hn.tree_id
@@ -50,6 +50,29 @@ async def _add_hierarchy(items: list[DataPointOut], db: Database) -> None:
             ORDER BY ht.name, hn.name""",
         dp_ids,
     )
+
+    # Build ancestor paths for all linked nodes via recursive CTE
+    node_ids = list({r["node_id"] for r in rows})
+    node_paths: dict[str, list[NodePathSegment]] = {}
+    if node_ids:
+        ph2 = ",".join("?" * len(node_ids))
+        path_rows = await db.fetchall(
+            f"""WITH RECURSIVE anc(leaf_id, cur_id, cur_name, cur_parent, depth) AS (
+                SELECT id, id, name, parent_id, 0 FROM hierarchy_nodes WHERE id IN ({ph2})
+                UNION ALL
+                SELECT a.leaf_id, hn2.id, hn2.name, hn2.parent_id, a.depth + 1
+                FROM anc a JOIN hierarchy_nodes hn2 ON hn2.id = a.cur_parent
+                WHERE a.cur_parent IS NOT NULL
+            )
+            SELECT leaf_id, cur_id, cur_name FROM anc WHERE depth > 0
+            ORDER BY leaf_id, depth DESC""",
+            node_ids,
+        )
+        for r in path_rows:
+            node_paths.setdefault(r["leaf_id"], []).append(
+                NodePathSegment(node_id=r["cur_id"], node_name=r["cur_name"])
+            )
+
     by_dp: dict[str, list[HierarchyNodeRef]] = {}
     for r in rows:
         by_dp.setdefault(r["datapoint_id"], []).append(
@@ -58,6 +81,8 @@ async def _add_hierarchy(items: list[DataPointOut], db: Database) -> None:
                 node_name=r["node_name"],
                 tree_id=r["tree_id"],
                 tree_name=r["tree_name"],
+                node_path=node_paths.get(r["node_id"], []),
+                display_depth=r["display_depth"] if r["display_depth"] is not None else 0,
             )
         )
     for item in items:

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -150,13 +150,20 @@ async def search(
 
         results = [dp for dp in results if _matches(dp)]
 
-    # 5a. node_id filter (specific nodes — OR logic)
+    # 5a. node_id filter — includes selected nodes AND all their descendants
     if node_id:
         node_id_list = [n.strip() for n in node_id.split(",") if n.strip()]
         if node_id_list:
             placeholders = ",".join("?" * len(node_id_list))
             rows = await db.fetchall(
-                f"SELECT DISTINCT datapoint_id FROM hierarchy_datapoint_links WHERE node_id IN ({placeholders})",
+                f"""WITH RECURSIVE desc(id) AS (
+                    SELECT id FROM hierarchy_nodes WHERE id IN ({placeholders})
+                    UNION ALL
+                    SELECT hn.id FROM hierarchy_nodes hn JOIN desc d ON hn.parent_id = d.id
+                )
+                SELECT DISTINCT hdl.datapoint_id
+                FROM hierarchy_datapoint_links hdl
+                JOIN desc d ON hdl.node_id = d.id""",
                 node_id_list,
             )
             matched_ids = {r["datapoint_id"] for r in rows}

--- a/obs/db/database.py
+++ b/obs/db/database.py
@@ -421,6 +421,10 @@ ALTER TABLE knx_trades ADD COLUMN parent_id TEXT;
 CREATE INDEX IF NOT EXISTS idx_knx_trade_parent ON knx_trades(parent_id);
 """
 
+_MIGRATION_V29 = """
+ALTER TABLE hierarchy_trees ADD COLUMN display_depth INTEGER NOT NULL DEFAULT 0;
+"""
+
 # List of (version, sql_or_callable) tuples — append new migrations here
 MIGRATIONS: list[tuple[int, str | Callable]] = [
     (1, _MIGRATION_V1),
@@ -451,6 +455,7 @@ MIGRATIONS: list[tuple[int, str | Callable]] = [
     (26, _MIGRATION_V26),
     (27, _MIGRATION_V27),
     (28, _MIGRATION_V28),
+    (29, _MIGRATION_V29),
 ]
 
 

--- a/tests/integration/test_hierarchy.py
+++ b/tests/integration/test_hierarchy.py
@@ -341,3 +341,88 @@ async def test_import_from_ets_groups_mode(client, auth_headers):
     resp3 = await client.get(f"/api/v1/hierarchy/trees/{body['tree_id']}/nodes", headers=auth_headers)
     roots = resp3.json()
     assert len(roots) == 2  # Hauptgruppe 1 + 2
+
+
+# ---------------------------------------------------------------------------
+# display_depth (Issue #443)
+# ---------------------------------------------------------------------------
+
+
+async def test_tree_display_depth_default(client, auth_headers):
+    """Newly created tree has display_depth=0 by default."""
+    tree = await _create_tree(client, auth_headers, "DepthTest")
+    assert tree["display_depth"] == 0
+
+
+async def test_tree_create_with_display_depth(client, auth_headers):
+    """Create a tree with explicit display_depth."""
+    resp = await client.post(
+        "/api/v1/hierarchy/trees",
+        json={"name": "Tiefe2", "description": "", "display_depth": 2},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["display_depth"] == 2
+
+
+async def test_tree_update_display_depth(client, auth_headers):
+    """Update display_depth via PUT."""
+    tree = await _create_tree(client, auth_headers, "UpdDepth")
+    assert tree["display_depth"] == 0
+
+    resp = await client.put(
+        f"/api/v1/hierarchy/trees/{tree['id']}",
+        json={"display_depth": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_depth"] == 1
+
+
+# ---------------------------------------------------------------------------
+# node_path in NodeRef (Issue #443)
+# ---------------------------------------------------------------------------
+
+
+async def test_datapoint_nodes_include_path(client, auth_headers):
+    """GET /hierarchy/datapoints/{id}/nodes returns node_path with ancestors."""
+    tree = await _create_tree(client, auth_headers, "Pfadtest")
+    root = await _create_node(client, auth_headers, tree["id"], "EG")
+    mid = await _create_node(client, auth_headers, tree["id"], "Wohnzimmer", parent_id=root["id"])
+    leaf = await _create_node(client, auth_headers, tree["id"], "Licht", parent_id=mid["id"])
+    dp = await _create_dp(client, auth_headers, "LichtDP")
+
+    await client.post(
+        "/api/v1/hierarchy/links",
+        json={"node_id": leaf["id"], "datapoint_id": dp["id"]},
+        headers=auth_headers,
+    )
+
+    resp = await client.get(f"/api/v1/hierarchy/datapoints/{dp['id']}/nodes", headers=auth_headers)
+    assert resp.status_code == 200
+    refs = resp.json()
+    assert len(refs) == 1
+    ref = refs[0]
+    assert ref["node_name"] == "Licht"
+    assert "node_path" in ref
+    # Path should contain EG and Wohnzimmer (root-first order)
+    path_names = [seg["node_name"] for seg in ref["node_path"]]
+    assert path_names == ["EG", "Wohnzimmer"]
+
+
+async def test_datapoint_nodes_path_root_node(client, auth_headers):
+    """A root-level node has an empty node_path."""
+    tree = await _create_tree(client, auth_headers, "RootPfad")
+    root = await _create_node(client, auth_headers, tree["id"], "Gebäude")
+    dp = await _create_dp(client, auth_headers, "GebaeudeDP")
+
+    await client.post(
+        "/api/v1/hierarchy/links",
+        json={"node_id": root["id"], "datapoint_id": dp["id"]},
+        headers=auth_headers,
+    )
+
+    resp = await client.get(f"/api/v1/hierarchy/datapoints/{dp['id']}/nodes", headers=auth_headers)
+    assert resp.status_code == 200
+    ref = resp.json()[0]
+    assert ref["node_path"] == []


### PR DESCRIPTION
## Summary

Closes #443

- **Selectable display start level** (`display_depth` per tree): the abbreviated hierarchy tag in the object list no longer always shows the top-level tree name. Each tree can be configured (0-4 levels deep) to start the display at a deeper ancestor (e.g. show `EG > Licht` instead of `Gebäude > Licht`). Configured in HierarchyManager via a new dropdown in the tree edit modal.
- **Full path tooltip on hover**: hovering over any hierarchy tag shows the complete root-to-leaf path via the native `title` attribute.
- **Clickable path segments / drill-down on name**: both the abbreviated start segment (ancestor) and the leaf segment of a hierarchy tag are independently clickable to set a filter. Clicking the tree name sets a tree-level filter.
- **Tree-level filter integrated into Hierarchieknoten dropdown**: clicking the tree name in a tag adds the whole tree as a filter entry inside the existing node filter button, shown with a tree icon and "Ganzer Ast" label. No separate filter area.
- **Descendant-inclusive node filter**: filtering by a node (e.g. `Untergeschoss`) now returns all datapoints linked to that node or any of its children/grandchildren via recursive CTE. Previously only direct links were matched.
- **Clickable names in HierarchyManager**: tree names and node names with children are now clickable to expand/collapse.
- **`node_path` in API responses**: `HierarchyNodeRef` and `NodeRef` carry the full ancestor chain (root-first) so the frontend can render complete breadcrumbs.
- **DB migration V29**: `ALTER TABLE hierarchy_trees ADD COLUMN display_depth INTEGER NOT NULL DEFAULT 0`.

## Test plan

- [x] Import a buildings hierarchy from ETS, set `display_depth = 1` on the tree, verify tags show the first-level node name instead of the tree name
- [x] Hover over a hierarchy tag to see the full path tooltip
- [x] Click the tree name segment of a tag — tree appears in Hierarchieknoten filter as "Ganzer Ast"; results include all objects in that tree
- [x] Click a node name segment — node filter is set; results include objects on that node and all descendant nodes
- [x] Filter on a mid-level node (e.g. `Untergeschoss`) — objects linked to `Garage` / `Keller` appear
- [x] Click tree name in HierarchyManager header — tree expands/collapses
- [x] Click node name with children in HierarchyManager — node expands/collapses
- [x] Run integration tests: `pytest tests/integration/test_hierarchy.py -m integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
