### PR TITLE
Export: RFC-4180-Eingabefelder für Trennzeichen, Quote und Escape

### DIFF
--- a/gui/src/views/ringbuffer/ExportDialog.vue
+++ b/gui/src/views/ringbuffer/ExportDialog.vue
@@ -1,20 +1,71 @@
 <template>
-  <Modal v-model="openModel" title="CSV/TSV-Export" :soft-backdrop="true" max-width="lg">
+  <Modal v-model="openModel" title="Export" :soft-backdrop="true" max-width="lg">
     <div class="flex flex-col gap-4">
-      <!-- Format -->
+      <!-- Delimiter / Quote / Escape -->
       <div class="form-group">
-        <label class="label">Format</label>
-        <div class="flex gap-4">
-          <label class="inline-flex items-center gap-2">
-            <input type="radio" value="csv" v-model="form.format" data-testid="export-format-csv" />
-            <span>CSV (Komma)</span>
-          </label>
-          <label class="inline-flex items-center gap-2">
-            <input type="radio" value="tsv" v-model="form.format" data-testid="export-format-tsv" />
-            <span>TSV (Tab)</span>
-          </label>
+        <div class="flex items-center justify-between mb-1">
+          <label class="label">CSV-Format</label>
+          <button
+            type="button"
+            class="btn-secondary btn-sm"
+            data-testid="export-reset-rfc4180"
+            title="Setzt Trennzeichen, Anführungszeichen und Escape-Zeichen auf die RFC-4180-Vorgabe."
+            @click="resetToRfc4180"
+          >
+            ↺ RFC 4180
+          </button>
         </div>
-        <p class="text-xs text-slate-500 mt-1">Dateiendung: <code class="font-mono">.{{ form.format }}</code></p>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs text-slate-500">Trennzeichen</label>
+            <div class="flex items-center gap-2">
+              <input
+                v-model="form.delimiter"
+                type="text"
+                maxlength="1"
+                class="input font-mono w-16 text-center"
+                data-testid="export-delimiter"
+                :placeholder="form.delimiter === '\t' ? '⇥' : ','"
+              />
+              <button
+                type="button"
+                class="btn-secondary btn-sm"
+                data-testid="export-delimiter-tab"
+                title="Tabulator als Trennzeichen setzen (TSV)"
+                @click="form.delimiter = '\t'"
+              >
+                ⇥ Tab
+              </button>
+              <span v-if="form.delimiter === '\t'" class="text-xs text-slate-500">Tabulator</span>
+            </div>
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs text-slate-500">Anführungszeichen</label>
+            <input
+              v-model="form.quote_char"
+              type="text"
+              maxlength="1"
+              class="input font-mono w-16 text-center"
+              data-testid="export-quote-char"
+              placeholder='"'
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs text-slate-500">Escape-Zeichen</label>
+            <input
+              v-model="form.escape_char"
+              type="text"
+              maxlength="1"
+              class="input font-mono w-16 text-center"
+              data-testid="export-escape-char"
+              placeholder="(leer)"
+            />
+          </div>
+        </div>
+        <p class="text-xs text-slate-500 mt-1.5">
+          Dateiendung: <code class="font-mono">.{{ form.delimiter === '\t' ? 'tsv' : 'csv' }}</code>.
+          Escape-Zeichen leer = RFC 4180 (Anführungszeichen im Feld werden verdoppelt).
+        </p>
       </div>
 
       <!-- Encoding -->
@@ -55,7 +106,7 @@
 
     <template #footer>
       <button class="btn-secondary" data-testid="btn-export-cancel" @click="openModel = false">Abbrechen</button>
-      <button class="btn-primary" :disabled="busy" data-testid="btn-export-go" @click="onExport">
+      <button class="btn-primary" :disabled="busy || !formValid" data-testid="btn-export-go" @click="onExport">
         <Spinner v-if="busy" size="sm" color="white" />
         {{ pendingRowCount !== null ? 'Trotzdem exportieren' : 'Exportieren' }}
       </button>
