### PR TITLE
fix(e2e): visu api_client specs nutzen INTERNAL_BASE_URL

### DIFF
--- a/tests/gui/helpers.ts
+++ b/tests/gui/helpers.ts
@@ -20,6 +20,17 @@ dotenv.config({ path: path.resolve(__dirname, '..', '..', '.env') })
 
 const OBS_HTTP_HOST_PORT = process.env.OBS_HTTP_HOST_PORT ?? '8080'
 export const BASE_URL = process.env.BASE_URL ?? `http://localhost:${OBS_HTTP_HOST_PORT}`
+
+// URL that the **server itself** (inside its container or process) uses to
+// reach its own API — needed by specs that wire URLs into logic nodes which
+// the backend then dereferences (`api_client`, webhooks, …). It is *not*
+// generally the same as BASE_URL: in a Docker-Compose deployment the host
+// port mapping (e.g. 8082 → 8080) is invisible inside the container, so the
+// server still has to talk to `localhost:8080`. Default matches the in-
+// container listen port; override via `INTERNAL_BASE_URL` for bare-metal
+// or non-standard setups.
+export const INTERNAL_BASE_URL = process.env.INTERNAL_BASE_URL ?? 'http://localhost:8080'
+
 const E2E_USER = process.env.E2E_USER ?? 'admin'
 const E2E_PASS = process.env.E2E_PASS ?? 'admin'
 

--- a/tests/gui/visu/logic-editor.spec.ts
+++ b/tests/gui/visu/logic-editor.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { BASE_URL, apiPost, apiPut, apiGet, apiDelete, getToken } from '../helpers'
+import { INTERNAL_BASE_URL, apiPost, apiPut, apiGet, apiDelete, getToken } from '../helpers'
 
 
 /**
@@ -565,7 +565,7 @@ test('Logic-Editor Palette zeigt API Client Node an', async ({ page }) => {
 // ---------------------------------------------------------------------------
 test('api_client GET-Request gegen eigenen Server liefert success=true', async ({ page }) => {
   // Use the public health endpoint — no auth required, always returns 200
-  const targetUrl = `${BASE_URL}/api/v1/system/health`
+  const targetUrl = `${INTERNAL_BASE_URL}/api/v1/system/health`
 
   const graph = await apiPost('/api/v1/logic/graphs', {
     name: `E2E-ApiClient-GET-${Date.now()}`,
@@ -618,7 +618,7 @@ test('api_client GET-Request gegen eigenen Server liefert success=true', async (
 test('api_client Bearer Auth sendet Authorization-Header', async ({ page }) => {
   // Use the real JWT token so the auth-protected endpoint returns 200.
   // This verifies the api_client node correctly forwards the Bearer header.
-  const targetUrl = `${BASE_URL}/api/v1/logic/node-types`
+  const targetUrl = `${INTERNAL_BASE_URL}/api/v1/logic/node-types`
   const token = await getToken()
 
   const graph = await apiPost('/api/v1/logic/graphs', {
@@ -738,7 +738,7 @@ test('api_client Erfolg-Ausgang löst nachgelagerten Node aus bei HTTP 200', asy
   //        api_client.success + const_value(true) → and_gate
   // After the second-pass fix, and_gate.out must be true when HTTP returns 200.
   // Use the public health endpoint — no auth required.
-  const targetUrl = `${BASE_URL}/api/v1/system/health`
+  const targetUrl = `${INTERNAL_BASE_URL}/api/v1/system/health`
 
   const graph = await apiPost('/api/v1/logic/graphs', {
     name: `E2E-ApiClient-Downstream-${Date.now()}`,


### PR DESCRIPTION
Closes #482

## Kontext

Beim ersten Vollauf der Playwright-Suite gegen einen Compose-Stack mit
`OBS_HTTP_HOST_PORT=8082` (Standard-Dev-Konfig im Fork) sind drei specs
in [`visu/logic-editor.spec.ts`](tests/gui/visu/logic-editor.spec.ts)
rot:

- `api_client GET-Request gegen eigenen Server liefert success=true`
- `api_client Bearer Auth sendet Authorization-Header`
- `api_client Erfolg-Ausgang löst nachgelagerten Node aus bei HTTP 200`

## Ursache

Die Specs schreiben eine URL in einen `api_client`-Logic-Node und
triggern dann den Graph. Der **Backend-Container** dereferenziert diese
URL selbst.

Bis #404 war die URL hartcodiert auf `http://localhost:8080` —
funktioniert sowohl vom Test-Host als auch von **innerhalb** des
Containers (8080 ist der Listen-Port).

Nach #404 wird die URL aus `BASE_URL` gebaut, welche jetzt
`http://localhost:${OBS_HTTP_HOST_PORT}` ist — also der **Host-Port**.
Bei einer Compose-Stack mit `OBS_HTTP_HOST_PORT=8082` kann der
Container `localhost:8082` nicht erreichen, weil das Port-Mapping
nur auf dem Host existiert.

## Fix

Konzept aufspalten:

- **`BASE_URL`** — URL aus Sicht des Test-Hosts (unverändert).
- **`INTERNAL_BASE_URL`** — neue Konstante, default
  `http://localhost:8080`, override via `INTERNAL_BASE_URL` env.
  URL aus Sicht des Servers, um sich selbst zu erreichen.

Die drei `api_client`-Specs nutzen `INTERNAL_BASE_URL`. Keine
Infrastrukturänderung für den Standardfall (8080 inside == default);
nicht-Standard-Deployments können `INTERNAL_BASE_URL` überschreiben.

## Verifikation

Lokal gegen einen `obs-dev`-Compose-Stack auf 8082:

```
npx playwright test --grep \"api_client\" --reporter=line
…
7 passed (6.4s)
```

Alle sieben api_client-bezogenen Specs (admin + visu) passieren — die
drei vorher roten inklusive.

## Test plan

- [ ] `docker compose up -d` mit beliebigem `OBS_HTTP_HOST_PORT` in `.env`
- [ ] `cd tests/gui && npx playwright test --grep \"api_client\" --reporter=line`
- [ ] alle sieben api_client-Specs grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)
