### PR TITLE
refactor(hierarchy): unify wording — Hierarchie / Wurzelknoten / Ebene

### DIFF
--- a/gui/src/components/HierarchyManager.vue
+++ b/gui/src/components/HierarchyManager.vue
@@ -9,7 +9,7 @@
         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
-        Neuer Ast
+        Neue Hierarchie
       </button>
       <button @click="openEtsImport" class="btn-secondary btn-sm" data-testid="btn-ets-import">
         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -32,7 +32,7 @@
       <svg class="w-10 h-10 mx-auto mb-3 text-slate-300 dark:text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h12M3 17h8"/>
       </svg>
-      Noch keine Hierarchieäste. Erstelle einen neuen Ast oder importiere aus ETS.
+      Noch keine Hierarchien. Erstelle eine neue Hierarchie oder importiere aus ETS.
     </div>
 
     <!-- Tree list -->
@@ -58,12 +58,12 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536M9 13l6.293-6.293a1 1 0 011.414 0l1.586 1.586a1 1 0 010 1.414L12 16H9v-3z"/>
             </svg>
           </button>
-          <button @click="addRootNode(tree)" class="btn-secondary btn-xs" :data-testid="`btn-add-root-${tree.id}`" title="Obersten Knoten hinzufügen">
+          <button @click="addRootNode(tree)" class="btn-secondary btn-xs" :data-testid="`btn-add-root-${tree.id}`" title="Wurzelknoten hinzufügen">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
             </svg>
           </button>
-          <button @click="confirmDeleteTree(tree)" class="btn-danger btn-xs" :data-testid="`btn-delete-tree-${tree.id}`" title="Ast löschen">
+          <button @click="confirmDeleteTree(tree)" class="btn-danger btn-xs" :data-testid="`btn-delete-tree-${tree.id}`" title="Hierarchie löschen">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7h6m-7 0a1 1 0 011-1h4a1 1 0 011 1m-7 0h8"/>
             </svg>
@@ -74,7 +74,7 @@
         <div v-if="expandedTrees.has(tree.id)" class="card-body pt-0">
           <div v-if="treeLoading.has(tree.id)" class="flex justify-center py-4"><Spinner size="sm" /></div>
           <div v-else-if="!treeNodes[tree.id]?.length" class="text-xs text-slate-500 py-2 text-center">
-            Dieser Ast ist noch leer.
+            Diese Hierarchie ist noch leer.
           </div>
           <div v-else class="tree-container">
             <HierarchyNodeTree
@@ -94,7 +94,7 @@
     <div v-if="treeModal.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="treeModal.open = false">
       <div class="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-sm p-6 flex flex-col gap-4">
         <h3 class="font-semibold text-slate-800 dark:text-slate-100">
-          {{ treeModal.isEdit ? 'Ast umbenennen' : 'Neuer Hierarchiebaum' }}
+          {{ treeModal.isEdit ? 'Hierarchie umbenennen' : 'Neue Hierarchie' }}
         </h3>
         <div class="form-group">
           <label class="label">Name</label>
@@ -152,7 +152,7 @@
       <div class="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-lg p-6 flex flex-col gap-4">
         <h3 class="font-semibold text-slate-800 dark:text-slate-100">Hierarchie aus ETS importieren</h3>
         <p class="text-sm text-slate-500">
-          Erzeugt einen neuen Hierarchiebaum aus den importierten ETS-Daten.
+          Erzeugt eine neue Hierarchie aus den importierten ETS-Daten.
           <span v-if="['buildings','trades'].includes(etsModal.mode)">Gebäude/Gewerke-Modus nutzt die räumliche bzw. funktionale Struktur aus dem ETS-Projekt.</span>
           <span v-else>Gruppenbezeichnungen werden direkt aus dem ETS-Projekt übernommen.</span>
         </p>
@@ -176,7 +176,7 @@
         </div>
 
         <div class="form-group">
-          <label class="label">Name des neuen Astes</label>
+          <label class="label">Name der neuen Hierarchie</label>
           <input v-model="etsModal.treeName" type="text" class="input" placeholder="z.B. Gewerke" />
         </div>
 
