### PR TITLE
feat: HierarchyManager — konkrete Beispiele beim Ast umbenennen (#467)

### DIFF
--- a/gui/src/components/HierarchyManager.vue
+++ b/gui/src/components/HierarchyManager.vue
@@ -98,7 +98,7 @@
         </h3>
         <div class="form-group">
           <label class="label">Name</label>
-          <input v-model="treeModal.name" ref="treeNameInput" type="text" class="input" placeholder="z.B. Gebäude, Gewerke, Funktion" @keydown.enter="saveTree" />
+          <input v-model="treeModal.name" ref="treeNameInput" type="text" class="input" :placeholder="treeModal.isEdit ? '' : 'z.B. Gebäude, Gewerke, Funktion'" @keydown.enter="saveTree" />
         </div>
         <div class="form-group">
           <label class="label">Beschreibung</label>
@@ -106,12 +106,8 @@
         </div>
         <div class="form-group">
           <label class="label">Anzeigestart-Ebene</label>
-          <select v-model="treeModal.display_depth" class="input text-sm">
-            <option :value="0">0 — Ast-Name (Standard, z.B. "Gebäude")</option>
-            <option :value="1">1 — Erste Ebene (z.B. "EG" statt "Gebäude")</option>
-            <option :value="2">2 — Zweite Ebene (z.B. "Wohnzimmer")</option>
-            <option :value="3">3 — Dritte Ebene</option>
-            <option :value="4">4 — Vierte Ebene</option>
+          <select v-model="treeModal.display_depth" class="input text-sm" data-testid="select-display-depth">
+            <option v-for="opt in depthOptions" :key="opt.value" :value="opt.value" :disabled="opt.disabled">{{ opt.label }}</option>
           </select>
           <p class="text-xs text-slate-500 mt-1">Bestimmt, welche Ebene im verkürzten Pfad-Tag angezeigt wird. Der vollständige Pfad ist stets als Tooltip sichtbar.</p>
         </div>
@@ -234,10 +230,11 @@
 </template>
 
 <script setup>
-import { ref, reactive, nextTick, onMounted } from 'vue'
+import { ref, reactive, computed, nextTick, onMounted } from 'vue'
 import { hierarchyApi } from '@/api/client.js'
 import HierarchyNodeTree from '@/components/HierarchyNodeTree.vue'
 import Spinner from '@/components/ui/Spinner.vue'
+import { buildDepthOptions } from '@/utils/hierarchyDepthOptions.js'
 
 // ── State ─────────────────────────────────────────────────────────────────
 
@@ -254,6 +251,14 @@ const treeNameInput = ref(null)
 const nodeNameInput = ref(null)
 
 const treeModal = reactive({ open: false, isEdit: false, id: null, name: '', description: '', display_depth: 0, saving: false, msg: null })
+
+const depthOptions = computed(() =>
+  buildDepthOptions({
+    isEdit: treeModal.isEdit,
+    tree: treeModal.isEdit ? { id: treeModal.id, name: treeModal.name } : null,
+    rootNodes: treeModal.isEdit ? treeNodes[treeModal.id] : null,
+  })
+)
 const nodeModal = reactive({ open: false, isEdit: false, id: null, treeId: null, parentId: null, name: '', description: '', saving: false, msg: null })
 const etsModal  = reactive({ open: false, treeName: '', mode: 'groups', autoLink: true, saving: false, msg: null })
 
@@ -308,6 +313,7 @@ function openCreateTree() {
 
 function openEditTree(tree) {
   Object.assign(treeModal, { open: true, isEdit: true, id: tree.id, name: tree.name, description: tree.description, display_depth: tree.display_depth ?? 0, saving: false, msg: null })
+  if (!treeNodes[tree.id]) loadTreeNodes(tree.id)
   nextTick(() => treeNameInput.value?.focus())
 }
 

--- a/gui/src/utils/hierarchyDepthOptions.js
+++ b/gui/src/utils/hierarchyDepthOptions.js
@@ -1,0 +1,49 @@
+const LEVEL_NAMES = ['Ast-Name', 'Erste Ebene', 'Zweite Ebene', 'Dritte Ebene', 'Vierte Ebene']
+
+const GENERIC_LABELS = [
+  '0 — Ast-Name (Standard, z.B. "Gebäude")',
+  '1 — Erste Ebene (z.B. "EG" statt "Gebäude")',
+  '2 — Zweite Ebene (z.B. "Wohnzimmer")',
+  '3 — Dritte Ebene',
+  '4 — Vierte Ebene',
+]
+
+function collectNamesAtDepth(nodes, depth) {
+  if (!nodes || nodes.length === 0) return []
+  if (depth === 0) return nodes.map(n => n?.name).filter(Boolean)
+  return nodes.flatMap(n => collectNamesAtDepth(n?.children, depth - 1))
+}
+
+export function buildDepthOptions({ isEdit, tree, rootNodes, maxDepth = 4 }) {
+  const options = []
+
+  for (let level = 0; level <= maxDepth; level++) {
+    if (!isEdit) {
+      options.push({ value: level, label: GENERIC_LABELS[level], disabled: false })
+      continue
+    }
+
+    if (level === 0) {
+      const name = tree?.name ?? LEVEL_NAMES[0]
+      options.push({ value: 0, label: `0 — ${name} (Ast-Name)`, disabled: false })
+      continue
+    }
+
+    const names = collectNamesAtDepth(rootNodes, level - 1)
+    const levelLabel = LEVEL_NAMES[level] ?? `Ebene ${level}`
+
+    if (names.length === 0) {
+      options.push({ value: level, label: `${level} — ${levelLabel}`, disabled: true })
+      continue
+    }
+
+    const example = names[0]
+    const distinct = new Set(names).size
+    const suffix = distinct === 1
+      ? `(nur "${example}")`
+      : `(z.B. "${example}" — ${distinct} unterschiedliche)`
+    options.push({ value: level, label: `${level} — ${levelLabel} ${suffix}`, disabled: false })
+  }
+
+  return options
+}

--- a/tests/gui/admin/hierarchy.spec.ts
+++ b/tests/gui/admin/hierarchy.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { apiPost, apiDelete } from '../helpers'
+
+// ---------------------------------------------------------------------------
+// Issue #467 — HierarchyManager Edit-Modal: konkrete Beispiele beim Umbenennen
+// ---------------------------------------------------------------------------
+//
+// Setup: legt einen Tree mit zwei Ebenen an, öffnet das Edit-Modal und prüft,
+// dass die Optionen der Anzeigestart-Ebene den echten Baum-/Knotennamen zeigen.
+
+test('Edit-Modal zeigt konkrete Beispiele aus dem aktuellen Baum', async ({ page }) => {
+  const treeName = `e2e-467-${Date.now()}`
+  const rootName = 'EG Test'
+  const childName = 'Wohnzimmer Test'
+
+  // 1) Tree + zweistufige Hierarchie via API anlegen
+  const tree = (await apiPost('/api/v1/hierarchy/trees', { name: treeName })) as { id: number }
+  const root = (await apiPost('/api/v1/hierarchy/nodes', {
+    tree_id: tree.id, parent_id: null, name: rootName,
+  })) as { id: number }
+  await apiPost('/api/v1/hierarchy/nodes', {
+    tree_id: tree.id, parent_id: root.id, name: childName,
+  })
+
+  try {
+    // 2) Settings → Hierarchie-Tab
+    await page.goto('/settings')
+    await page.click('button:has-text("Hierarchie")')
+    await expect(page.locator('[data-testid="hierarchy-tab"]')).toBeVisible({ timeout: 5_000 })
+
+    // 3) Edit-Pencil des neuen Baums klicken
+    const treeCard = page.locator(`[data-testid="tree-${tree.id}"]`)
+    await expect(treeCard).toBeVisible()
+    await treeCard.locator(`[data-testid="btn-edit-tree-${tree.id}"]`).click()
+
+    // 4) Select-Optionen enthalten echte Namen
+    const select = page.locator('[data-testid="select-display-depth"]')
+    await expect(select).toBeVisible()
+    const optionTexts = await select.locator('option').allTextContents()
+
+    expect(optionTexts[0]).toContain(treeName)            // "0 — <treeName> (Ast-Name)"
+    expect(optionTexts[0]).toContain('Ast-Name')
+    expect(optionTexts[1]).toContain(rootName)             // "1 — Erste Ebene (nur \"EG Test\")"
+    expect(optionTexts[1]).toContain('nur')                // genau ein Wurzelknoten → distinct=1
+    expect(optionTexts[2]).toContain(childName)            // "2 — Zweite Ebene (nur \"Wohnzimmer Test\")"
+    // Ebene 3 + 4 sind disabled (Baum hat nur 2 Ebenen)
+    const disabled3 = await select.locator('option').nth(3).getAttribute('disabled')
+    expect(disabled3).not.toBeNull()
+
+    // 5) Name-Input hat im Edit-Modus keinen generischen Placeholder
+    const nameInput = page.locator('input.input').first()
+    await expect(nameInput).toHaveValue(treeName)
+    const placeholder = await nameInput.getAttribute('placeholder')
+    expect(placeholder ?? '').toBe('')
+  } finally {
+    // 6) Cleanup
+    await apiDelete(`/api/v1/hierarchy/trees/${tree.id}`)
+  }
+})


### PR DESCRIPTION
## Summary

Im **Edit-Modus** des HierarchyManager zeigt das „Anzeigestart-Ebene"-Dropdown jetzt konkrete Beispiele aus dem aktuellen Baum statt generischer Platzhalter:

```
0 — <Baumname> (Ast-Name)
1 — Erste Ebene (z.B. "EG" — 3 unterschiedliche)   ← falls mehrere
1 — Erste Ebene (nur "Hauptgebäude")               ← falls einzigartig
2 — Zweite Ebene (z.B. "Wohnzimmer" — N unterschiedliche)
```

Ebenen ohne Daten sind disabled. Der Distinct-Count signalisiert, ob die Verkürzung auf dieser Ebene überhaupt zu unterscheidbaren Tags führt — bei `(nur "X")` bringt die Ebene keine Differenzierung.

Im **Create-Modus** bleibt das bestehende generische Wording („z. B. Gebäude"-Hinweise) erhalten.

Zusätzlich:
- Name-Input-Placeholder im Edit-Modus weggelassen — der echte Name steht ja bereits im Feld.
- `openEditTree` lädt jetzt die Tree-Knoten, falls noch nicht geladen, damit die dynamischen Beispiele auch ohne vorheriges Expand verfügbar sind.

Logik in eine pure Funktion ausgelagert: `gui/src/utils/hierarchyDepthOptions.js`.

## Test plan

- [x] Playwright-E2E `tests/gui/admin/hierarchy.spec.ts` — legt Tree mit zwei Ebenen via API an, öffnet das Edit-Modal, prüft die Modal-Optionen, säubert hinterher. Lokal grün gegen obs-dev (port 8082).
- [x] Manueller Browser-Test im Edit-Modal (verschiedene Baum-Topologien)
- [x] Lint (`./tools/lint.sh --check`) grün
- [x] `npm run build` in `gui/` grün

Closes #467