@@ -83,8 +134,18 @@ const openModel = computed({
 
 const EXPORT_WARN_THRESHOLD = 1000
 
+// RFC 4180 defaults: comma delimiter, double-quote quoting, no separate
+// escape (quote-doubling inside quoted fields handles internal quotes).
+const RFC_4180_DEFAULTS = Object.freeze({
+  delimiter: ',',
+  quote_char: '"',
+  escape_char: '',
+})
+
 const form = reactive({
-  format: 'csv',
+  delimiter: ',',
+  quote_char: '"',
+  escape_char: '',
   encoding: 'utf8',
   include_unit: true,
   include_matched_set_ids: false,
@@ -92,6 +153,17 @@ const form = reactive({
 const busy = ref(false)
 const errorMsg = ref('')
 const pendingRowCount = ref(null)
+
+// delimiter and quote_char are required single characters. escape_char may be
+// empty (= no escape, RFC 4180 quote-doubling). Both backend Pydantic and the
+// UI enforce this so the Export button is disabled while the form is invalid.
+const formValid = computed(
+  () => form.delimiter.length === 1 && form.quote_char.length === 1 && form.escape_char.length <= 1,
+)
+
+function resetToRfc4180() {
+  Object.assign(form, RFC_4180_DEFAULTS)
+}
 
 watch(
   () => props.modelValue,
@@ -157,7 +229,9 @@ async function onExport() {
     const body = {
       set_ids: props.setIds || [],
       time: props.time || null,
-      format: form.format,
+      delimiter: form.delimiter,
+      quote_char: form.quote_char,
+      escape_char: form.escape_char,
       encoding: form.encoding,
       include_unit: form.include_unit,
       include_matched_set_ids: form.include_matched_set_ids,
@@ -172,7 +246,8 @@ async function onExport() {
     // Extract filename from Content-Disposition if present
     const cd = resp.headers?.['content-disposition'] || ''
     const match = cd.match(/filename="([^"]+)"/)
-    a.download = match ? match[1] : `ringbuffer_export.${form.format}`
+    const fallbackExt = form.delimiter === '\t' ? 'tsv' : 'csv'
+    a.download = match ? match[1] : `ringbuffer_export.${fallbackExt}`
     document.body.appendChild(a)
     a.click()
     a.remove()

--- a/obs/api/v1/ringbuffer.py
+++ b/obs/api/v1/ringbuffer.py
@@ -346,29 +346,45 @@ class RingBufferFiltersetOrderPatch(BaseModel):
 
 
 class RingBufferMultiExportRequest(BaseModel):
-    """Request body for ``POST /filtersets/export/csv`` (multi-set CSV/TSV export).
+    """Request body for ``POST /filtersets/export/csv`` (multi-set CSV export).
 
     Streams the full OR-union of entries matching any of the active filtersets,
-    plus an optional time filter, in CSV or TSV format. The export is
-    independent of UI pagination.
+    plus an optional time filter, as a delimiter-separated text file. The
+    delimiter, quote character and escape character are configurable — the
+    defaults follow RFC 4180. The export is independent of UI pagination.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     set_ids: list[str] = Field(default_factory=list)
     time: RingBufferTimeFilterV2 | None = None
-    format: Literal["csv", "tsv"] = "csv"
+    # Single-character delimiter (e.g. ',' for CSV, '\t' for TSV, ';' for
+    # German Excel). Always exactly one character.
+    delimiter: str = Field(default=",", min_length=1, max_length=1)
+    # Quote character around fields that contain the delimiter, the quote
+    # character itself, or newlines. Default '"' per RFC 4180.
+    quote_char: str = Field(default='"', min_length=1, max_length=1)
+    # Escape character for the quote character inside a quoted field. Empty
+    # string (default) selects RFC 4180 behaviour: the quote char inside a
+    # quoted field is doubled. Setting a single character switches the csv
+    # writer to backslash-style escaping (doublequote=False).
+    escape_char: str = Field(default="", max_length=1)
     encoding: Literal["utf8", "utf8-bom"] = "utf8"
     include_unit: bool = True
     include_matched_set_ids: bool = False
 
 
 class RingBufferExportSettings(BaseModel):
-    """Persisted user defaults for the CSV/TSV export dialog (#427)."""
+    """Persisted user defaults for the CSV export dialog (#427)."""
 
-    model_config = ConfigDict(extra="forbid")
+    # `extra="ignore"` so legacy persisted blobs that still carry `format`
+    # (csv|tsv) load without raising. The legacy fields are mapped to the
+    # new delimiter-based schema in get_ringbuffer_export_settings.
+    model_config = ConfigDict(extra="ignore")
 
-    format: Literal["csv", "tsv"] = "csv"
+    delimiter: str = Field(default=",", min_length=1, max_length=1)
+    quote_char: str = Field(default='"', min_length=1, max_length=1)
+    escape_char: str = Field(default="", max_length=1)
     encoding: Literal["utf8", "utf8-bom"] = "utf8"
     include_unit: bool = True
     include_matched_set_ids: bool = False
@@ -1373,8 +1389,12 @@ async def export_ringbuffer_filtersets_csv(
             f"export row limit exceeded (max {_CSV_EXPORT_MAX_ROWS})",
         )
 
-    delimiter = "\t" if body.format == "tsv" else ","
-    extension = "tsv" if body.format == "tsv" else "csv"
+    # Tab delimiter conventionally produces .tsv with the matching media type;
+    # everything else lands as .csv. Extension and media type are derived from
+    # the delimiter, not from a separate format selector.
+    extension = "tsv" if body.delimiter == "\t" else "csv"
+    media_type = "text/tab-separated-values" if body.delimiter == "\t" else "text/csv"
+
     fieldnames = list(_CSV_EXPORT_HEADERS)
     if body.include_unit:
         fieldnames.append("unit")
@@ -1389,7 +1409,17 @@ async def export_ringbuffer_filtersets_csv(
     )
     if body.encoding == "utf8-bom":
         spool.write("﻿")
-    writer = csv.DictWriter(spool, fieldnames=fieldnames, delimiter=delimiter)
+    # Empty escape_char selects RFC 4180 behaviour (doublequote=True). Setting
+    # an escape_char switches the writer to backslash-style escaping; csv
+    # requires doublequote=False in that mode.
+    writer_kwargs: dict[str, Any] = {
+        "delimiter": body.delimiter,
+        "quotechar": body.quote_char,
+    }
+    if body.escape_char:
+        writer_kwargs["escapechar"] = body.escape_char
+        writer_kwargs["doublequote"] = False
+    writer = csv.DictWriter(spool, fieldnames=fieldnames, **writer_kwargs)
     writer.writeheader()
     for entry in entries:
         row = _entry_to_csv_row(entry)
@@ -1401,7 +1431,6 @@ async def export_ringbuffer_filtersets_csv(
 
     spool.seek(0)
     filename = f"ringbuffer_export_{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}.{extension}"
-    media_type = "text/tab-separated-values" if body.format == "tsv" else "text/csv"
     background_tasks.add_task(spool.close)
     return StreamingResponse(
         spool,
@@ -1423,8 +1452,17 @@ async def get_ringbuffer_export_settings(
     if not row or not row["value"]:
         return RingBufferExportSettings()
     try:
-        return RingBufferExportSettings(**json.loads(row["value"]))
-    except (json.JSONDecodeError, ValidationError):
+        raw = json.loads(row["value"])
+    except json.JSONDecodeError:
+        return RingBufferExportSettings()
+    # Legacy format: pre-#427 the dialog stored a CSV/TSV radio selection.
+    # Translate to the new delimiter when the new key is absent so users
+    # don't silently lose their old TSV preference on first load.
+    if isinstance(raw, dict) and "delimiter" not in raw and raw.get("format") == "tsv":
+        raw["delimiter"] = "\t"
+    try:
+        return RingBufferExportSettings(**raw)
+    except ValidationError:
         return RingBufferExportSettings()
 
 

--- a/tests/integration/test_ringbuffer_export_count.py
+++ b/tests/integration/test_ringbuffer_export_count.py
@@ -143,6 +143,6 @@ async def test_count_unknown_set_id_is_skipped_like_export(client, auth_headers)
 
 
 async def test_count_rejects_unknown_fields(client, auth_headers):
-    """Format/encoding options on the count endpoint are a programming error → 422."""
-    resp = await _post_count(client, auth_headers, {"set_ids": [], "format": "csv"})
+    """Delimiter/encoding options on the count endpoint are a programming error → 422."""
+    resp = await _post_count(client, auth_headers, {"set_ids": [], "delimiter": ","})
     assert resp.status_code == 422

--- a/tests/integration/test_ringbuffer_multi_export.py
+++ b/tests/integration/test_ringbuffer_multi_export.py
@@ -182,7 +182,7 @@ async def test_multi_export_unknown_set_id_is_silently_skipped(client, auth_head
 # ---------------------------------------------------------------------------
 
 
-async def test_multi_export_tsv_format_uses_tab_and_tsv_extension(client, auth_headers):
+async def test_multi_export_tab_delimiter_uses_tsv_extension(client, auth_headers):
     tag = f"rb427tsv-{uuid.uuid4().hex[:8]}"
     dp = await _create_dp(client, auth_headers, f"RB427 TSV {uuid.uuid4()}", tags=[tag])
     await _write_value(client, auth_headers, dp["id"], 4.0)
@@ -198,7 +198,7 @@ async def test_multi_export_tsv_format_uses_tab_and_tsv_extension(client, auth_h
         resp = await _post_multi_export(
             client,
             auth_headers,
-            {"set_ids": [set_id], "format": "tsv"},
+            {"set_ids": [set_id], "delimiter": "\t"},
         )
         assert resp.status_code == 200, resp.text
         # Content-Disposition ends with .tsv
@@ -464,11 +464,32 @@ async def test_multi_export_quotes_csv_special_characters(client, auth_headers):
 # ---------------------------------------------------------------------------
 
 
-async def test_multi_export_invalid_format_returns_422(client, auth_headers):
+async def test_multi_export_legacy_format_key_returns_422(client, auth_headers):
+    # The `format` field was removed in favour of explicit delimiter/quote_char/
+    # escape_char. The request model has extra="forbid" so unknown fields fail
+    # validation rather than silently dropping the user's choice.
     resp = await _post_multi_export(
         client,
         auth_headers,
-        {"set_ids": [], "format": "xls"},
+        {"set_ids": [], "format": "csv"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_multi_export_multi_char_delimiter_returns_422(client, auth_headers):
+    resp = await _post_multi_export(
+        client,
+        auth_headers,
+        {"set_ids": [], "delimiter": "||"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_multi_export_empty_delimiter_returns_422(client, auth_headers):
+    resp = await _post_multi_export(
+        client,
+        auth_headers,
+        {"set_ids": [], "delimiter": ""},
     )
     assert resp.status_code == 422, resp.text
 
@@ -480,3 +501,31 @@ async def test_multi_export_invalid_encoding_returns_422(client, auth_headers):
         {"set_ids": [], "encoding": "latin1"},
     )
     assert resp.status_code == 422, resp.text
+
+
+async def test_multi_export_custom_delimiter_and_quote(client, auth_headers):
+    tag = f"rb427sep-{uuid.uuid4().hex[:8]}"
+    dp = await _create_dp(client, auth_headers, f"RB427 sep {uuid.uuid4()}", tags=[tag])
+    await _write_value(client, auth_headers, dp["id"], 4.0)
+
+    set_id = (
+        await _create_filterset(
+            client,
+            auth_headers,
+            {"name": f"RB427 sep-set {uuid.uuid4()}", "filter": {"tags": [tag]}},
+        )
+    )["id"]
+    try:
+        resp = await _post_multi_export(
+            client,
+            auth_headers,
+            {"set_ids": [set_id], "delimiter": ";", "quote_char": "'"},
+        )
+        assert resp.status_code == 200, resp.text
+        # Header line uses ; as separator.
+        header = resp.text.splitlines()[0]
+        assert ";" in header
+        rows = _parse_rows(resp.text, delimiter=";")
+        assert any(row["datapoint_id"] == dp["id"] for row in rows)
+    finally:
+        await _delete_filterset(client, auth_headers, set_id)


### PR DESCRIPTION
## Kontext

Feedback der Kollegen nach dem Merge von #404: die CSV/TSV-Radioauswahl im
Export-Dialog ist nicht ausreichend. Konkret fehlte
- **Semikolon** als Trennzeichen (deutsches Excel)
- **Anführungszeichen** konfigurierbar
- **Escape-Zeichen** konfigurierbar (RFC 4180 doppelt Anführungszeichen,
  manche Tools verlangen Backslash-Escape)

## Änderung

Backend (`obs/api/v1/ringbuffer.py`):

- `RingBufferMultiExportRequest` und `RingBufferExportSettings`:
  `format` raus, dafür `delimiter` (1 char), `quote_char` (1 char) und
  `escape_char` (0–1 chars). RFC-4180-Defaults `,` / `\"` / leer.
- Dateiendung und MIME-Typ werden vom Trennzeichen abgeleitet: Tab →
  `.tsv` / `text/tab-separated-values`, sonst `.csv` / `text/csv`.
- Empty `escape_char` ⇒ Python-`csv` doppelt interne Quotes (RFC 4180).
  Non-empty `escape_char` ⇒ `doublequote=False`, Backslash-Style.
- Persistierung-Load (`GET /export/settings`) migriert Legacy-Daten:
  altes `format: \"tsv\"` ⇒ `delimiter: \"\\t\"`. Nutzer verlieren ihre
  TSV-Präferenz nicht.
- Request-Model bleibt `extra=\"forbid\"`; alte Clients mit `format`
  kriegen 422 und müssen mit dem Dialog updaten.

Frontend (`gui/src/views/ringbuffer/ExportDialog.vue`):

- Drei `maxlength=1`-Inputs (monospace). Trennzeichen hat einen
  `⇥ Tab`-Helper-Button (Tab ist im Text-Input nicht tippbar) und
  zeigt einen `Tabulator`-Hinweis, sobald `\\t` aktiv ist.
- `↺ RFC 4180`-Button setzt Trennzeichen/Quote/Escape auf die Vorgabe
  zurück.
- Speichern-Button disabled solange ein erforderliches Feld leer ist.
- Persistierung unverändert via `getExportSettings` / `putExportSettings`.

## Tests

`tests/integration/test_ringbuffer_multi_export.py`:

- `test_multi_export_tsv_format_uses_tab_and_tsv_extension` →
  `test_multi_export_tab_delimiter_uses_tsv_extension`, jetzt mit
  `delimiter: \"\\t\"`.
- Neu: `test_multi_export_custom_delimiter_and_quote` (`;` + `'`).
- Neu: `test_multi_export_multi_char_delimiter_returns_422`.
- Neu: `test_multi_export_empty_delimiter_returns_422`.
- Bestehender Format-422-Test prüft jetzt, dass die alte `format`-Key
  durch `extra=\"forbid\"` abgewiesen wird (Regression-Schutz für
  Clients, die nicht migriert wurden).

\`pytest tests/integration/test_ringbuffer_{multi_export,export_count}.py\`
→ **21 passed**.

## Test plan

- [ ] http://localhost:8080 → `/ringbuffer` → Export
- [ ] Default `,` / `\"` / leer ⇒ Komma-CSV, Dateiendung `.csv`
- [ ] `⇥ Tab`-Button ⇒ Hinweis erscheint, Export ist `.tsv`
- [ ] Trennzeichen `;` ⇒ Semikolon-CSV
- [ ] Escape-Zeichen `\\\\` setzen ⇒ Backslash-Escape statt Quote-Doubling
- [ ] `↺ RFC 4180` ⇒ alle drei Felder zurück auf Default
- [ ] Dialog schließen + neu öffnen ⇒ letzte Einstellung kommt zurück
- [ ] DB-Backup mit `format: \"tsv\"` in `app_settings` einspielen
      ⇒ erstes Öffnen zeigt `\\t` als Trennzeichen (Legacy-Migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)