@@ -337,8 +337,8 @@ async function saveTree() {
 }
 
 function confirmDeleteTree(tree) {
-  deleteConfirm.title = `Ast löschen: ${tree.name}`
-  deleteConfirm.message = 'Dieser Ast und alle enthaltenen Knoten sowie Verknüpfungen werden unwiderruflich gelöscht.'
+  deleteConfirm.title = `Hierarchie löschen: ${tree.name}`
+  deleteConfirm.message = 'Diese Hierarchie und alle enthaltenen Knoten sowie Verknüpfungen werden unwiderruflich gelöscht.'
   deleteConfirm.saving = false
   deleteConfirm.action = async () => {
     deleteConfirm.saving = true

--- a/gui/src/utils/hierarchyDepthOptions.js
+++ b/gui/src/utils/hierarchyDepthOptions.js
@@ -1,7 +1,7 @@
-const LEVEL_NAMES = ['Ast-Name', 'Erste Ebene', 'Zweite Ebene', 'Dritte Ebene', 'Vierte Ebene']
+const LEVEL_NAMES = ['Hierarchiename', 'Erste Ebene', 'Zweite Ebene', 'Dritte Ebene', 'Vierte Ebene']
 
 const GENERIC_LABELS = [
-  '0 — Ast-Name (Standard, z.B. "Gebäude")',
+  '0 — Hierarchiename (Standard, z.B. "Gebäude")',
   '1 — Erste Ebene (z.B. "EG" statt "Gebäude")',
   '2 — Zweite Ebene (z.B. "Wohnzimmer")',
   '3 — Dritte Ebene',
@@ -25,7 +25,7 @@ export function buildDepthOptions({ isEdit, tree, rootNodes, maxDepth = 4 }) {
 
     if (level === 0) {
       const name = tree?.name ?? LEVEL_NAMES[0]
-      options.push({ value: 0, label: `0 — ${name} (Ast-Name)`, disabled: false })
+      options.push({ value: 0, label: `0 — ${name} (Hierarchiename)`, disabled: false })
       continue
     }
 

--- a/obs/api/v1/hierarchy.py
+++ b/obs/api/v1/hierarchy.py
@@ -1,10 +1,10 @@
 """Hierarchy Manager API — /api/v1/hierarchy/...
 
 Endpoints:
-  GET    /hierarchy/trees                         → alle Äste (Trees)
-  POST   /hierarchy/trees                         → Ast anlegen
-  PUT    /hierarchy/trees/{tree_id}               → Ast umbenennen
-  DELETE /hierarchy/trees/{tree_id}               → Ast löschen
+  GET    /hierarchy/trees                         → alle Hierarchien (Trees)
+  POST   /hierarchy/trees                         → Hierarchie anlegen
+  PUT    /hierarchy/trees/{tree_id}               → Hierarchie umbenennen
+  DELETE /hierarchy/trees/{tree_id}               → Hierarchie löschen
 
   GET    /hierarchy/trees/{tree_id}/nodes         → Baumstruktur (nested)
   POST   /hierarchy/nodes                         → Knoten anlegen
@@ -513,12 +513,12 @@ async def delete_link(
 
 @router.get("/nodes/search", response_model=list[NodeSearchResult])
 async def search_nodes(
-    q: str = Query("", description="Volltext-Suche in Knoten- und Ast-Namen"),
+    q: str = Query("", description="Volltext-Suche in Knoten- und Hierarchienamen"),
     limit: int = Query(30, ge=1, le=200),
     _user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> list[NodeSearchResult]:
-    """Knoten über alle Äste hinweg suchen. Gibt Knoten mit Ast-Kontext zurück."""
+    """Knoten über alle Hierarchien hinweg suchen. Gibt Knoten mit Hierarchie-Kontext zurück."""
     if q:
         like = f"%{q}%"
         rows = await db.fetchall(

--- a/tests/gui/admin/hierarchy.spec.ts
+++ b/tests/gui/admin/hierarchy.spec.ts
@@ -38,12 +38,12 @@ test('Edit-Modal zeigt konkrete Beispiele aus dem aktuellen Baum', async ({ page
     await expect(select).toBeVisible()
     const optionTexts = await select.locator('option').allTextContents()
 
-    expect(optionTexts[0]).toContain(treeName)            // "0 — <treeName> (Ast-Name)"
-    expect(optionTexts[0]).toContain('Ast-Name')
+    expect(optionTexts[0]).toContain(treeName)            // "0 — <treeName> (Hierarchiename)"
+    expect(optionTexts[0]).toContain('Hierarchiename')
     expect(optionTexts[1]).toContain(rootName)             // "1 — Erste Ebene (nur \"EG Test\")"
     expect(optionTexts[1]).toContain('nur')                // genau ein Wurzelknoten → distinct=1
     expect(optionTexts[2]).toContain(childName)            // "2 — Zweite Ebene (nur \"Wohnzimmer Test\")"
-    // Ebene 3 + 4 sind disabled (Baum hat nur 2 Ebenen)
+    // Ebene 3 + 4 sind disabled (Hierarchie hat nur 2 Ebenen)
     const disabled3 = await select.locator('option').nth(3).getAttribute('disabled')
     expect(disabled3).not.toBeNull()
 

--- a/tests/integration/test_hierarchy.py
+++ b/tests/integration/test_hierarchy.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.integration
 # ---------------------------------------------------------------------------
 
 
-async def _create_tree(client, auth_headers, name="Gebäude", desc="Test-Ast") -> dict:
+async def _create_tree(client, auth_headers, name="Gebäude", desc="Test-Hierarchie") -> dict:
     resp = await client.post(
         "/api/v1/hierarchy/trees",
         json={"name": name, "description": desc},


### PR DESCRIPTION
Closes #489

## Summary

Vereinheitlicht die Bezeichnungen rund um die Hierarchie-Funktion auf ein einheitliches Modell. Vorher mischten sich „Ast" und „Hierarchiebaum" als Begriffe für dasselbe `hierarchy_trees`-Objekt (z. B. „Neuer Hierarchiebaum" beim Create, „Ast umbenennen" beim Edit). „Ast" wurde zudem mehrdeutig verwendet: einmal als Synonym für die Top-Level-Hierarchie, einmal (korrekt) als Subtree.

| Konzept | Begriff |
|---|---|
| `hierarchy_trees`-Zeile (gesamtes Objekt) | **Hierarchie** (UI) / **Hierarchiebaum** (API-Errors) |
| Top-Level-Knoten innerhalb einer Hierarchie | **Wurzelknoten** |
| Beliebiger innerer Knoten | **Knoten** (unverändert) |
| Tiefe (0, 1, 2, …) | **Ebene** (unverändert) |
| Subtree unterhalb eines Knotens | **Ast** (nur dort, wo „kompletter Teilbaum" gemeint ist) |

## Geänderte Strings

### GUI

- `gui/src/components/HierarchyManager.vue`:
  - Toolbar: „Neuer Ast" → „Neue Hierarchie"
  - Empty-State: „Noch keine Hierarchieäste …" → „Noch keine Hierarchien …"
  - Create-Modal-Titel: „Neuer Hierarchiebaum" → „Neue Hierarchie" (Edit-Pfad parallel: „Ast umbenennen" → „Hierarchie umbenennen")
  - Tooltips: „Obersten Knoten hinzufügen" → „Wurzelknoten hinzufügen"; „Ast löschen" → „Hierarchie löschen"
  - Delete-Confirm + Empty-Inner-State: „Dieser Ast …" → „Diese Hierarchie …"
  - ETS-Import-Modal: Beschreibung + Label angepasst
- `gui/src/utils/hierarchyDepthOptions.js`: Dropdown-Label `0 — Ast-Name` → `0 — Hierarchiename` (Edit- und Create-Modus)

### API (FastAPI)

- `obs/api/v1/hierarchy.py`: Modul-Docstring + Search-`description` + Search-Docstring auf „Hierarchie" angeglichen. API-Errors „Hierarchiebaum nicht gefunden" bleiben unverändert (passen ins neue Schema).

### Tests

- `tests/gui/admin/hierarchy.spec.ts` (Playwright) — erwartet neues Label
- `tests/integration/test_hierarchy.py` — Default-Description-String

### Nicht verändert

- `gui/src/views/DataPointsView.vue:176` — „Ganzer Ast" als Chip-Suffix bleibt; hier ist „Ast" = Subtree, semantisch passend.
- Datenbankschema, API-Pfade, englische Identifier (`Tree`, `Node`, `root`) — kein Breaking Change.

## Test plan

- [x] `./tools/lint.sh --check` grün
- [x] `npm --prefix gui run build` grün
- [x] `npm --prefix gui test` grün (303/303 vorhandene Vitest-Specs unverändert)
- [x] Manuell gegen `obs-dev` (Port 8082) verifiziert: alle Modale und Tooltips zeigen das neue Wording
- [ ] Playwright `tests/gui/admin/hierarchy.spec.ts` läuft im PR-CI durch
- [ ] Integration-Test `tests/integration/test_hierarchy.py` läuft im PR-CI durch

🤖 Generated with [Claude Code](https://claude.com/claude-code)