### PR TITLE
chore: ignore frontend artefacts and playwright local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,18 @@ htmlcov/
 .coverage
 coverage.xml
 
+# Node.js dependencies
+node_modules/
+
+# Frontend build artefacts (built by vite / docker)
+gui_dist/
+frontend_dist/
+
+# Playwright local artefacts (auth tokens, test runs, HTML reports)
+tests/gui/.auth/
+tests/gui/test-results/
+tests/gui/playwright-report/
+
 # Docs build output
 docs/_build/
 


### PR DESCRIPTION
## Summary

Adds `.gitignore` patterns for files generated by the build/test toolchain so they stop showing up as untracked. The most important one is `tests/gui/.auth/` — Playwright's `auth.setup.ts` writes a session token there (`admin.json`), and right now this token is visible in `git status` on every working tree and could be committed by accident via `git add .`.

Added patterns:
- `node_modules/` — applies at any depth (`gui/`, `frontend/`, `tests/gui/`, and any future `package.json`)
- `gui_dist/` — built by `cd gui && npm run build`, copied into the Docker image
- `frontend_dist/` — built by `cd frontend && npm run build`, copied into the Docker image
- `tests/gui/.auth/` — Playwright auth state (contains session tokens)
- `tests/gui/test-results/` — Playwright test run output
- `tests/gui/playwright-report/` — Playwright HTML report

Notes:
- The existing `.dockerignore` already excludes `gui/node_modules/`. This PR aligns git with that.
- `frontend/package-lock.json` stays tracked (existing convention is preserved — no `package-lock.json` pattern added).
- Nothing currently tracked is affected (`git ls-files -c -i --exclude-standard` returns empty after this change).

## Test plan

- [x] `git check-ignore -v <path>` confirms each new pattern matches its target (`gui/node_modules` → `node_modules/`, `tests/gui/.auth/admin.json` → `tests/gui/.auth/`, etc.)
- [x] `git ls-files -c -i --exclude-standard` shows no collisions with currently tracked files
- [x] `git status` after the change shows a clean working tree (no more untracked `node_modules/`, `gui_dist/`, `.auth/`, …)