### PR TITLE
ci(e2e): Playwright-Suite auf GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,91 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      # docker-compose.yml reads these for the obs + Mosquitto containers
+      OBS_HTTP_HOST_PORT: "8080"
+      OBS_MQTT_USERNAME: obs
+      OBS_MQTT_PASSWORD: ci-mqtt-pass
+      OBS_JWT_SECRET: ci-jwt-secret-min-32-chars-long-enough
+      OBS_LOG_LEVEL: WARNING
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Bring up the stack
+        run: docker compose up -d --build
+
+      - name: Wait for /system/health
+        run: |
+          for i in {1..60}; do
+            if curl -sf http://localhost:8080/api/v1/system/health >/dev/null; then
+              echo "stack healthy after ${i} attempts"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::stack did not become healthy in 120s"
+          docker compose ps
+          docker compose logs --no-color
+          exit 1
+
+      - name: Create demo user for demo-setup specs
+        run: |
+          set -euo pipefail
+          TOKEN=$(
+            curl -sS -X POST http://localhost:8080/api/v1/auth/login \
+              -H 'Content-Type: application/json' \
+              -d '{"username":"admin","password":"admin"}' \
+            | jq -r .access_token
+          )
+          curl -sS -X POST http://localhost:8080/api/v1/auth/users \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d '{"username":"demo","password":"demo","is_admin":false}' \
+            -o /dev/null -w 'create-demo-user: HTTP %{http_code}\n'
+
+      - name: Install Playwright dependencies
+        working-directory: tests/gui
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright suite
+        working-directory: tests/gui
+        run: npx playwright test --reporter=line
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: |
+            tests/gui/test-results
+            tests/gui/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Compose logs on failure
+        if: failure()
+        run: docker compose logs --no-color


### PR DESCRIPTION
## Kontext

Vor #404 lief Playwright nie im CI. Folge: drei visu-Specs sind sechs
Wochen lang grün geblieben, obwohl sie schon längst rot waren —
\`live-mode-badge\` wurde umbenannt, Phase-1-FilterBuilder-Selektoren
weggeräumt, \`format\`-Radio gegen RFC-4180-Inputs ersetzt. Niemand hat
gemerkt, dass die Suite kaputt ist, bis ich beim Anrollen gegen den
8082-Stack ins Leere gegriffen habe.

Dieser PR schließt die Lücke: bei jedem Push auf main und jedem PR
gegen main läuft die volle Suite auf einem Ubuntu-Runner.

## Ablauf

1. \`docker compose up -d --build\` mit den Workflow-Env-Defaults
   (Port 8080, admin/admin)
2. 120-Sekunden-Health-Polling auf \`/api/v1/system/health\` — bei
   Timeout werden compose ps + logs in der Job-Ausgabe gedumpt
3. Vorab einen \`demo\`/\`demo\` Non-Admin-User per Auth-API anlegen.
   Lokale Dev-DBs haben den manuell drin, frische CI-DBs nicht. Ohne
   diesen Schritt fielen 10 demo-Specs (\`demo.setup.ts\` + abhängige)
   reflexartig aus.
4. \`npm install\` + \`npx playwright install --with-deps chromium\` in
   \`tests/gui\`
5. \`npx playwright test --reporter=line\` — Volle Suite (admin + visu +
   demo)
6. Bei Failure: \`tests/gui/test-results\` und etwaiger
   \`playwright-report\` als Artefakt (7 Tage), zusätzlich compose
   logs im Job-Output

## Steuerung

- \`concurrency.cancel-in-progress: true\` — schnelle aufeinanderfolgende
  Pushes/Pushes-und-PR-Updates canceln den laufenden Job, ein Pile-up
  ist nicht nötig
- \`timeout-minutes: 20\` — lokaler Vollauf war 3 min, das gibt
  Headroom für kalten Cache + Chromium-Download

## Abhängigkeit

PR basiert auf [#484](https://github.com/abeggled/openbridgeserver/pull/484) (visu \`INTERNAL_BASE_URL\` Fix). Sobald #484
gemergt ist, kann dieser Diff direkt auf main rebased werden. Solange
#484 offen ist, würde der Workflow auf main rot starten — daher die
Basis-Wahl.

## Test plan

- [ ] PR merged → erster CI-Run gegen main ist grün
- [ ] Künftige PRs mit Frontend-Änderungen sehen den Suite-Status im
      Check-Strip
- [ ] Selektor-Drift in einer Frontend-PR fällt sofort auf, nicht
      sechs Wochen später

🤖 Generated with [Claude Code](https://claude.com/claude-code)