### PR TITLE
feat(knx): detect tunnel-pool overload and surface as visible warning (#466)

### DIFF
--- a/docs/smoke-tests/issue-466-knx-tunnel-overload.md
+++ b/docs/smoke-tests/issue-466-knx-tunnel-overload.md
@@ -256,6 +256,27 @@ gezielt zu überfüllen.
 
 ---
 
+## Erwartetes Verhalten beim echten Pingpong (nicht-offensichtlich)
+
+Wenn die Pool-Überlastung *aktiv* ist (jeder Reconnect-Versuch scheitert),
+flackert die Severity der betroffenen Instanz im Polling zwischen
+`warning` und `error`:
+
+- `_record_disconnect()` setzt nach 3 Disconnects severity → `warning`.
+- Der nächste fehlgeschlagene Reconnect-Versuch läuft durch
+  `_publish_status(False, "Tunnel could not be established", severity="error")`
+  und überschreibt `_last_severity` → wieder `error`.
+- Bei einer weiteren Disconnect-Welle (selten, weil `_warning_active`
+  re-publish im selben Fenster blockiert) kommt warning evtl. zurück.
+
+Das ist gewollt: `error` ist die härtere Aussage ("Adapter ist nicht
+verbunden") und dominiert die diagnostische `warning` ("Pool wahrscheinlich
+überlastet"). Bei einem Code-Review **kein Bug**.
+
+In der UI sieht das als Wechsel zwischen rotem und gelbem Status aus.
+Sobald das Gateway einen Slot freigibt, wechselt der Status stabil auf
+`ok` / grün.
+
 ## Bei Fehlverhalten
 
 - **UI bleibt grün trotz Warn-Detail im REST-Response:**

--- a/docs/smoke-tests/issue-466-knx-tunnel-overload.md
+++ b/docs/smoke-tests/issue-466-knx-tunnel-overload.md
@@ -1,0 +1,268 @@
+# Smoke-Test: KNX-Tunnel-Pool-Überlastungs-Warnung (Issue #466)
+
+Diese Anleitung verifiziert, dass die UI sichtbar warnt, wenn der KNX/IP-Tunnel-Pool
+eines Gateways mehrfach in kurzer Zeit Disconnects produziert. Sie ist für Reviewer
+des zugehörigen Pull-Requests gedacht und beschreibt drei Pfade — wähle den, der
+zu deinem Setup passt.
+
+| Pfad | Setup | Was es zeigt | Aufwand |
+|---|---|---|---|
+| **A — UI-Sichtkontrolle** | Lokales Backend + GUI, Adapter angelegt, Browser-Devtools | Reine UI-Reaktion: Ampel, Badge, Sidebar-Bubble, Dashboard-Kachel | 5 min |
+| **B — Backend-Verhalten** | `pytest` lokal | Detection + Severity-Lifecycle Ende-zu-Ende | 30 s |
+| **C — End-to-End mit Hardware** | Drei `obs`-Stacks an einem realen KNX/IP-Gateway | Definitiver Beweis am echten Pool-Overload | 30 min, Hardware nötig |
+
+Bei minimaler Reviewer-Zeit reicht **A + B**. Pfad C ist die Goldstandard-Verifikation
+für jemanden mit Hardware-Zugriff.
+
+---
+
+## Erwartetes Verhalten (alle Pfade)
+
+Wenn binnen 5 min **3 oder mehr** Tunnel-Disconnects auf demselben KNX-Adapter eingehen:
+
+- Backend publisht ein `AdapterStatusEvent(severity="warning",
+  detail="KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet.")`
+  ohne das `connected`-Flag zu kippen.
+- REST-Antwort `/api/v1/adapters/instances` enthält für diese Instanz
+  `severity: "warning"` und `status_detail: "KNX-Tunnel-Slot …"`.
+- Folge-Disconnects im aktiven Warn-Fenster führen **nicht** zu weiteren
+  Warning-Events (kein Event-Spam).
+- Nachdem das 5-min-Fenster ohne neue Disconnects vergeht und ein Reconnect-Event
+  eintrifft, kippt der Status zurück auf `severity="ok"`.
+
+## Erwartete UI-Reaktion
+
+| Stelle | Vorher | Nach Schwellenüberschreitung |
+|---|---|---|
+| Adapter-Karte (`/adapters`) Ampel | grün (Verbunden) | **gelb** (Eingeschränkt) |
+| Adapter-Karte Badge | "Verbunden" / `success` | "Eingeschränkt" / `warning` |
+| Adapter-Karte Detail-Banner | ausgeblendet | gelb, mit `KNX-Tunnel-Slot …` |
+| Sidebar-Menüpunkt "Adapter" | ohne Bubble | **`⚠ 1`** in amber/gelb |
+| Dashboard (`/`) Kachel "Aktive Warnungen" | ausgeblendet | sichtbar, Einklicker zu `/adapters` |
+
+---
+
+## Pfad A — UI-Sichtkontrolle (ohne Hardware)
+
+Diese Variante zwingt die GUI-Komponenten in den Warn-Zustand, ohne dass ein
+echter KNX-Gateway oder ein Backend-Trick nötig wäre. Sie testet ausschließlich
+die UI — das Backend-Verhalten deckt Pfad B ab.
+
+### Voraussetzungen
+
+- Vite-Dev-Server für die GUI (`npm run dev`) — wichtig: der Pinia-Store ist
+  **nur** im Dev-Build über die Browser-Konsole greifbar. Im
+  Production-Container-Build (`/gui_dist/`) ist `__vue_app__` minifiziert.
+- Backend (lokal `python -m obs` oder Docker-Container) auf dem Port, den
+  der Vite-Proxy in `gui/vite.config.js` als `proxy['/api'].target` anspricht.
+- **Keine** Browser-Extension nötig (das Snippet unten greift Pinia direkt
+  über die Vue-App-Instance).
+
+### Vorbereitung
+
+```bash
+# Backend
+python -m obs                            # default: Port 8080
+
+# In zweitem Terminal: GUI Dev-Server
+cd gui && npm install && npm run dev     # öffnet http://localhost:5173
+```
+
+Falls das Backend auf einem anderen Port läuft (z. B. Docker-Stack auf 8083),
+in `gui/vite.config.js` temporär `proxy['/api'].target` anpassen
+**(diesen Edit vor dem Commit revertieren!)**.
+
+Im Browser `http://localhost:5173` öffnen, einloggen (`admin`/`admin`).
+Falls noch keine KNX-Instanz vorhanden ist: unter `/adapters` eine anlegen
+(`Adapter-Typ = KNX`, Defaults reichen). Sie verbindet sich mangels Gateway
+nicht — irrelevant, wir manipulieren gleich nur den Frontend-State.
+
+### Snippet — Pinia greifen und Polling sperren
+
+Browser-Devtools öffnen (Cmd-Opt-I / F12) → Tab **Console**, einmalig
+einfügen und ausführen:
+
+```js
+// Vue-App-Instance → Pinia → adapters-Store (alles ohne Extension).
+const app    = document.querySelector('#app').__vue_app__
+const pinia  = app.config.globalProperties.$pinia
+const store  = pinia._s.get('adapters')
+const knx    = store.instances.find(a => a.adapter_type === 'KNX')
+
+// Background-Polling sperren, damit der Mock nicht alle 10–30 s
+// vom Backend überschrieben wird. (Revert: store.fetchAdapters = __origFetch)
+window.__origFetch    = store.fetchAdapters
+store.fetchAdapters   = async () => {}
+
+// Convenience-Setter für die drei Zustände:
+window.setSev = (sev, detail = '') => { knx.severity = sev; knx.status_detail = detail }
+
+console.log('✅ Pinia gesperrt. Verwende setSev("warning", "…") / setSev("error", "…") / setSev("ok").')
+```
+
+### Schritt 1 — Warning-Zustand prüfen
+
+In der Konsole:
+
+```js
+setSev('warning', 'KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet.')
+```
+
+Auf der **`/adapters`**-Seite — am Eintrag "Smoke466 KNX" (oder Deinem
+KNX-Adapter) — sollten **alle vier** folgenden Punkte erfüllt sein:
+
+| # | Wo? | Vorher | Nachher |
+|---|---|---|---|
+| 1 | Kleine Status-Ampel **ganz links neben dem Adapternamen** | grüner Punkt | **gelber Punkt** (kein Pulsieren) |
+| 2 | Badge **rechts neben dem KNX-Typ-Label** | grünes "Verbunden" | **gelbes "Eingeschränkt"** |
+| 3 | **Unter** dem Card-Header (zwischen Header und Verknüpfungs-Zeile) | nicht vorhanden | gelber Hinweis-Streifen mit Warn-Icon + Detail-Text |
+| 4 | Sidebar links, Menüpunkt **"Adapter"** | nur Icon + Label | zusätzlich **gelbe `⚠ 1`**-Bubble rechts |
+
+Sidebar-Bubble bleibt auch sichtbar, wenn Du die Sidebar einklappst
+(Pfeil-Button unten links) — sie wandert dann als kleiner Marker an
+das Icon.
+
+Anschließend in den **Dashboard-Bereich `/` (Übersicht) navigieren**:
+
+| # | Wo? | Erwartung |
+|---|---|---|
+| 5 | Zwischen den vier StatCards oben und dem "Adapter Status"-Grid | **neue Kachel** "Aktive Warnungen (1)" mit gelbem linken Rand |
+| 6 | Innerhalb der Warnungs-Kachel | Zeile mit Adaptername + KNX-Badge + gelbem "Warnung"-Badge + Detail-Text |
+| 7 | Klick auf die Zeile | Navigation zurück nach `/adapters` |
+| 8 | In der "Adapter Status"-Kachel rechts daneben | dieselbe KNX-Zeile zeigt jetzt **gelben Punkt** + **"Eingeschränkt"**-Badge statt grün |
+
+### Schritt 2 — Error-Zustand prüfen
+
+```js
+setSev('error', 'KNX Backbone-Key ungültig (kein Hex-String)')
+```
+
+| # | Wo? | Erwartung |
+|---|---|---|
+| 9 | Adapter-Karte | **roter Punkt**, Badge **"Fehler"** (rot), roter Detail-Banner |
+| 10 | Sidebar-Bubble | wird **rot** statt gelb |
+| 11 | Dashboard-Kachel-Border links | wird **rot** |
+| 12 | Dashboard-Adapter-Status-Zeile | **roter Punkt** + "Fehler"-Badge |
+
+### Schritt 3 — Recovery prüfen
+
+```js
+setSev('ok', '')
+```
+
+| # | Wo? | Erwartung |
+|---|---|---|
+| 13 | Adapter-Karte | grüne Ampel, "Verbunden"-Badge (sofern `connected: true`), Detail-Banner verschwunden |
+| 14 | Sidebar-Bubble | weg |
+| 15 | Dashboard-Warnungs-Kachel | weg (komplett ausgeblendet) |
+| 16 | Dashboard-Adapter-Status-Zeile | wieder grüner Punkt + "Verbunden" |
+
+### Aufräumen
+
+```js
+store.fetchAdapters = window.__origFetch    // Polling wieder einschalten
+```
+
+Damit übernimmt der echte Backend-Status wieder die Anzeige. Alternativ:
+Browser-Tab neu laden.
+
+### Bonus: Backend-Pfad live verifizieren
+
+Der `severity="error"`-Pfad lässt sich auch echt am Backend triggern, ohne
+Console-Trick: PATCH die KNX-Instanz auf eine ungültige `routing_secure`-Config.
+`_publish_status(..., severity="error")` läuft dann durch die ganze Kette
+bis ins REST-Response.
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:8083/api/v1/auth/login \
+        -H 'Content-Type: application/json' \
+        -d '{"username":"admin","password":"admin"}' \
+      | python3 -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+
+ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+       http://localhost:8083/api/v1/adapters/instances \
+     | python3 -c "import sys,json;[print(a['id']) for a in json.load(sys.stdin) if a['adapter_type']=='KNX']")
+
+# Schaltet severity → 'error'
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+     http://localhost:8083/api/v1/adapters/instances/$ID \
+     -d '{"config":{"connection_type":"routing_secure","host":"239.0.0.1","backbone_key":"KEIN-HEX-AAAA"}}' \
+   | python3 -c "import sys,json;a=json.load(sys.stdin);print(f\"severity={a['severity']} detail={a['status_detail']}\")"
+
+# Zurück zu severity='ok' (Tunneling auf echtes Gateway)
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+     http://localhost:8083/api/v1/adapters/instances/$ID \
+     -d '{"config":{"connection_type":"tunneling","host":"192.168.178.89","port":3671,"individual_address":"1.1.250"}}' \
+   | python3 -c "import sys,json;a=json.load(sys.stdin);print(f\"severity={a['severity']} detail={a['status_detail']}\")"
+```
+
+Erwartete Console-Ausgabe:
+
+```
+severity=error detail=KNX Backbone-Key ungültig (kein Hex-String): ...
+severity=ok    detail=Connected to 192.168.178.89:3671
+```
+
+In der UI (bei aktivem Polling) sieht man die Umschaltung innerhalb von
+≤10 s — rote Ampel ↔ grüne Ampel.
+
+---
+
+## Pfad B — Backend-Verhalten (ohne Hardware, ohne UI)
+
+```bash
+pytest tests/adapters/test_knx.py::TestTunnelOverloadDetection -v
+```
+
+Erwartung: 11 Tests grün. Sie decken ab:
+- Sliding-Window prunet alte Disconnects (`test_disconnect_older_than_window_is_pruned`)
+- Default-Schwelle 3/300 s aus Issue (`test_config_defaults_match_issue_spec`)
+- Warning erst ab Threshold, nicht vorher (`test_below_threshold_publishes_no_warning`,
+  `test_threshold_reached_publishes_warning_status`)
+- Kein Event-Spam (`test_further_disconnects_do_not_republish_warning`)
+- Recovery nach Quiet-Window (`test_connected_after_quiet_period_clears_warning`,
+  `test_reconnect_during_active_window_does_not_clear_warning`)
+- xknx-Callback-Routing (`test_xknx_disconnected_callback_records_event`,
+  `test_xknx_connected_callback_runs_reconnect_handler`,
+  `test_xknx_connecting_callback_is_ignored`)
+
+---
+
+## Pfad C — End-to-End mit echter Hardware
+
+Setup:
+
+- Ein KNX/IP-Gateway mit kleinem Tunnel-Pool (typisch 2–4 Slots; viele MDT-/Weinzierl-Modelle).
+- Drei `obs`-Stacks gleichzeitig laufen lassen, alle mit demselben Gateway
+  als Tunneling-Ziel konfiguriert (`connection_type: tunneling`,
+  gleicher `host`, gleiche oder unterschiedliche `individual_address` —
+  wichtig: alle drei wollen einen Slot).
+
+Vorgehen:
+
+1. Stack 1 starten und verbinden lassen.
+2. Stack 2 starten und verbinden lassen.
+3. Stack 3 starten. Sobald der Gateway-Pool voll ist, beginnt das
+   Pingpong (`xknx.log: Received DisconnectRequest from tunnelling server.`).
+4. UI eines beliebigen der drei Stacks öffnen.
+5. Innerhalb von ~2 min sollte derselbe Effekt wie in Pfad A auftreten:
+   gelbe Ampel + Badge + Detail-Banner + Sidebar-Bubble + Dashboard-Kachel.
+6. Stack 3 stoppen → Pool ist wieder im Limit. Nach 5 min Stille kippt der
+   Status zurück auf grün/Verbunden (Recovery).
+
+Falls das Gateway einen größeren Pool hat als die Anzahl Stacks: zusätzliche
+Drittclients (ETS, Home-Assistant `xknx`) parallel laufen lassen, um den Pool
+gezielt zu überfüllen.
+
+---
+
+## Bei Fehlverhalten
+
+- **UI bleibt grün trotz Warn-Detail im REST-Response:**
+  Browser-Cache / Frontend-Build prüfen — `npm run build` neu, dann Hard-Reload (Cmd-Shift-R).
+- **REST-Response liefert `severity: "ok"` obwohl Backend-Logs Warnung zeigen:**
+  Adapter-Instance frisch nach `_publish_status`-Erweiterung neu gestartet?
+  `_last_severity` ist In-Memory; ein Adapter-Restart resettet auf `"ok"`.
+- **Detail-Text auf Englisch / weicht ab:**
+  Quellzeichenkette steht als `TUNNEL_OVERLOAD_DETAIL` in
+  `obs/adapters/knx/adapter.py`. Ändern dort, nicht in der UI.

--- a/gui/src/components/layout/Sidebar.vue
+++ b/gui/src/components/layout/Sidebar.vue
@@ -30,7 +30,7 @@
       <RouterLink
         v-for="item in navItems" :key="item.to"
         :to="item.to"
-        :title="collapsed ? item.label : ''"
+        :title="collapsed ? (item.label + (item.to === '/adapters' && adapterWarningCount ? ` — ${adapterWarningCount} Warnung(en)` : '')) : ''"
         :data-testid="'nav-' + (item.to === '/' ? 'home' : item.to.replace('/', ''))"
         :class="[
           'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors',
@@ -39,8 +39,21 @@
             : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700/60 hover:text-slate-800 dark:hover:text-slate-100'
         ]"
       >
-        <span class="shrink-0 text-lg w-5 text-center" v-html="item.icon" />
-        <span v-if="!collapsed" class="truncate">{{ item.label }}</span>
+        <span class="shrink-0 text-lg w-5 text-center relative" v-html="item.icon" />
+        <span v-if="!collapsed" class="truncate flex-1">{{ item.label }}</span>
+        <span
+          v-if="item.to === '/adapters' && adapterWarningCount > 0"
+          :class="[
+            'inline-flex items-center justify-center rounded-full text-[10px] font-bold leading-none',
+            adapterErrorCount > 0
+              ? 'bg-red-500/20 text-red-500 dark:text-red-400 border border-red-500/40'
+              : 'bg-amber-500/20 text-amber-600 dark:text-amber-400 border border-amber-500/40',
+            collapsed ? 'absolute -top-1 -right-1 min-w-[16px] h-4 px-1' : 'min-w-[20px] h-5 px-1.5',
+          ]"
+          :data-testid="'nav-adapter-warning-count'"
+        >
+          {{ adapterWarningCount }}
+        </span>
       </RouterLink>
 
       <!-- Visu link + Custom Links (abgesetzt) -->
@@ -90,20 +103,33 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { computed, onBeforeUnmount, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useWebSocketStore } from '@/stores/websocket'
 import { useNavLinksStore } from '@/stores/navLinks'
 import { useAuthStore } from '@/stores/auth'
+import { useAdapterStore } from '@/stores/adapters'
 import VisuIcon from '@/components/ui/VisuIcon.vue'
 
 defineProps({ collapsed: Boolean })
 defineEmits(['toggle'])
 
-const route    = useRoute()
-const ws       = useWebSocketStore()
-const navStore = useNavLinksStore()
-const auth     = useAuthStore()
+const route        = useRoute()
+const ws           = useWebSocketStore()
+const navStore     = useNavLinksStore()
+const auth         = useAuthStore()
+const adapterStore = useAdapterStore()
+
+// Issue #466: aggregate severity across instances so the user sees a counter
+// next to the "Adapter" menu item from any page.
+const adapterWarningCount = computed(
+  () => adapterStore.instances.filter(a => a.severity && a.severity !== 'ok').length,
+)
+const adapterErrorCount = computed(
+  () => adapterStore.instances.filter(a => a.severity === 'error').length,
+)
+
+let adapterPoll = null
 
 const navItems = [
   { to: '/',           label: 'Übersicht',    icon: '&#9783;' },
@@ -117,7 +143,21 @@ const navItems = [
 ]
 
 // Nur laden wenn bereits eingeloggt — sonst triggert der 401 den Interceptor-Redirect
-onMounted(() => { if (auth.isLoggedIn && !navStore.links.length) navStore.load() })
+onMounted(() => {
+  if (!auth.isLoggedIn) return
+  if (!navStore.links.length) navStore.load()
+  // Adapter-Status für den Warning-Counter (issue #466).
+  // Silent refresh; AdaptersView pollt selbst alle 10s wenn aktiv.
+  if (!adapterStore.instances.length) adapterStore.fetchAdapters({ silent: true }).catch(() => {})
+  adapterPoll = window.setInterval(
+    () => adapterStore.fetchAdapters({ silent: true }).catch(() => {}),
+    30000,
+  )
+})
+
+onBeforeUnmount(() => {
+  if (adapterPoll) window.clearInterval(adapterPoll)
+})
 
 function isActive(to) {
   if (to === '/') return route.path === '/'

--- a/gui/src/stores/adapters.js
+++ b/gui/src/stores/adapters.js
@@ -14,7 +14,11 @@ export const useAdapterStore = defineStore('adapters', () => {
         // Background refresh: only update status fields to avoid re-rendering the whole list
         for (const updated of data) {
           const existing = instances.value.find(a => a.id === updated.id)
-          if (existing) existing.connected = updated.connected
+          if (existing) {
+            existing.connected = updated.connected
+            existing.severity = updated.severity ?? 'ok'
+            existing.status_detail = updated.status_detail ?? ''
+          }
         }
       } else {
         instances.value = data

--- a/gui/src/utils/adapterStatus.js
+++ b/gui/src/utils/adapterStatus.js
@@ -1,0 +1,28 @@
+// Pure helpers that map an AdapterInstanceOut to its visible status — used by
+// AdaptersView, DashboardView and any future place that renders an adapter row.
+// Issue #466: ordering matters — severity overrides connected so a "warning"
+// adapter is rendered amber even while its tunnel is technically up.
+
+export function adapterDotClass(a) {
+  if (!a.running) return 'bg-slate-600'
+  if (a.severity === 'error') return 'bg-red-500'
+  if (a.severity === 'warning') return 'bg-amber-400'
+  if (a.connected) return 'bg-green-400'
+  return 'bg-amber-400 animate-pulse'
+}
+
+export function adapterBadgeVariant(a) {
+  if (!a.running) return 'muted'
+  if (a.severity === 'error') return 'danger'
+  if (a.severity === 'warning') return 'warning'
+  if (a.connected) return 'success'
+  return 'warning'
+}
+
+export function adapterStatusLabel(a) {
+  if (!a.running) return 'Inaktiv'
+  if (a.severity === 'error') return 'Fehler'
+  if (a.severity === 'warning') return 'Eingeschränkt'
+  if (a.connected) return 'Verbunden'
+  return 'Läuft'
+}

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -347,34 +347,13 @@ import AnwesenheitDatapointSelector from '@/components/adapters/AnwesenheitDatap
 import AnwesenheitConfigForm from '@/components/adapters/AnwesenheitConfigForm.vue'
 import KnxConfigForm        from '@/components/adapters/KnxConfigForm.vue'
 import Modal         from '@/components/ui/Modal.vue'
+import { adapterDotClass as dotClass, adapterBadgeVariant as statusBadgeVariant, adapterStatusLabel as statusLabel } from '@/utils/adapterStatus'
 
 const store          = useAdapterStore()
 const auth           = useAuthStore()
 const isDemo         = computed(() => auth.username === 'demo')
 const expanded       = reactive({})
 
-// Status-Ampel / Badge — berücksichtigt severity zusätzlich zu connected/running.
-function dotClass(a) {
-  if (!a.running) return 'bg-slate-600'
-  if (a.severity === 'error') return 'bg-red-500'
-  if (a.severity === 'warning') return 'bg-amber-400'
-  if (a.connected) return 'bg-green-400'
-  return 'bg-amber-400 animate-pulse'
-}
-function statusBadgeVariant(a) {
-  if (!a.running) return 'muted'
-  if (a.severity === 'error') return 'danger'
-  if (a.severity === 'warning') return 'warning'
-  if (a.connected) return 'success'
-  return 'warning'
-}
-function statusLabel(a) {
-  if (!a.running) return 'Inaktiv'
-  if (a.severity === 'error') return 'Fehler'
-  if (a.severity === 'warning') return 'Eingeschränkt'
-  if (a.connected) return 'Verbunden'
-  return 'Läuft'
-}
 const drafts         = reactive({})   // id → { name, config, enabled }
 const feedback       = reactive({})   // id → { success, detail }
 const busy           = reactive({})   // id → 'test' | 'save' | 'restart' | null

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -97,11 +97,11 @@
         <!-- Card Header -->
         <div class="card-header">
           <div class="flex items-center gap-3 min-w-0">
-            <span :class="['w-3 h-3 rounded-full shrink-0', a.connected ? 'bg-green-400' : a.running ? 'bg-amber-400 animate-pulse' : 'bg-slate-600']" />
+            <span :class="['w-3 h-3 rounded-full shrink-0', dotClass(a)]" :data-testid="`adapter-dot-${a.id}`" />
             <h3 class="font-semibold text-slate-800 dark:text-slate-100 truncate">{{ a.name }}</h3>
             <Badge variant="info" size="xs">{{ a.adapter_type }}</Badge>
-            <Badge :variant="a.connected ? 'success' : a.running ? 'warning' : 'muted'" size="xs">
-              {{ a.connected ? 'Verbunden' : a.running ? 'Läuft' : 'Inaktiv' }}
+            <Badge :variant="statusBadgeVariant(a)" size="xs" :data-testid="`adapter-status-badge-${a.id}`">
+              {{ statusLabel(a) }}
             </Badge>
           </div>
           <div class="flex items-center gap-2 shrink-0">
@@ -117,6 +117,24 @@
         <div class="px-5 py-2 flex gap-4 text-sm text-slate-500">
           <span>Verknüpfungen: <span class="text-slate-600 dark:text-slate-300 font-medium">{{ a.bindings }}</span></span>
           <span v-if="!a.registered" class="text-amber-400">⚠ Typ nicht registriert</span>
+        </div>
+
+        <!-- Status-Detail bei Warning/Error -->
+        <div
+          v-if="a.severity && a.severity !== 'ok' && a.status_detail"
+          :class="[
+            'mx-5 mb-3 flex items-start gap-2 p-3 rounded-lg text-sm',
+            a.severity === 'error'
+              ? 'bg-red-500/10 border border-red-500/30 text-red-500 dark:text-red-400'
+              : 'bg-amber-500/10 border border-amber-500/30 text-amber-600 dark:text-amber-400',
+          ]"
+          :data-testid="`adapter-status-detail-${a.id}`"
+        >
+          <svg class="w-4 h-4 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+          </svg>
+          <span>{{ a.status_detail }}</span>
         </div>
 
         <!-- Expanded Config Panel -->
@@ -334,6 +352,29 @@ const store          = useAdapterStore()
 const auth           = useAuthStore()
 const isDemo         = computed(() => auth.username === 'demo')
 const expanded       = reactive({})
+
+// Status-Ampel / Badge — berücksichtigt severity zusätzlich zu connected/running.
+function dotClass(a) {
+  if (!a.running) return 'bg-slate-600'
+  if (a.severity === 'error') return 'bg-red-500'
+  if (a.severity === 'warning') return 'bg-amber-400'
+  if (a.connected) return 'bg-green-400'
+  return 'bg-amber-400 animate-pulse'
+}
+function statusBadgeVariant(a) {
+  if (!a.running) return 'muted'
+  if (a.severity === 'error') return 'danger'
+  if (a.severity === 'warning') return 'warning'
+  if (a.connected) return 'success'
+  return 'warning'
+}
+function statusLabel(a) {
+  if (!a.running) return 'Inaktiv'
+  if (a.severity === 'error') return 'Fehler'
+  if (a.severity === 'warning') return 'Eingeschränkt'
+  if (a.connected) return 'Verbunden'
+  return 'Läuft'
+}
 const drafts         = reactive({})   // id → { name, config, enabled }
 const feedback       = reactive({})   // id → { success, detail }
 const busy           = reactive({})   // id → 'test' | 'save' | 'restart' | null

--- a/gui/src/views/DashboardView.vue
+++ b/gui/src/views/DashboardView.vue
@@ -121,6 +121,7 @@ import { useAdapterStore } from '@/stores/adapters'
 import Badge   from '@/components/ui/Badge.vue'
 import Spinner from '@/components/ui/Spinner.vue'
 import StatCard from '@/components/ui/StatCard.vue'
+import { adapterDotClass as adapterDot, adapterBadgeVariant, adapterStatusLabel } from '@/utils/adapterStatus'
 
 const dpStore  = useDatapointStore()
 const ws       = useWebSocketStore()
@@ -136,27 +137,6 @@ const adapterIssues = computed(
   () => adStore.instances.filter(a => a.severity && a.severity !== 'ok'),
 )
 
-function adapterDot(a) {
-  if (!a.running) return 'bg-slate-600'
-  if (a.severity === 'error') return 'bg-red-500'
-  if (a.severity === 'warning') return 'bg-amber-400'
-  if (a.connected) return 'bg-green-400'
-  return 'bg-amber-400'
-}
-function adapterBadgeVariant(a) {
-  if (!a.running) return 'muted'
-  if (a.severity === 'error') return 'danger'
-  if (a.severity === 'warning') return 'warning'
-  if (a.connected) return 'success'
-  return 'warning'
-}
-function adapterStatusLabel(a) {
-  if (!a.running) return 'Inaktiv'
-  if (a.severity === 'error') return 'Fehler'
-  if (a.severity === 'warning') return 'Eingeschränkt'
-  if (a.connected) return 'Verbunden'
-  return 'Läuft'
-}
 
 let unsubWs = null
 

--- a/gui/src/views/DashboardView.vue
+++ b/gui/src/views/DashboardView.vue
@@ -14,6 +14,53 @@
       <StatCard label="Server" :value="health.status === 'ok' ? 'Online' : 'Fehler'" icon="🖥️" :color="health.status === 'ok' ? 'green' : 'red'" />
     </div>
 
+    <!-- Aktive Warnungen (issue #466) — nur sichtbar bei degraded/fehlerhaften Adaptern -->
+    <div
+      v-if="adapterIssues.length"
+      class="card border-l-4"
+      :class="adapterIssues.some(a => a.severity === 'error') ? 'border-red-500' : 'border-amber-500'"
+      data-testid="dashboard-adapter-issues"
+    >
+      <div class="card-header">
+        <h3 class="font-semibold text-slate-800 dark:text-slate-100 text-sm flex items-center gap-2">
+          <svg class="w-4 h-4 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+          </svg>
+          Aktive Warnungen
+          <span class="text-xs text-slate-500 font-normal">({{ adapterIssues.length }})</span>
+        </h3>
+        <RouterLink to="/adapters" class="text-xs text-blue-400 hover:underline">Zu Adaptern →</RouterLink>
+      </div>
+      <div class="card-body flex flex-col gap-2">
+        <RouterLink
+          v-for="a in adapterIssues"
+          :key="a.id"
+          to="/adapters"
+          class="flex items-start gap-3 p-3 rounded-lg hover:bg-slate-100/80 dark:hover:bg-slate-800/40 transition-colors"
+        >
+          <span
+            :class="[
+              'w-2.5 h-2.5 mt-1.5 rounded-full shrink-0',
+              a.severity === 'error' ? 'bg-red-500' : 'bg-amber-400',
+            ]"
+          />
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-medium text-slate-700 dark:text-slate-200">{{ a.name }}</span>
+              <Badge variant="info" size="xs">{{ a.adapter_type }}</Badge>
+              <Badge :variant="a.severity === 'error' ? 'danger' : 'warning'" size="xs">
+                {{ a.severity === 'error' ? 'Fehler' : 'Warnung' }}
+              </Badge>
+            </div>
+            <div v-if="a.status_detail" class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+              {{ a.status_detail }}
+            </div>
+          </div>
+        </RouterLink>
+      </div>
+    </div>
+
     <!-- Adapter status + recent values -->
     <div class="grid lg:grid-cols-2 gap-4">
       <!-- Adapters -->
@@ -27,11 +74,9 @@
           <div v-else-if="!adapters.length" class="text-center text-slate-500 text-sm py-4">Keine Adapter konfiguriert</div>
           <div v-for="a in adapters" :key="a.adapter_type"
                class="flex items-center gap-3 p-3 bg-surface-700 rounded-lg">
-            <span :class="['w-2.5 h-2.5 rounded-full shrink-0', a.connected ? 'bg-green-400' : a.running ? 'bg-amber-400' : 'bg-slate-600']" />
+            <span :class="['w-2.5 h-2.5 rounded-full shrink-0', adapterDot(a)]" />
             <span class="flex-1 text-sm font-medium text-slate-700 dark:text-slate-200">{{ a.adapter_type }}</span>
-            <Badge :variant="a.connected ? 'success' : a.running ? 'warning' : 'muted'" size="xs">
-              {{ a.connected ? 'Verbunden' : a.running ? 'Läuft' : 'Inaktiv' }}
-            </Badge>
+            <Badge :variant="adapterBadgeVariant(a)" size="xs">{{ adapterStatusLabel(a) }}</Badge>
             <span class="text-xs text-slate-500">{{ a.bindings }} Verknüpfungen</span>
           </div>
         </div>
@@ -68,7 +113,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { systemApi } from '@/api/client'
 import { useDatapointStore } from '@/stores/datapoints'
 import { useWebSocketStore } from '@/stores/websocket'
@@ -84,6 +129,34 @@ const adStore  = useAdapterStore()
 const health   = ref({ status: '…', datapoints: '…', adapters_running: '…' })
 const adapters = ref([])
 const adaptersLoading = ref(false)
+
+// Issue #466: surface adapters reporting warning/error so degraded ones are
+// not buried in the regular adapter list.
+const adapterIssues = computed(
+  () => adStore.instances.filter(a => a.severity && a.severity !== 'ok'),
+)
+
+function adapterDot(a) {
+  if (!a.running) return 'bg-slate-600'
+  if (a.severity === 'error') return 'bg-red-500'
+  if (a.severity === 'warning') return 'bg-amber-400'
+  if (a.connected) return 'bg-green-400'
+  return 'bg-amber-400'
+}
+function adapterBadgeVariant(a) {
+  if (!a.running) return 'muted'
+  if (a.severity === 'error') return 'danger'
+  if (a.severity === 'warning') return 'warning'
+  if (a.connected) return 'success'
+  return 'warning'
+}
+function adapterStatusLabel(a) {
+  if (!a.running) return 'Inaktiv'
+  if (a.severity === 'error') return 'Fehler'
+  if (a.severity === 'warning') return 'Eingeschränkt'
+  if (a.connected) return 'Verbunden'
+  return 'Läuft'
+}
 
 let unsubWs = null
 

--- a/obs/adapters/base.py
+++ b/obs/adapters/base.py
@@ -46,6 +46,10 @@ class AdapterBase(ABC):
         self._bindings: list[Any] = []  # list[AdapterBinding]
         self._instance_id: uuid.UUID = instance_id or uuid.uuid4()
         self._instance_name: str = name or getattr(self, "adapter_type", "unknown")
+        # Cached so REST API can serve last-known severity/detail without
+        # subscribing to the EventBus (GUI polls /adapters/instances).
+        self._last_severity: str = "ok"
+        self._last_detail: str = ""
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -98,16 +102,30 @@ class AdapterBase(ABC):
     def connected(self) -> bool:
         return self._connected
 
-    async def _publish_status(self, connected: bool, detail: str = "") -> None:
+    @property
+    def last_severity(self) -> str:
+        return self._last_severity
+
+    @property
+    def last_detail(self) -> str:
+        return self._last_detail
+
+    async def _publish_status(self, connected: bool, detail: str = "", severity: str = "ok") -> None:
         from obs.core.event_bus import AdapterStatusEvent
 
-        self._connected = connected
+        # severity="warning" signals degraded operation without changing the
+        # connected flag — issue #466. All other severities track `connected`.
+        if severity != "warning":
+            self._connected = connected
+        self._last_severity = severity
+        self._last_detail = detail
         await self._bus.publish(
             AdapterStatusEvent(
                 adapter_type=self.adapter_type,
                 instance_id=self._instance_id,
                 instance_name=self._instance_name,
-                connected=connected,
+                connected=self._connected,
                 detail=detail,
+                severity=severity,
             ),
         )

--- a/obs/adapters/knx/adapter.py
+++ b/obs/adapters/knx/adapter.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -42,6 +44,8 @@ from obs.adapters.base import AdapterBase
 from obs.adapters.knx.dpt_registry import DPTRegistry
 from obs.adapters.registry import register
 from obs.core.event_bus import DataValueEvent
+
+TUNNEL_OVERLOAD_DETAIL = "KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet."
 
 # Import APCI classes at module level so missing symbols fail loudly at startup
 try:
@@ -98,6 +102,11 @@ class KnxAdapterConfig(BaseModel):
         default=None,
         json_schema_extra={"format": "password", "writeOnly": True},
     )
+    # Issue #466: tunnel-pool overload detection.
+    # `threshold` disconnects within `window_s` seconds raise a visible warning
+    # on the adapter card without flipping the connected flag.
+    tunnel_overload_threshold: int = Field(default=3, ge=1)
+    tunnel_overload_window_s: int = Field(default=300, ge=1)
 
 
 class KnxBindingConfig(BaseModel):
@@ -127,6 +136,14 @@ class KnxAdapter(AdapterBase):
         self._value_getter: Any = None
         self._reconnect_task: asyncio.Task | None = None
         self._stopped: bool = False
+        # Tunnel-overload detection (issue #466)
+        self._disconnect_times: deque[datetime] = deque()
+        self._warning_active: bool = False
+
+    @staticmethod
+    def _now() -> datetime:
+        """Monkeypatch-able clock seam for deterministic tests."""
+        return datetime.now(UTC)
 
     def set_value_getter(self, getter: Any) -> None:
         """Set a callable that returns ValueState | None for a datapoint UUID."""
@@ -150,7 +167,7 @@ class KnxAdapter(AdapterBase):
             from xknx.telegram.address import IndividualAddress
         except ImportError:
             logger.error("xknx not installed — KNX adapter disabled")
-            await self._publish_status(False, "xknx not installed")
+            await self._publish_status(False, "xknx not installed", severity="error")
             return
 
         # Clean up any previous xknx instance before creating a new one
@@ -198,7 +215,11 @@ class KnxAdapter(AdapterBase):
                 else:
                     # Manueller Modus Routing: Backbone-Key
                     if not cfg.backbone_key:
-                        await self._publish_status(False, "routing_secure erfordert backbone_key oder knxkeys_file_path")
+                        await self._publish_status(
+                            False,
+                            "routing_secure erfordert backbone_key oder knxkeys_file_path",
+                            severity="error",
+                        )
                         logger.error("KNX IP Secure (Routing): backbone_key und knxkeys_file_path fehlen")
                         return
                     backbone_hex = cfg.backbone_key.replace(":", "").replace(" ", "")
@@ -206,11 +227,11 @@ class KnxAdapter(AdapterBase):
                     secure_config = SecureConfig(backbone_key=backbone_hex)
                     logger.info("KNX IP Secure: Manueller Modus (Routing, backbone_key)")
             except ValueError as exc:
-                await self._publish_status(False, f"KNX Backbone-Key ungültig (kein Hex-String): {exc}")
+                await self._publish_status(False, f"KNX Backbone-Key ungültig (kein Hex-String): {exc}", severity="error")
                 logger.error("KNX IP Secure backbone_key Parse-Fehler: %s", exc)
                 return
             except Exception as exc:
-                await self._publish_status(False, f"KNX IP Secure Konfigurationsfehler: {exc}")
+                await self._publish_status(False, f"KNX IP Secure Konfigurationsfehler: {exc}", severity="error")
                 logger.error("KNX IP Secure Konfigurationsfehler: %s", exc)
                 return
 
@@ -235,7 +256,10 @@ class KnxAdapter(AdapterBase):
                 secure_config=secure_config,
             )
 
-        self._xknx = XKNX(connection_config=conn_cfg)
+        self._xknx = XKNX(
+            connection_config=conn_cfg,
+            connection_state_changed_cb=self._on_xknx_connection_state,
+        )
 
         try:
             await self._xknx.start()
@@ -253,7 +277,7 @@ class KnxAdapter(AdapterBase):
             # Rebuild sniffer on the new xknx instance
             await self._on_bindings_reloaded()
         except Exception as exc:
-            await self._publish_status(False, str(exc))
+            await self._publish_status(False, str(exc), severity="error")
             logger.warning("KNX connect failed: %s", exc)
 
     async def _reconnect_loop(self) -> None:
@@ -265,6 +289,72 @@ class KnxAdapter(AdapterBase):
             if not self._connected:
                 logger.info("KNX: not connected — attempting reconnect …")
                 await self._do_connect()
+
+    # ------------------------------------------------------------------
+    # Tunnel-pool overload detection — issue #466
+    # ------------------------------------------------------------------
+
+    def _prune_disconnects(self, now: datetime) -> None:
+        """Drop disconnect timestamps older than tunnel_overload_window_s."""
+        try:
+            window_s = int(self._config.get("tunnel_overload_window_s", 300))
+        except (TypeError, ValueError):
+            window_s = 300
+        cutoff = now.timestamp() - window_s
+        while self._disconnect_times and self._disconnect_times[0].timestamp() < cutoff:
+            self._disconnect_times.popleft()
+
+    async def _record_disconnect(self) -> None:
+        """Note a disconnect event; raise warning if it exceeds the threshold."""
+        try:
+            threshold = int(self._config.get("tunnel_overload_threshold", 3))
+        except (TypeError, ValueError):
+            threshold = 3
+        now = self._now()
+        self._disconnect_times.append(now)
+        self._prune_disconnects(now)
+
+        if not self._warning_active and len(self._disconnect_times) >= threshold:
+            self._warning_active = True
+            await self._publish_status(
+                connected=self._connected,
+                detail=TUNNEL_OVERLOAD_DETAIL,
+                severity="warning",
+            )
+            logger.warning(
+                "KNX tunnel-pool overload suspected: %d disconnects in last %ss",
+                len(self._disconnect_times),
+                self._config.get("tunnel_overload_window_s", 300),
+            )
+
+    async def _record_reconnect(self) -> None:
+        """Note a (re)connect event; clear warning once the window is quiet."""
+        now = self._now()
+        self._prune_disconnects(now)
+        if self._warning_active and not self._disconnect_times:
+            self._warning_active = False
+            await self._publish_status(
+                connected=self._connected,
+                detail="Tunnel-Pool wieder stabil.",
+                severity="ok",
+            )
+            logger.info("KNX tunnel-pool warning cleared (quiet window).")
+
+    def _on_xknx_connection_state(self, state: Any) -> None:
+        """Sync callback registered with xknx.connection_state_changed_cb.
+
+        xknx calls this from the main loop via call_soon_threadsafe, so the
+        actual async bookkeeping is scheduled via create_task.
+        """
+        try:
+            from xknx.core.connection_state import XknxConnectionState
+        except ImportError:
+            return
+        if state == XknxConnectionState.DISCONNECTED:
+            asyncio.ensure_future(self._record_disconnect())
+        elif state == XknxConnectionState.CONNECTED:
+            asyncio.ensure_future(self._record_reconnect())
+        # CONNECTING is a transient state — ignored.
 
     async def disconnect(self) -> None:
         self._stopped = True

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -51,6 +51,8 @@ class AdapterInstanceOut(BaseModel):
     registered: bool  # Typ-Klasse geladen?
     running: bool
     connected: bool
+    severity: str = "ok"  # "ok" | "warning" | "error" — last AdapterStatusEvent
+    status_detail: str = ""
     bindings: int
     created_at: str
     updated_at: str
@@ -162,6 +164,8 @@ def _instance_out(row: Any, instance: Any | None) -> AdapterInstanceOut:
         registered=cls is not None,
         running=instance is not None,
         connected=instance.connected if instance else False,
+        severity=getattr(instance, "last_severity", "ok") if instance else "ok",
+        status_detail=getattr(instance, "last_detail", "") if instance else "",
         bindings=len(instance.get_bindings()) if instance else 0,
         created_at=row["created_at"],
         updated_at=row["updated_at"],

--- a/obs/core/event_bus.py
+++ b/obs/core/event_bus.py
@@ -18,7 +18,9 @@ import uuid
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
+
+Severity = Literal["ok", "warning", "error"]
 
 logger = logging.getLogger(__name__)
 
@@ -41,13 +43,20 @@ class DataValueEvent:
 
 @dataclass
 class AdapterStatusEvent:
-    """Fired when an adapter connection state changes."""
+    """Fired when an adapter connection state changes.
+
+    `severity` lets the adapter signal degraded operation while still
+    technically connected (e.g. repeated KNX/IP tunnel disconnects in a
+    rolling window — see issue #466). The GUI renders ok/warning/error
+    differently in the adapter card, sidebar counter and dashboard tile.
+    """
 
     adapter_type: str
     connected: bool
     detail: str = ""
     instance_id: uuid.UUID | None = None
     instance_name: str = ""
+    severity: Severity = "ok"
     ts: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/tests/adapters/test_knx.py
+++ b/tests/adapters/test_knx.py
@@ -6,6 +6,10 @@ without the optional dependency.
 """
 
 from __future__ import annotations
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+from xknx.core.connection_state import XknxConnectionState
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.telegram import Telegram
 from xknx.telegram.address import GroupAddress
@@ -13,6 +17,7 @@ from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWri
 
 from obs.adapters.knx.adapter import KnxAdapter, KnxAdapterConfig, KnxBindingConfig, _telegram_to_bytes
 from obs.adapters.knx.dpt_registry import DPTRegistry
+from obs.core.event_bus import AdapterStatusEvent
 
 
 import pytest
@@ -373,3 +378,198 @@ class TestDPTRegistry:
         dpt = DPTRegistry.get("DPT9.001")
         val = 21.5
         assert abs(dpt.decoder(dpt.encoder(val)) - val) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Tunnel-Pool overload detection — issue #466
+# ---------------------------------------------------------------------------
+
+
+def _warning_events(mock_bus) -> list[AdapterStatusEvent]:
+    return [c.args[0] for c in mock_bus.publish.call_args_list if isinstance(c.args[0], AdapterStatusEvent) and c.args[0].severity == "warning"]
+
+
+def _ok_status_events(mock_bus) -> list[AdapterStatusEvent]:
+    return [c.args[0] for c in mock_bus.publish.call_args_list if isinstance(c.args[0], AdapterStatusEvent) and c.args[0].severity == "ok"]
+
+
+class TestTunnelOverloadDetection:
+    """Issue #466: detect repeated KNX/IP tunnel disconnects (pool overload)
+    and surface them as a visible AdapterStatusEvent with severity=warning."""
+
+    def _make_adapter(self, mock_bus, *, threshold: int = 3, window_s: int = 300) -> KnxAdapter:
+        return KnxAdapter(
+            event_bus=mock_bus,
+            config={
+                "host": "127.0.0.1",
+                "tunnel_overload_threshold": threshold,
+                "tunnel_overload_window_s": window_s,
+            },
+        )
+
+    def _pin_now(self, monkeypatch, adapter: KnxAdapter, when: datetime) -> None:
+        monkeypatch.setattr(adapter, "_now", lambda: when)
+
+    # ------------------------------------------------------------------
+    # Config schema
+    # ------------------------------------------------------------------
+
+    def test_config_defaults_match_issue_spec(self):
+        cfg = KnxAdapterConfig()
+        assert cfg.tunnel_overload_threshold == 3
+        assert cfg.tunnel_overload_window_s == 300
+
+    def test_config_accepts_custom_values(self):
+        cfg = KnxAdapterConfig(tunnel_overload_threshold=5, tunnel_overload_window_s=600)
+        assert cfg.tunnel_overload_threshold == 5
+        assert cfg.tunnel_overload_window_s == 600
+
+    # ------------------------------------------------------------------
+    # Sliding window
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_disconnect_older_than_window_is_pruned(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        self._pin_now(monkeypatch, adapter, t0)
+        await adapter._record_disconnect()
+        self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=301))
+        await adapter._record_disconnect()
+
+        # The first event aged out — only the most recent one remains.
+        assert len(adapter._disconnect_times) == 1
+        assert adapter._disconnect_times[0] == t0 + timedelta(seconds=301)
+
+    # ------------------------------------------------------------------
+    # Warning publication
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_publishes_no_warning(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        for offset in (0, 30):
+            self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        assert _warning_events(mock_bus) == []
+
+    @pytest.mark.asyncio
+    async def test_threshold_reached_publishes_warning_status(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        for offset in (0, 30, 60):
+            self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        warnings = _warning_events(mock_bus)
+        assert len(warnings) == 1
+        evt = warnings[0]
+        assert evt.adapter_type == "KNX"
+        assert evt.severity == "warning"
+        # Issue #466 wording — the GUI/admin uses detail verbatim.
+        assert "Tunnel" in evt.detail
+        assert "anderem Client" in evt.detail or "anderer Client" in evt.detail
+
+    @pytest.mark.asyncio
+    async def test_further_disconnects_do_not_republish_warning(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        for offset in (0, 30, 60, 90, 120):
+            self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        # Exactly one warning event — no spam while overload persists.
+        assert len(_warning_events(mock_bus)) == 1
+
+    # ------------------------------------------------------------------
+    # Recovery
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_connected_after_quiet_period_clears_warning(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        for offset in (0, 30, 60):
+            self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+        assert len(_warning_events(mock_bus)) == 1
+
+        # Window passes without further disconnects, then xknx reports CONNECTED.
+        self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=400))
+        await adapter._record_reconnect()
+
+        # A status event with severity="ok" must be published exactly once on recovery.
+        ok_events = _ok_status_events(mock_bus)
+        assert len(ok_events) >= 1
+        assert ok_events[-1].severity == "ok"
+        assert adapter._warning_active is False
+
+    @pytest.mark.asyncio
+    async def test_reconnect_during_active_window_does_not_clear_warning(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        for offset in (0, 30, 60):
+            self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+        ok_before = len(_ok_status_events(mock_bus))
+
+        # Ping-pong reconnect still inside the window — must NOT publish an ok event.
+        self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=90))
+        await adapter._record_reconnect()
+
+        assert adapter._warning_active is True
+        assert len(_ok_status_events(mock_bus)) == ok_before
+
+    # ------------------------------------------------------------------
+    # xknx callback wiring
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_xknx_disconnected_callback_records_event(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+        self._pin_now(monkeypatch, adapter, t0)
+
+        # The xknx ConnectionManager calls the sync callback in the main event loop.
+        adapter._on_xknx_connection_state(XknxConnectionState.DISCONNECTED)
+        # Allow the scheduled async record task to run.
+        await asyncio.sleep(0)
+
+        assert len(adapter._disconnect_times) == 1
+
+    @pytest.mark.asyncio
+    async def test_xknx_connected_callback_runs_reconnect_handler(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+        # First trip the warning, then advance time past the window.
+        for offset in (0, 30, 60):
+            self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        self._pin_now(monkeypatch, adapter, t0 + timedelta(seconds=400))
+        adapter._on_xknx_connection_state(XknxConnectionState.CONNECTED)
+        await asyncio.sleep(0)
+
+        assert adapter._warning_active is False
+        assert any(e.severity == "ok" for e in _ok_status_events(mock_bus))
+
+    @pytest.mark.asyncio
+    async def test_xknx_connecting_callback_is_ignored(self, mock_bus, monkeypatch):
+        adapter = self._make_adapter(mock_bus, threshold=3, window_s=300)
+        t0 = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+        self._pin_now(monkeypatch, adapter, t0)
+
+        adapter._on_xknx_connection_state(XknxConnectionState.CONNECTING)
+        await asyncio.sleep(0)
+
+        assert len(adapter._disconnect_times) == 0
+        assert _warning_events(mock_bus) == []


### PR DESCRIPTION
## Closes #466

Depending on the KNX/IP gateway, a given number of clients exceed its tunnel pool. Today
that produces silent ping-pong reconnects every 30 s, with no UI feedback.
The user only sees that values flicker.

## What this PR does

1. **Detection** — `KnxAdapter` subscribes to xknx's
   `connection_state_changed_cb`. Every `DISCONNECTED` transition is
   recorded in a sliding window. Three disconnects within 300 s
   (both configurable per adapter instance) trigger an
   `AdapterStatusEvent(severity="warning")` with detail
   `"KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet."`
   The `connected` flag is left unchanged so the warning never masks an
   actual disconnect.
2. **Surface** — `AdapterStatusEvent.severity` is a new `Literal["ok","warning","error"]`
   field, cached on `AdapterBase`, exposed via `AdapterInstanceOut.severity`
   and `.status_detail` so REST polling carries the state to the GUI without
   subscribing to the EventBus.
3. **Visualize** — three GUI places react:
   - **Adapter card**: 4-stage status dot (green / amber / red / grey-pulse),
     severity-aware badge (`Verbunden` / `Eingeschränkt` / `Fehler`), and a
     coloured detail banner under the card header.
   - **Sidebar**: a small amber (or red, if any adapter is in error)
     counter bubble on the "Adapter" menu item, visible from every page.
   - **Dashboard**: a new "Aktive Warnungen" tile, only shown when at least
     one adapter is non-ok; clicking a row navigates to `/adapters`.
4. **Existing error pathways** (xknx import failure, missing/invalid
   SecureConfig fields, generic connect exceptions) now publish with
   `severity="error"`, distinguishing them from graceful disconnects.
<img width="1527" height="606" alt="Bildschirmfoto 2026-05-15 um 14 40 39" src="https://github.com/user-attachments/assets/698ccb79-91c6-4e49-a3e4-6306dba56103" />

## Tests

- 11 new pytest cases in `TestTunnelOverloadDetection` (window pruning,
  threshold semantics, single-emit, recovery, xknx callback routing for
  all three connection states).
- Total: 1115 pytest pass, 7 skipped.
- Lint clean (`./tools/lint.sh --check`).
- `npm run build` clean.

## Smoke test (Path A — Pinia console mock, no hardware required)

Full reviewer-friendly walkthrough with all 16 visual checks lives in
[`docs/smoke-tests/issue-466-knx-tunnel-overload.md`](docs/smoke-tests/issue-466-knx-tunnel-overload.md).
Quick version:

1. `python -m obs` + `cd gui && npm run dev` (the Pinia store is only
   reachable from `__vue_app__` in the dev build, not the production
   bundle served by FastAPI).
2. Log in at `http://localhost:5173` (`admin` / `admin`).
3. Create any KNX adapter instance — the host doesn't need to be
   reachable, we manipulate the frontend state directly.
4. Open browser DevTools → Console, paste this once:

   ```js
   const app    = document.querySelector('#app').__vue_app__
   const pinia  = app.config.globalProperties.$pinia
   const store  = pinia._s.get('adapters')
   const knx    = store.instances.find(a => a.adapter_type === 'KNX')

   // Pause background polling so the mock isn't overwritten every 10–30 s.
   window.__origFetch  = store.fetchAdapters
   store.fetchAdapters = async () => {}

   window.setSev = (sev, detail = '') => { knx.severity = sev; knx.status_detail = detail }

   console.log('✅ Pinia locked. Use setSev("warning"|"error"|"ok", "…")')
   ```

5. Trigger each severity and verify the UI:

   ```js
   setSev('warning', 'KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet.')
   // → adapter card: amber dot, "Eingeschränkt" badge, yellow detail banner
   // → sidebar: amber "⚠ 1" bubble on "Adapter"
   // → dashboard "/" : new "Aktive Warnungen (1)" tile with yellow left border

   setSev('error', 'KNX Backbone-Key ungültig (kein Hex-String)')
   // → red dot, "Fehler" badge, red banner; sidebar bubble red, tile border red

   setSev('ok', '')
   // → green dot, "Verbunden" badge; bubble + warnings tile gone
   ```

6. When done, restore: `store.fetchAdapters = window.__origFetch`
   (or just reload the tab).

The same severity field is what the backend actually publishes —
`docs/smoke-tests/` also documents the curl one-liner that triggers
`severity="error"` end-to-end on a running stack (PATCH the adapter to an
invalid `routing_secure` config) and `pytest tests/adapters/test_knx.py::TestTunnelOverloadDetection`
covers the detection logic in isolation.

## Hardware verification

Reproduced live with one MDT IP-Interface (SCN-IP000.03 / SCN-IP100.03,
4 tunnel slots per spec) and 5 simultaneous clients (3 obs stacks + ETS
Bus Monitor + a pool-filler stack). The 5th client cycled cleanly through
all severity states (`error` → `warning` → `error` → `ok`) and the GUI
matched the expected colour/badge/banner/counter/tile changes. While the
pool stays overloaded the severity alternates between `warning` and
`error` every ~30 s: this is by design — every failed reconnect
re-publishes the harder `error`, the diagnostic `warning` re-asserts itself
when `_record_disconnect()` hits the threshold again. At 30 s intervals
the alternation reads as a measured status update, not a flicker.

## Commits

1. `feat(events)` — schema + AdapterBase cache + API surface
2. `feat(knx)`    — detection + tests
3. `feat(gui)`    — adapter card severity rendering + store
4. `feat(gui)`    — sidebar counter
5. `feat(gui)`    — dashboard tile
6. `docs`         — smoke test
7. `refactor(gui)` — extract shared `adapterStatus` helpers (deduplicate
   `AdaptersView` / `DashboardView`, makes the helpers unit-testable)
8. `docs`         — note expected severity flicker between warning/error
   during an active ping-pong (by design: `error` is harder than the
   diagnostic `warning`)
