### PR TITLE
[codex] Fix ioBroker Socket.IO reconnect lifecycle

### DIFF
--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -34,6 +34,7 @@ import base64
 import contextlib
 import json
 import logging
+import random
 import time
 from typing import Any
 
@@ -71,6 +72,7 @@ class IoBrokerAdapterConfig(BaseModel):
     access_token: str | None = Field(default=None, json_schema_extra={"format": "password"})
     resubscribe_interval_seconds: int = Field(default=60, ge=0)
     reconnect_interval_seconds: int = Field(default=5, ge=1)
+    reconnect_max_interval_seconds: int = Field(default=60, ge=1)
 
 
 class IoBrokerBindingConfig(BaseModel):
@@ -299,6 +301,19 @@ class IoBrokerAdapter(AdapterBase):
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
+    async def _close_socket(self, sio: Any | None) -> None:
+        if sio is None:
+            return
+        with contextlib.suppress(Exception):
+            await sio.disconnect()
+
+    async def _detach_and_close_socket(self, sio: Any | None) -> None:
+        if sio is None:
+            return
+        if self._socket is sio:
+            self._socket = None
+        await self._close_socket(sio)
+
     async def _subscription_watchdog(self) -> None:
         assert self._cfg is not None
         interval = self._cfg.resubscribe_interval_seconds
@@ -335,6 +350,7 @@ class IoBrokerAdapter(AdapterBase):
             if self._socket is not sio:
                 return
             logger.info("ioBroker Socket.IO disconnected")
+            self._socket = None
             await self._publish_status(False, "Socket.IO getrennt")
             self._ensure_reconnect_task()
 
@@ -350,6 +366,9 @@ class IoBrokerAdapter(AdapterBase):
         async with self._connect_lock:
             if self._disconnect_requested:
                 return False
+            old_socket = self._socket
+            if old_socket is not None:
+                await self._detach_and_close_socket(old_socket)
             sio = self._build_socket()
             self._socket = sio
             try:
@@ -360,6 +379,7 @@ class IoBrokerAdapter(AdapterBase):
                     logger.warning("ioBroker Socket.IO polling handshake failed; retrying with websocket transport")
                     fallback_kwargs = dict(self._connect_kwargs)
                     fallback_kwargs["transports"] = ["websocket"]
+                    await self._detach_and_close_socket(sio)
                     fallback_sio = self._build_socket()
                     self._socket = fallback_sio
                     try:
@@ -367,12 +387,10 @@ class IoBrokerAdapter(AdapterBase):
                         self._connect_kwargs = fallback_kwargs
                         return True
                     except Exception:
-                        if self._socket is fallback_sio:
-                            self._socket = None
+                        await self._detach_and_close_socket(fallback_sio)
                         logger.exception("ioBroker Socket.IO websocket fallback failed")
                         return False
-                if self._socket is sio:
-                    self._socket = None
+                await self._detach_and_close_socket(sio)
                 logger.exception("ioBroker Socket.IO connection failed")
                 return False
 
@@ -391,13 +409,19 @@ class IoBrokerAdapter(AdapterBase):
 
     async def _reconnect_loop(self) -> None:
         assert self._cfg is not None
+        base_delay = float(self._cfg.reconnect_interval_seconds)
+        max_delay = float(max(self._cfg.reconnect_max_interval_seconds, self._cfg.reconnect_interval_seconds))
+        attempt = 0
         while not self._disconnect_requested:
             if self._socket_is_connected():
                 return
             connected = await self._connect_socket()
             if connected:
                 return
-            await asyncio.sleep(self._cfg.reconnect_interval_seconds)
+            delay = min(max_delay, base_delay * (2**attempt))
+            jitter = random.uniform(-0.2 * delay, 0.2 * delay)
+            await asyncio.sleep(max(0.1, delay + jitter))
+            attempt += 1
 
     async def _subscribe_bound_states(self, *, force_publish_initial: bool = True) -> bool:
         if not self._socket_is_connected() or not self._state_map:

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -253,6 +253,79 @@ class TestSubscribe:
 
 
 class TestReconnect:
