### PR TITLE
fix(#471): Berechtigungsmanagement - Non-Admin, Demo, Visu PIN-Write

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -75,7 +75,12 @@ export function setSessionToken(nodeId: string, token: string, expiresIn = 3600)
 // ── Write-Kontext ─────────────────────────────────────────────────────────────
 // Wird von VisuViewer gesetzt bevor Widgets rendern; automatisch bei Write mitgeschickt.
 
-interface WriteContext { pageId?: string; sessionToken?: string }
+interface WriteContext {
+  pageId?: string
+  sessionToken?: string
+  /** Knoten, der das Access-Level definiert (für Session-Token-Verwaltung bei Ablauf) */
+  definingId?: string
+}
 let _writeContext: WriteContext = {}
 
 export function setWriteContext(ctx: WriteContext): void { _writeContext = ctx }
@@ -277,15 +282,25 @@ export const datapoints = {
   deleteBinding: (dpId: string, bindingId: string) =>
     request<void>(`/datapoints/${dpId}/bindings/${bindingId}`, { method: 'DELETE' }),
 
-  write: (id: string, value: unknown) => {
+  write: async (id: string, value: unknown) => {
     const headers: Record<string, string> = {}
     if (_writeContext.pageId)      headers['X-Page-Id']       = _writeContext.pageId
     if (_writeContext.sessionToken) headers['X-Session-Token'] = _writeContext.sessionToken
-    return request<void>(`/datapoints/${id}/value`, {
-      method: 'POST',
-      body: JSON.stringify({ value }),
-      headers,
-    })
+    try {
+      return await request<void>(`/datapoints/${id}/value`, {
+        method: 'POST',
+        body: JSON.stringify({ value }),
+        headers,
+      })
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message === 'Valid session token required') {
+        // Session abgelaufen (z.B. nach Server-Neustart) — Token löschen und Re-Auth auslösen
+        const defId = _writeContext.definingId
+        if (defId) sessionStorage.removeItem(`session_${defId}`)
+        window.dispatchEvent(new CustomEvent('visu:session-expired'))
+      }
+      throw err
+    }
   },
 }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -38,14 +38,14 @@ const router = createRouter({
       path: '/manage',
       name: 'manage',
       component: () => import('@/views/TreeManager.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: { requiresAuth: true },
     },
     {
       path: '/editor/:id',
       name: 'editor',
       component: () => import('@/views/VisuEditor.vue'),
       props: true,
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: { requiresAuth: true },
     },
     // Viewer muss nach /editor/:id stehen (sonst matcht /:id zuerst)
     {

--- a/frontend/src/views/VisuViewer.vue
+++ b/frontend/src/views/VisuViewer.vue
@@ -125,10 +125,11 @@ async function load() {
 
     if (currentNode?.type === 'PAGE') {
       await visuStore.loadPage(props.id)
-      // Write-Kontext für Backend-Autorisierung setzen (pageId + ggf. Session-Token)
+      // Write-Kontext für Backend-Autorisierung setzen (pageId + Session-Token + definingId)
       setWriteContext({
         pageId:       props.id,
         sessionToken: getSessionToken(definingId) ?? undefined,
+        definingId,
       })
       ws.connect()
       dpStore.subscribe(allDpIds.value)
@@ -142,8 +143,17 @@ async function load() {
   }
 }
 
-onMounted(load)
-onUnmounted(clearWriteContext)
+// Session abgelaufen (z.B. nach Server-Neustart) — erneut laden; load() leitet zu PIN-Auth weiter
+function onSessionExpired() { load() }
+
+onMounted(() => {
+  load()
+  window.addEventListener('visu:session-expired', onSessionExpired)
+})
+onUnmounted(() => {
+  window.removeEventListener('visu:session-expired', onSessionExpired)
+  clearWriteContext()
+})
 watch(() => props.id, load)
 
 // Grid-Geometrie — feste Pixel-Werte → 1:1 identisch mit Editor (WYSIWYG)

--- a/gui/src/views/SettingsView.vue
+++ b/gui/src/views/SettingsView.vue
@@ -27,7 +27,7 @@
     <div v-if="activeTab === 'general'" class="flex flex-col gap-4 max-w-md">
 
       <!-- Zeitzone -->
-      <div v-if="!isDemo" class="card">
+      <div class="card" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
         <div class="card-header"><h3 class="font-semibold text-sm text-slate-800 dark:text-slate-100">Allgemeine Einstellungen</h3></div>
         <div class="card-body flex flex-col gap-4">
           <div class="form-group">
@@ -100,7 +100,7 @@
     </div>
 
     <!-- ── Passwort ── -->
-    <div v-if="activeTab === 'password' && !isDemo" class="card max-w-md">
+    <div v-if="activeTab === 'password'" class="card max-w-md" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
       <div class="card-header"><h3 class="font-semibold text-sm text-slate-800 dark:text-slate-100">Passwort ändern</h3></div>
       <div class="card-body">
         <form @submit.prevent="changePassword" class="flex flex-col gap-4">
@@ -126,7 +126,7 @@
     </div>
 
     <!-- ── Benutzer (Admin only) ── -->
-    <div v-if="activeTab === 'users' && auth.isAdmin && !isDemo">
+    <div v-if="activeTab === 'users' && (auth.isAdmin || isDemo)" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
       <div class="flex items-center gap-3 mb-4">
         <span class="flex-1 text-sm text-slate-400">{{ users.length }} Benutzer</span>
         <button @click="openCreateUser" class="btn-primary btn-sm">+ Benutzer</button>
@@ -163,7 +163,7 @@
     </div>
 
     <!-- ── API Keys ── -->
-    <div v-if="activeTab === 'apikeys' && !isDemo">
+    <div v-if="activeTab === 'apikeys'" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
       <div class="flex items-center gap-3 mb-4">
         <span class="flex-1 text-sm text-slate-400">{{ apiKeys.length }} API Keys</span>
         <button @click="createApiKey" class="btn-primary btn-sm">+ API Key</button>
@@ -189,7 +189,7 @@
     </div>
 
     <!-- ── Datenmanagement ── -->
-    <div v-if="activeTab === 'importexport' && !isDemo" class="flex flex-col gap-4 max-w-lg">
+    <div v-if="activeTab === 'importexport'" class="flex flex-col gap-4 max-w-lg" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
 
       <!-- Sicherung erstellen (download) -->
       <div class="card p-5 flex flex-col gap-3">
@@ -356,7 +356,7 @@
     </div>
 
     <!-- ── History Backend ── -->
-    <div v-if="activeTab === 'history' && !isDemo" class="flex flex-col gap-4 max-w-2xl">
+    <div v-if="activeTab === 'history'" class="flex flex-col gap-4 max-w-2xl" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
       <div class="card">
         <div class="card-header">
           <h3 class="font-semibold text-sm text-slate-800 dark:text-slate-100">Historie DB</h3>
@@ -552,7 +552,7 @@
     </div>
 
     <!-- ── Icons Library ── -->
-    <div v-if="activeTab === 'icons' && !isDemo" class="flex flex-col gap-4" data-testid="icons-tab">
+    <div v-if="activeTab === 'icons'" class="flex flex-col gap-4" data-testid="icons-tab" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
 
       <!-- Toolbar -->
       <div class="flex flex-wrap items-center gap-3">
@@ -713,7 +713,7 @@
     </div>
 
     <!-- ── Links ── -->
-    <div v-if="activeTab === 'links' && !isDemo" class="flex flex-col gap-4 max-w-lg" data-testid="links-tab">
+    <div v-if="activeTab === 'links'" class="flex flex-col gap-4 max-w-lg" data-testid="links-tab" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
       <div class="card">
         <div class="card-header flex items-center justify-between">
           <div>
@@ -798,7 +798,7 @@
     </div>
 
     <!-- ── Danger Zone ── -->
-    <div v-if="activeTab === 'dangerzone' && !isDemo" class="flex flex-col gap-4 max-w-lg">
+    <div v-if="activeTab === 'dangerzone'" class="flex flex-col gap-4 max-w-lg" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
       <div class="rounded-lg border border-red-500/40 bg-red-500/5 overflow-hidden">
         <div class="px-5 py-3 border-b border-red-500/30 flex items-center gap-2">
           <svg class="w-4 h-4 text-red-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1038,7 +1038,7 @@ onMounted(async () => {
 })
 
 watch(activeTab, (tab) => {
-  if (tab === 'history' && auth.isAdmin) {
+  if (tab === 'history') {
     loadHistorySettings()
     loadHistoryFilterDps()
   }
@@ -1065,14 +1065,14 @@ async function saveTz() {
 const tabs = computed(() => [
   { id: 'general',      label: 'Allgemein' },
   { id: 'password',     label: 'Passwort' },
-  ...(auth.isAdmin ? [{ id: 'users', label: 'Benutzer' }] : []),
+  ...(auth.isAdmin || isDemo.value ? [{ id: 'users', label: 'Benutzer' }] : []),
   { id: 'apikeys',      label: 'API Keys' },
-  ...(!isDemo.value ? [{ id: 'links', label: 'Links' }] : []),
+  { id: 'links',        label: 'Links' },
   { id: 'hierarchy',    label: 'Hierarchie' },
   { id: 'importexport', label: 'Datenmanagement' },
   { id: 'icons',        label: 'Icons' },
-  ...(!isDemo.value ? [{ id: 'history', label: 'Historie DB' }] : []),
-  ...(!isDemo.value ? [{ id: 'dangerzone', label: 'Danger Zone' }] : []),
+  { id: 'history',      label: 'Historie DB' },
+  { id: 'dangerzone',   label: 'Danger Zone' },
 ])
 
 // ── History Backend ────────────────────────────────────────────────────────

--- a/gui/src/views/SettingsView.vue
+++ b/gui/src/views/SettingsView.vue
@@ -18,7 +18,7 @@
     </div>
 
     <!-- Demo-Modus Banner -->
-    <div v-if="isDemo && activeTab !== 'general'" class="flex items-center gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg text-sm text-amber-600 dark:text-amber-400">
+    <div v-if="isDemo" class="flex items-center gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg text-sm text-amber-600 dark:text-amber-400">
       <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v4m0 4h.01M12 3a9 9 0 110 18A9 9 0 0112 3z"/></svg>
       Demo-Modus — dieser Bereich ist schreibgeschützt/gesperrt.
     </div>
@@ -545,7 +545,7 @@
     <!-- ── Hierarchie ── -->
     <div v-if="activeTab === 'hierarchy'" class="flex flex-col gap-4" data-testid="hierarchy-tab">
       <div class="card">
-        <div class="card-body">
+        <div class="card-body" :class="{ 'pointer-events-none select-none opacity-60': isDemo }">
           <HierarchyManager />
         </div>
       </div>
@@ -713,7 +713,7 @@
     </div>
 
     <!-- ── Links ── -->
-    <div v-if="activeTab === 'links' && auth.isAdmin && !isDemo" class="flex flex-col gap-4 max-w-lg" data-testid="links-tab">
+    <div v-if="activeTab === 'links' && !isDemo" class="flex flex-col gap-4 max-w-lg" data-testid="links-tab">
       <div class="card">
         <div class="card-header flex items-center justify-between">
           <div>
@@ -798,7 +798,7 @@
     </div>
 
     <!-- ── Danger Zone ── -->
-    <div v-if="activeTab === 'dangerzone' && auth.isAdmin && !isDemo" class="flex flex-col gap-4 max-w-lg">
+    <div v-if="activeTab === 'dangerzone' && !isDemo" class="flex flex-col gap-4 max-w-lg">
       <div class="rounded-lg border border-red-500/40 bg-red-500/5 overflow-hidden">
         <div class="px-5 py-3 border-b border-red-500/30 flex items-center gap-2">
           <svg class="w-4 h-4 text-red-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1067,12 +1067,12 @@ const tabs = computed(() => [
   { id: 'password',     label: 'Passwort' },
   ...(auth.isAdmin ? [{ id: 'users', label: 'Benutzer' }] : []),
   { id: 'apikeys',      label: 'API Keys' },
-  ...(auth.isAdmin && !isDemo.value ? [{ id: 'links', label: 'Links' }] : []),
+  ...(!isDemo.value ? [{ id: 'links', label: 'Links' }] : []),
   { id: 'hierarchy',    label: 'Hierarchie' },
   { id: 'importexport', label: 'Datenmanagement' },
   { id: 'icons',        label: 'Icons' },
-  ...(auth.isAdmin ? [{ id: 'history', label: 'Historie DB' }] : []),
-  ...(auth.isAdmin ? [{ id: 'dangerzone', label: 'Danger Zone' }] : []),
+  ...(!isDemo.value ? [{ id: 'history', label: 'Historie DB' }] : []),
+  ...(!isDemo.value ? [{ id: 'dangerzone', label: 'Danger Zone' }] : []),
 ])
 
 // ── History Backend ────────────────────────────────────────────────────────

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -238,22 +238,13 @@ async def get_value(
     )
 
 
-async def _resolve_page_access(db: Database, node_id: str) -> str:
-    """Traversiert die parent_id-Kette und gibt das effektive Access-Level zurück."""
-    current_id: str | None = node_id
-    while current_id:
-        async with db.conn.execute("SELECT access, parent_id FROM visu_nodes WHERE id = ?", (current_id,)) as cur:
-            row = await cur.fetchone()
-        if not row:
-            return "private"  # Unbekannter Knoten → sicher ablehnen
-        if row["access"] is not None:
-            return row["access"]
-        current_id = row["parent_id"]
-    return "public"
-
-
 async def _page_has_datapoint(db: Database, page_id: str, dp_id: uuid.UUID) -> bool:
-    """Return True if the page contains a widget bound to this datapoint."""
+    """Return True if the page contains a widget bound to this datapoint.
+
+    Checks both the formal datapoint_id / status_datapoint_id fields and any
+    additional datapoint IDs stored inside widget.config (used by Rolladen,
+    Licht, RTR and other multi-channel widgets).
+    """
     row = await db.fetchone("SELECT page_config FROM visu_nodes WHERE id = ? AND type = 'PAGE'", (page_id,))
     if not row:
         return False
@@ -268,7 +259,12 @@ async def _page_has_datapoint(db: Database, page_id: str, dp_id: uuid.UUID) -> b
         return False
 
     dp_id_str = str(dp_id)
-    return any(widget.datapoint_id == dp_id_str or widget.status_datapoint_id == dp_id_str for widget in page.widgets)
+    for widget in page.widgets:
+        if widget.datapoint_id == dp_id_str or widget.status_datapoint_id == dp_id_str:
+            return True
+        if any(v == dp_id_str for v in widget.config.values() if isinstance(v, str)):
+            return True
+    return False
 
 
 @router.post("/{dp_id}/value", status_code=status.HTTP_204_NO_CONTENT)
@@ -302,18 +298,17 @@ async def write_value(
         if not await _page_has_datapoint(db, page_id, dp_id):
             raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Datapoint is not part of the page")
 
-        access = await _resolve_page_access(db, page_id)
+        from obs.api.v1.visu import _check_user_access, _resolve_access_with_node
+
+        access, defining_node_id = await _resolve_access_with_node(db, page_id)
         if access == "readonly":
             raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Page is read-only")
         if access == "protected":
             session_token = request.headers.get("X-Session-Token")
-            if not session_token or not validate_session(session_token, page_id):
+            validate_id = defining_node_id or page_id
+            if not session_token or not validate_session(session_token, validate_id):
                 raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Valid session token required")
         elif access == "user":
-            if user is None:
-                raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-            from obs.api.v1.visu import _check_user_access
-
             if not await _check_user_access(db, page_id, user):
                 raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Zugriff verweigert")
         elif access not in ("public",):

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -17,7 +17,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, field_serializer
 
-from obs.api.auth import get_admin_user, get_current_user, optional_current_user
+from obs.api.auth import get_current_user, optional_current_user
 from obs.api.v1.sessions import validate_session
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -162,7 +162,7 @@ async def list_datapoints(
 @router.post("/", response_model=DataPointOut, status_code=status.HTTP_201_CREATED)
 async def create_datapoint(
     body: DataPointCreate,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
 ) -> DataPointOut:
     from obs.models.types import DataTypeRegistry
 
@@ -191,7 +191,7 @@ async def get_datapoint(
 async def update_datapoint(
     dp_id: uuid.UUID,
     body: DataPointUpdate,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
 ) -> DataPointOut:
     reg = get_registry()
     if reg.get(dp_id) is None:
@@ -211,7 +211,7 @@ async def update_datapoint(
 @router.delete("/{dp_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_datapoint(
     dp_id: uuid.UUID,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
 ) -> None:
     reg = get_registry()
     if reg.get(dp_id) is None:
@@ -282,7 +282,7 @@ async def write_value(
     """Write a value to a DataPoint via the internal EventBus.
 
     Zugriffslogik:
-    - JWT vorhanden → immer erlaubt (Admin)
+    - JWT vorhanden (eingeloggter Benutzer) → immer erlaubt
     - X-Page-Id Header + Seite ist 'public' → erlaubt
     - X-Page-Id Header + Seite ist 'protected' + gültiger X-Session-Token → erlaubt
     - Seite ist 'readonly' → 403 (auch mit Page-Header)
@@ -318,13 +318,6 @@ async def write_value(
                 raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Zugriff verweigert")
         elif access not in ("public",):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-
-    else:
-        if user is None:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-        row = await db.fetchone("SELECT is_admin FROM users WHERE username=?", (user,))
-        if not row or not row["is_admin"]:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Admin access required")
 
     event = DataValueEvent(
         datapoint_id=dp_id,

--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
-from obs.api.auth import get_admin_user, get_current_user
+from obs.api.auth import get_current_user
 from obs.db.database import Database, get_db
 from obs.logic.models import (
     FlowData,
@@ -70,7 +70,7 @@ async def list_graphs(
 @router.post("/graphs", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def create_graph(
     body: LogicGraphCreate,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -115,7 +115,7 @@ async def get_graph(
 async def update_graph_full(
     graph_id: str,
     body: LogicGraphCreate,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -151,7 +151,7 @@ async def update_graph_full(
 async def update_graph_partial(
     graph_id: str,
     body: LogicGraphUpdate,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -185,7 +185,7 @@ async def update_graph_partial(
 @router.delete("/graphs/{graph_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_graph(
     graph_id: str,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> None:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -203,7 +203,7 @@ async def delete_graph(
 @router.post("/graphs/import", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def import_graph(
     body: LogicGraphImport,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     if body.obs_export != "logic_graph":
@@ -277,7 +277,7 @@ async def import_graph(
 @router.post("/graphs/{graph_id}/run", status_code=status.HTTP_200_OK)
 async def run_graph(
     graph_id: str,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> dict:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -299,7 +299,7 @@ async def run_graph(
 )
 async def duplicate_graph(
     graph_id: str,
-    _admin: str = Depends(get_admin_user),
+    _user: str = Depends(get_current_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     row = await db.fetchone("SELECT * FROM logic_graphs WHERE id=?", (graph_id,))


### PR DESCRIPTION
## Summary

Fixes GitHub issue #471: broken permission management introduced by PR #456.

### What changed

**Backend — `obs/api/v1/datapoints.py`**
- Reverted `create_datapoint`, `update_datapoint`, `delete_datapoint` back to `get_current_user` (was wrongly changed to `get_admin_user` in #456)
- Removed erroneous admin-only check inside `write_value` for authenticated users
- Extended `_page_has_datapoint()` to also inspect `widget.config` values (catches multi-channel widgets: Rolladen, RTR, Licht)
- Fixed `write_value` to validate PIN session against `defining_node_id` (parent LOCATION) instead of always `page_id`, so inherited `protected` access works correctly

**Backend — `obs/api/v1/logic.py`**
- All 7 mutation endpoints (`create_graph`, `update_graph_full`, `update_graph_partial`, `delete_graph`, `import_graph`, `run_graph`, `duplicate_graph`) reverted from `get_admin_user` to `get_current_user`

**Frontend Visu — `frontend/src/router/index.ts`**
- Removed `requiresAdmin: true` from `/manage` (TreeManager) and `/editor/:id` (VisuEditor); kept `requiresAuth: true`

**Frontend Visu — `frontend/src/api/client.ts`**
- Extended `WriteContext` with `definingId` (the node that defines the PIN access level)
- `write()` now catches `403 "Valid session token required"`, removes the stale session token from `sessionStorage`, and dispatches `visu:session-expired` — handles server-restart invalidation of in-memory sessions

**Frontend Visu — `frontend/src/views/VisuViewer.vue`**
- Passes `definingId` to `setWriteContext`
- Listens for `visu:session-expired` and calls `load()` — user is redirected to PIN auth for re-authentication

**Frontend GUI — `gui/src/views/SettingsView.vue`**
- All settings tabs are now visible in demo mode (`demo` user), displayed as read-only (`pointer-events-none select-none opacity-60`)
- Previously hidden tabs (`Links`, `Historie DB`, `Danger Zone`) now shown with overlay
- `Benutzer` tab visible for demo user (empty list, overlay)
- `Zeitzone` in Allgemein-Tab visible for demo user (overlay)
- Demo banner shown on all tabs

## Behaviour after fix

| Actor | Can do |
|---|---|
| Non-admin user | Everything except create/delete users |
| `demo` user | All menus/tabs visible, all read-only |
| Unauthenticated Visu (public page) | Read + write datapoints on the page |
| PIN-authenticated Visu (protected page) | Read + write datapoints on the page (incl. multi-channel widgets) |
| Expired PIN session (after server restart) | Auto-redirect to PIN re-auth on next write attempt |

## Reviewer notes

- In-memory `_sessions` dict in `sessions.py` is still cleared on server restart. The frontend now gracefully handles this by clearing the stale client-side token and triggering re-auth. A persistent session store (DB-backed) would be a follow-up improvement.
- User management (create/delete users) remains admin-only per the issue spec.

Generated with [Claude Code](https://claude.com/claude-code)