+    def test_build_socket_disables_socketio_internal_reconnect(self, adapter):
+        class FakeSocket:
+            def event(self, handler):
+                return handler
+
+            def on(self, _event):
+                def decorator(handler):
+                    return handler
+
+                return decorator
+
+        class FakeSocketIO:
+            def __init__(self):
+                self.kwargs = None
+
+            def AsyncClient(self, **kwargs):  # noqa: N802
+                self.kwargs = kwargs
+                return FakeSocket()
+
+        fake_socketio = FakeSocketIO()
+        adapter._socketio = fake_socketio
+
+        adapter._build_socket()
+
+        assert fake_socketio.kwargs["reconnection"] is False
+        assert fake_socketio.kwargs["logger"] is False
+        assert fake_socketio.kwargs["engineio_logger"] is False
+
+    @pytest.mark.asyncio
+    async def test_disconnect_handler_detaches_socket_and_starts_single_reconnect(self, adapter):
+        class FakeSocket:
+            def event(self, handler):
+                setattr(self, handler.__name__, handler)
+                return handler
+
+            def on(self, _event):
+                def decorator(handler):
+                    return handler
+
+                return decorator
+
+        socket = FakeSocket()
+        adapter._socket = socket
+        adapter._disconnect_requested = False
+        adapter._publish_status = AsyncMock()
+        adapter._ensure_reconnect_task = MagicMock()
+
+        adapter._register_socket_handlers(socket)
+        await socket.disconnect()
+        await socket.disconnect()
+
+        assert adapter._socket is None
+        adapter._publish_status.assert_awaited_once_with(False, "Socket.IO getrennt")
+        adapter._ensure_reconnect_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_socket_closes_stale_socket_before_replacing_it(self, adapter):
+        adapter._connect_url = "http://192.168.1.50:8084"
+        adapter._connect_kwargs = {"socketio_path": "socket.io"}
+        stale_socket = MagicMock()
+        stale_socket.connected = False
+        stale_socket.disconnect = AsyncMock()
+        new_socket = MagicMock()
+        new_socket.connect = AsyncMock()
+        adapter._socket = stale_socket
+        adapter._build_socket = MagicMock(return_value=new_socket)
+
+        connected = await adapter._connect_socket()
+
+        assert connected is True
+        stale_socket.disconnect.assert_awaited_once()
+        assert adapter._socket is new_socket
+
     @pytest.mark.asyncio
     async def test_connect_socket_retries_open_packet_error_with_websocket(self, adapter):
         adapter._connect_url = "http://192.168.1.50:8084"


### PR DESCRIPTION
## Summary

Fixes the ioBroker Socket.IO reconnect lifecycle so unstable ioBroker connections do not create competing Engine.IO read/write loops and log storms.

## Root Cause

The adapter already owns reconnect orchestration through `_reconnect_loop()`, but stale Socket.IO clients were not consistently detached/closed before replacement and disconnect handling kept the old active socket reference around. In unstable connection windows this can leave old Engine.IO loops alive while OBS starts a replacement client.

## Changes

- Keep OBS as the single reconnect owner and preserve `reconnection=False` for the Socket.IO client.
- Add explicit stale socket detach/close helpers.
- Detach the active socket on disconnect before scheduling reconnect.
- Close old polling sockets before websocket fallback and failed sockets after connect errors.
- Add reconnect backoff with jitter and a configurable max interval.
- Add regression tests for internal reconnect being disabled, idempotent disconnect handling, and stale socket cleanup before replacement.

## Validation

Local branch validation:

- `python -m compileall obs/adapters/iobroker/adapter.py`
- `python -m pytest tests/adapters/test_iobroker.py tests/contracts/test_socketio_contract.py -q` -> 44 passed
- `python -m ruff check obs/adapters/iobroker/adapter.py tests/adapters/test_iobroker.py`
- `python -m ruff format obs/adapters/iobroker/adapter.py tests/adapters/test_iobroker.py --check`

Broader validation before opening this PR:

- `python -m pytest tests/adapters/test_iobroker.py` -> 28 passed
- `python -m pytest tests/adapters/ tests/contracts/` -> 520 passed, 6 skipped
- Full suite was started locally: 1104 passed before integration tests hit the local environment blocker `FileNotFoundError: docker` from the Mosquitto fixture.

MM12 runtime validation:

- Built and deployed `obs-openbridgeserver:iobroker-ws` on MM12.
- Health OK: `datapoints=256`, `adapters_running=2`.
- Docker health: healthy.
- AEGIS: healthy, running, risk none, stability quiet.
- OBS logs after deploy: `engineio.client` count was 0 in the observed post-deploy window; no `packet queue is empty` / `Server has stopped communicating` storm observed.
