### PR TITLE
feat(filtersets): fine-grained ownership — admin/owner edit, per-user view (#478)

### DIFF
--- a/gui/src/views/ringbuffer/FilterEditor.vue
+++ b/gui/src/views/ringbuffer/FilterEditor.vue
@@ -7,6 +7,18 @@
     @update:model-value="onModalToggle"
   >
     <div class="flex flex-col gap-5">
+      <!-- Owner / permission banner (#478): visible on every existing set -->
+      <p
+        v-if="setId && loadedSet"
+        data-testid="filter-editor-owner-line"
+        class="text-xs text-slate-500 dark:text-slate-400"
+      >
+        <span v-if="loadedSet.created_by === auth.username">Eigenes Set</span>
+        <span v-else-if="loadedSet.created_by">Eigentümer: <strong>{{ loadedSet.created_by }}</strong></span>
+        <span v-else>Geteiltes Set (vor #478 angelegt — nur Admin darf bearbeiten)</span>
+        <span v-if="!canEdit" class="ml-2 inline-flex items-center rounded bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wide">Nur lesend</span>
+      </p>
+
       <!-- Set-Metadaten -->
       <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div class="flex flex-col gap-1">
@@ -224,9 +236,9 @@
       <button
         v-if="setId"
         class="btn-danger btn-sm"
-        :disabled="deleting || saving"
+        :disabled="deleting || saving || !canEdit"
         data-testid="filter-editor-delete"
-        title="Filter-Set unwiderruflich löschen"
+        :title="canEdit ? 'Filter-Set unwiderruflich löschen' : 'Nur der Eigentümer oder ein Admin darf löschen'"
         @click="onDelete"
       >
         🗑 Löschen
@@ -234,8 +246,9 @@
       <button class="btn-secondary btn-sm" data-testid="filter-editor-cancel" @click="onCancel">Verwerfen</button>
       <button
         class="btn-primary btn-sm"
-        :disabled="saving || filterIsEmpty || deleting"
+        :disabled="saving || filterIsEmpty || deleting || !canEdit"
         data-testid="filter-editor-save-topbar"
+        :title="canEdit ? '' : 'Nur der Eigentümer oder ein Admin darf speichern'"
         @click="onSave(true)"
       >
         Speichern &amp; in Topleiste
@@ -270,6 +283,9 @@ import DpCombobox from '@/components/ui/DpCombobox.vue'
 import TagCombobox from '@/components/ui/TagCombobox.vue'
 import AdapterCombobox from '@/components/ui/AdapterCombobox.vue'
 import { isEmptyFilter } from '@/composables/useClientSideMatch'
+import { useAuthStore } from '@/stores/auth'
+
+const auth = useAuthStore()
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
@@ -340,6 +356,7 @@ const filterIsEmpty = computed(() =>
     value_filter: form.valueOperator ? { operator: form.valueOperator } : null,
   }),
 )
+
 const errorMsg = ref('')
 const saving = ref(false)
 const deleting = ref(false)
@@ -348,6 +365,16 @@ const confirmOpen = ref(false)
 const confirmDeleteOpen = ref(false)
 const expanding = ref(false)
 const loadedSet = ref(null)
+
+// Fine-grained ownership (#478): admin can edit every set; non-admin users
+// only the sets they created themselves. New sets (no setId yet) are always
+// editable by the caller. Legacy sets (created_by == null) are admin-only.
+const canEdit = computed(() => {
+  if (!props.setId) return true
+  const owner = loadedSet.value?.created_by
+  if (auth.isAdmin) return true
+  return owner != null && owner === auth.username
+})
 // Cache hierarchy node descendants by `${tree_id}:${node_id}` so we can
 // resolve descendants client-side without needing a dedicated backend route.
 const hierarchyTreeCache = new Map() // tree_id -> array of {id, parent_id}

--- a/gui/src/views/ringbuffer/TopbarFilterChips.vue
+++ b/gui/src/views/ringbuffer/TopbarFilterChips.vue
@@ -25,12 +25,12 @@
           class="w-1.5 self-stretch shrink-0"
           :style="{ backgroundColor: set.color || '#94a3b8' }"
         />
-        <!-- Active/inactive toggle -->
+        <!-- Active/inactive toggle (per-user — #478, open to everyone) -->
         <button
           type="button"
           :data-testid="`topbar-chip-toggle-${set.id}`"
           class="px-2 py-1 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-800 dark:hover:text-white"
-          :title="set.is_active ? 'Aktiv — klicken zum Deaktivieren' : 'Inaktiv — klicken zum Aktivieren'"
+          :title="set.is_active ? 'Aktiv — klicken zum Deaktivieren (nur für mich)' : 'Inaktiv — klicken zum Aktivieren (nur für mich)'"
           @click.stop="onToggleActive(set)"
         >
           {{ set.is_active ? '●' : '○' }}
@@ -40,6 +40,7 @@
           type="button"
           :data-testid="`topbar-chip-body-${set.id}`"
           class="px-2 py-1 text-sm text-slate-800 dark:text-slate-100 hover:underline focus:outline-none"
+          :title="ownerTitle(set)"
           @click.stop="$emit('edit-set', set.id)"
         >
           <span
@@ -49,6 +50,25 @@
             title="Dieses Set hat keinen Filter konfiguriert — die Tabelle bleibt leer, solange das Set aktiv ist."
           >⚠</span>
           {{ set.name }}
+          <!-- Owner hint: visible for everyone (including admin) on every set
+               the caller does NOT own. Shared legacy sets (created_by==null)
+               show "shared". The lock icon is only added when the caller has
+               no write access (non-admin, non-owner) so admin sees the owner
+               without misleading "read-only" affordance. -->
+          <span
+            v-if="!isMine(set)"
+            :data-testid="`topbar-chip-owner-${set.id}`"
+            class="ml-1 text-xs text-slate-400 dark:text-slate-500"
+            :title="ownerTitle(set)"
+          >
+            <span v-if="set.created_by">@{{ set.created_by }}</span>
+            <span v-else class="italic">geteilt</span>
+            <span
+              v-if="!canEdit(set)"
+              :data-testid="`topbar-chip-owner-lock-${set.id}`"
+              class="ml-0.5"
+            >🔒</span>
+          </span>
         </button>
         <!-- Remove from topbar -->
         <button
@@ -143,13 +163,39 @@ import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { VueDraggable } from 'vue-draggable-plus'
 import { ringbufferApi } from '@/api/client'
 import { isEmptyFilter } from '@/composables/useClientSideMatch'
+import { useAuthStore } from '@/stores/auth'
 
 const emit = defineEmits(['edit-set', 'new-set', 'changed', 'export'])
 
+const auth = useAuthStore()
 const filtersets = ref([])
 const addMenuOpen = ref(false)
 const addMenuQuery = ref('')
 const searchInputRef = ref(null)
+
+// Admin can edit every set; non-admin users only the sets they created
+// themselves (#478). All per-user state (is_active toggle, topbar pinning,
+// drag-reorder, +Add, ×Remove) stays open for everyone — only the chip body
+// (which jumps into the FilterEditor for editing/deleting) signals the lock
+// via the 🔒 marker.
+function canEdit(set) {
+  if (!set) return false
+  if (auth.isAdmin) return true
+  const owner = set.created_by
+  return owner != null && owner === auth.username
+}
+
+function isMine(set) {
+  return !!set && set.created_by != null && set.created_by === auth.username
+}
+
+function ownerTitle(set) {
+  if (!set) return ''
+  if (isMine(set)) return 'Eigenes Set — bearbeiten'
+  if (set.created_by == null) return 'Geteiltes Set (nur Admin darf bearbeiten)'
+  if (canEdit(set)) return `Eigentümer: ${set.created_by} — bearbeiten als Admin`
+  return `Eigentümer: ${set.created_by} — klicken um zu öffnen / zu klonen`
+}
 
 const activeSets = computed({
   get() {

--- a/obs/api/v1/ringbuffer.py
+++ b/obs/api/v1/ringbuffer.py
@@ -315,6 +315,8 @@ class RingBufferFiltersetOut(BaseModel):
     filter: FilterCriteria
     created_at: str
     updated_at: str
+    # #478: NULL on rows created before V33 — treated as "shared, admin-only editable".
+    created_by: str | None = None
 
 
 class RingBufferFiltersetTopbarPatch(BaseModel):
@@ -676,33 +678,105 @@ async def _query_v2_entries(
 # ---------------------------------------------------------------------------
 
 
-def _row_to_filterset(row: Any) -> RingBufferFiltersetOut:
+def _row_to_filterset(row: Any, *, user_state: tuple[bool, bool, int] | None = None) -> RingBufferFiltersetOut:
+    """Project a DB row into the API model.
+
+    ``user_state`` holds the per-user override
+    ``(is_active, topbar_active, topbar_order)`` from
+    ``ringbuffer_filterset_user_state``. When absent (no row for this user),
+    the set is treated as active and un-pinned for that user. The global
+    ``is_active`` / ``topbar_active`` / ``topbar_order`` columns on
+    ``ringbuffer_filtersets`` are no longer surfaced via the API (#478 —
+    fully isolated per-user view).
+    """
+    if user_state is not None:
+        is_active, topbar_active, topbar_order = user_state
+    else:
+        is_active, topbar_active, topbar_order = True, False, 0
+    created_by = row["created_by"] if "created_by" in row.keys() else None
     return RingBufferFiltersetOut(
         id=row["id"],
         name=row["name"],
         description=row["description"],
         dsl_version=int(row["dsl_version"]),
-        is_active=bool(row["is_active"]),
+        is_active=is_active,
         color=_normalize_color(row["color"] if "color" in row.keys() else None),
-        topbar_active=bool(row["topbar_active"]) if "topbar_active" in row.keys() else False,
-        topbar_order=int(row["topbar_order"]) if "topbar_order" in row.keys() else 0,
+        topbar_active=topbar_active,
+        topbar_order=topbar_order,
         filter=_decode_filter(row["filter_json"] if "filter_json" in row.keys() else None),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        created_by=created_by,
     )
 
 
-async def _fetch_filterset(db: Database, filterset_id: str) -> RingBufferFiltersetOut | None:
+async def _fetch_user_state(db: Database, username: str, filterset_id: str) -> tuple[bool, bool, int] | None:
+    """Return ``(is_active, topbar_active, topbar_order)`` for the user, or ``None``."""
+    row = await db.fetchone(
+        "SELECT is_active, topbar_active, topbar_order FROM ringbuffer_filterset_user_state WHERE username=? AND filterset_id=?",
+        (username, filterset_id),
+    )
+    if not row:
+        return None
+    return bool(row["is_active"]), bool(row["topbar_active"]), int(row["topbar_order"])
+
+
+async def _fetch_filterset(db: Database, filterset_id: str, *, username: str | None = None) -> RingBufferFiltersetOut | None:
     row = await db.fetchone("SELECT * FROM ringbuffer_filtersets WHERE id=?", (filterset_id,))
     if not row:
         return None
-    return _row_to_filterset(row)
+    user_state = await _fetch_user_state(db, username, filterset_id) if username else None
+    return _row_to_filterset(row, user_state=user_state)
+
+
+async def _is_admin(db: Database, username: str) -> bool:
+    row = await db.fetchone("SELECT is_admin FROM users WHERE username=?", (username,))
+    return row is not None and bool(row["is_admin"])
+
+
+async def _require_filterset_ownership(db: Database, filterset_id: str, current_user: str) -> RingBufferFiltersetOut:
+    """Load a set or raise: 404 if missing, 403 if the caller is neither admin
+    nor the owner. Mirrors the API-key admin-or-owner pattern in ``obs/api/auth.py``.
+
+    Rows with ``created_by IS NULL`` (pre-#478 sets) are treated as shared and
+    admin-only mutable.
+    """
+    current = await _fetch_filterset(db, filterset_id, username=current_user)
+    if current is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
+    if await _is_admin(db, current_user):
+        return current
+    if current.created_by != current_user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Nur Admin oder Eigentümer")
+    return current
+
+
+async def _upsert_user_state(
+    db: Database,
+    *,
+    username: str,
+    filterset_id: str,
+    is_active: bool,
+    topbar_active: bool,
+    topbar_order: int,
+) -> None:
+    await db.execute(
+        """INSERT INTO ringbuffer_filterset_user_state
+             (username, filterset_id, is_active, topbar_active, topbar_order)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(username, filterset_id) DO UPDATE SET
+             is_active=excluded.is_active,
+             topbar_active=excluded.topbar_active,
+             topbar_order=excluded.topbar_order""",
+        (username, filterset_id, int(is_active), int(topbar_active), int(topbar_order)),
+    )
 
 
 async def _insert_filterset(
     db: Database,
     *,
     payload: RingBufferFiltersetIn,
+    created_by: str | None,
 ) -> RingBufferFiltersetOut:
     now = _now_iso()
     filterset_id = _new_id()
@@ -710,8 +784,8 @@ async def _insert_filterset(
     await db.execute(
         """INSERT INTO ringbuffer_filtersets
            (id, name, description, dsl_version, is_active,
-            color, topbar_active, topbar_order, filter_json, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            color, topbar_active, topbar_order, filter_json, created_at, updated_at, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             filterset_id,
             payload.name,
@@ -724,10 +798,24 @@ async def _insert_filterset(
             _encode_filter(payload.filter),
             now,
             now,
+            created_by,
         ),
     )
+    # Seed the creator's own per-user state from the POST body so GET as that
+    # user returns is_active/topbar_active/topbar_order as requested. We only
+    # write a row when something diverges from the defaults (active+un-pinned)
+    # to keep the override table lean.
+    if created_by is not None and (not payload.is_active or payload.topbar_active or payload.topbar_order):
+        await _upsert_user_state(
+            db,
+            username=created_by,
+            filterset_id=filterset_id,
+            is_active=bool(payload.is_active),
+            topbar_active=bool(payload.topbar_active),
+            topbar_order=int(payload.topbar_order),
+        )
     await db.commit()
-    created = await _fetch_filterset(db, filterset_id)
+    created = await _fetch_filterset(db, filterset_id, username=created_by)
     if not created:
         raise RuntimeError("failed to create filterset")
     return created
@@ -915,19 +1003,26 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
 
 @router.get("/filtersets", response_model=list[RingBufferFiltersetOut])
 async def list_ringbuffer_filtersets(
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> list[RingBufferFiltersetOut]:
-    rows = await db.fetchall(
-        "SELECT * FROM ringbuffer_filtersets ORDER BY topbar_order, created_at, id",
-    )
-    return [_row_to_filterset(row) for row in rows]
+    rows = await db.fetchall("SELECT * FROM ringbuffer_filtersets")
+    states = {
+        row["filterset_id"]: (bool(row["is_active"]), bool(row["topbar_active"]), int(row["topbar_order"]))
+        for row in await db.fetchall(
+            "SELECT filterset_id, is_active, topbar_active, topbar_order FROM ringbuffer_filterset_user_state WHERE username=?",
+            (current_user,),
+        )
+    }
+    out = [_row_to_filterset(row, user_state=states.get(row["id"])) for row in rows]
+    out.sort(key=lambda fs: (fs.topbar_order, fs.created_at, fs.id))
+    return out
 
 
 @router.post("/filtersets", response_model=RingBufferFiltersetOut, status_code=status.HTTP_201_CREATED)
 async def create_ringbuffer_filterset(
     request: Request,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> RingBufferFiltersetOut:
     raw = await _read_json_body(request)
@@ -937,16 +1032,16 @@ async def create_ringbuffer_filterset(
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             "filterset.filter must declare at least one criterion (hierarchy_nodes, datapoints, tags, adapters, q, or value_filter)",
         )
-    return await _insert_filterset(db, payload=payload)
+    return await _insert_filterset(db, payload=payload, created_by=current_user)
 
 
 @router.get("/filtersets/{filterset_id}", response_model=RingBufferFiltersetOut)
 async def get_ringbuffer_filterset(
     filterset_id: str,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> RingBufferFiltersetOut:
-    current = await _fetch_filterset(db, filterset_id)
+    current = await _fetch_filterset(db, filterset_id, username=current_user)
     if not current:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
     return current
@@ -956,12 +1051,10 @@ async def get_ringbuffer_filterset(
 async def update_ringbuffer_filterset(
     filterset_id: str,
     request: Request,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> RingBufferFiltersetOut:
-    current = await _fetch_filterset(db, filterset_id)
-    if not current:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
+    current = await _require_filterset_ownership(db, filterset_id, current_user)
 
     raw = await _read_json_body(request)
     try:
@@ -976,10 +1069,7 @@ async def update_ringbuffer_filterset(
     name = body.name if body.name is not None else current.name
     description = body.description if body.description is not None else current.description
     dsl_version = body.dsl_version if body.dsl_version is not None else current.dsl_version
-    is_active = body.is_active if body.is_active is not None else current.is_active
     color = body.color if body.color is not None else current.color
-    topbar_active = body.topbar_active if body.topbar_active is not None else current.topbar_active
-    topbar_order = body.topbar_order if body.topbar_order is not None else current.topbar_order
     new_filter = body.filter if body.filter is not None else current.filter
 
     if _is_empty_criteria(new_filter):
@@ -988,26 +1078,43 @@ async def update_ringbuffer_filterset(
             "filterset.filter must declare at least one criterion (hierarchy_nodes, datapoints, tags, adapters, q, or value_filter)",
         )
 
+    # is_active, topbar_active and topbar_order live in
+    # ringbuffer_filterset_user_state per-user (#478); PUT only changes the
+    # shared payload (name/description/filter/color/dsl_version) and never
+    # touches the global is_active / topbar_* columns.
     await db.execute(
         """UPDATE ringbuffer_filtersets
-           SET name=?, description=?, dsl_version=?, is_active=?,
-               color=?, topbar_active=?, topbar_order=?, filter_json=?, updated_at=?
+           SET name=?, description=?, dsl_version=?,
+               color=?, filter_json=?, updated_at=?
            WHERE id=?""",
         (
             name,
             description,
             dsl_version,
-            int(is_active),
             color,
-            int(topbar_active),
-            int(topbar_order),
             _encode_filter(new_filter),
             now,
             filterset_id,
         ),
     )
+    # Allow body.is_active/topbar_active/topbar_order to update the caller's
+    # own per-user state for backward compat with clients that still bundle
+    # these fields into a PUT.
+    if body.is_active is not None or body.topbar_active is not None or body.topbar_order is not None:
+        prior = await _fetch_user_state(db, current_user, filterset_id)
+        active = body.is_active if body.is_active is not None else (prior[0] if prior else True)
+        topbar_active = body.topbar_active if body.topbar_active is not None else (prior[1] if prior else False)
+        order = body.topbar_order if body.topbar_order is not None else (prior[2] if prior else 0)
+        await _upsert_user_state(
+            db,
+            username=current_user,
+            filterset_id=filterset_id,
+            is_active=bool(active),
+            topbar_active=bool(topbar_active),
+            topbar_order=int(order),
+        )
     await db.commit()
-    updated = await _fetch_filterset(db, filterset_id)
+    updated = await _fetch_filterset(db, filterset_id, username=current_user)
     if not updated:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
     return updated
@@ -1016,12 +1123,10 @@ async def update_ringbuffer_filterset(
 @router.delete("/filtersets/{filterset_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_ringbuffer_filterset(
     filterset_id: str,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> None:
-    row = await db.fetchone("SELECT id FROM ringbuffer_filtersets WHERE id=?", (filterset_id,))
-    if not row:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
+    await _require_filterset_ownership(db, filterset_id, current_user)
     await db.execute_and_commit("DELETE FROM ringbuffer_filtersets WHERE id=?", (filterset_id,))
 
 
@@ -1029,9 +1134,11 @@ async def delete_ringbuffer_filterset(
 async def clone_ringbuffer_filterset(
     filterset_id: str,
     body: RingBufferFiltersetCloneRequest,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> RingBufferFiltersetOut:
+    # Cloning stays open for everyone — that's how a non-admin gets a writable
+    # copy of an admin-curated or someone else's set (#478).
     source = await _fetch_filterset(db, filterset_id)
     if not source:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
@@ -1046,10 +1153,10 @@ async def clone_ringbuffer_filterset(
         # Clones do not inherit topbar activation — the user explicitly opts in
         # via the PATCH /topbar endpoint after deciding the clone is ready.
         topbar_active=False,
-        topbar_order=source.topbar_order,
+        topbar_order=0,
         filter=source.filter,
     )
-    return await _insert_filterset(db, payload=clone_payload)
+    return await _insert_filterset(db, payload=clone_payload, created_by=current_user)
 
 
 # ---------------------------------------------------------------------------
@@ -1060,72 +1167,96 @@ async def clone_ringbuffer_filterset(
 @router.patch("/filtersets/order", response_model=list[RingBufferFiltersetOut])
 async def patch_ringbuffer_filtersets_order(
     body: RingBufferFiltersetOrderPatch,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> list[RingBufferFiltersetOut]:
-    """Persist a new topbar order for several sets in one batch.
+    """Persist a new topbar order for several sets in one batch — per-user.
 
-    Sets not mentioned in ``items`` keep their existing ``topbar_order``.
-    Unknown IDs are ignored silently — same rationale as for the multi-query
-    endpoint (a racing delete must not break drag-and-drop reordering).
+    Sets not mentioned in ``items`` keep their existing per-user ``topbar_order``.
+    Unknown IDs are ignored silently — a racing delete must not break drag-and-
+    drop reordering.
     """
-    now = _now_iso()
     known_ids = {row["id"] for row in await db.fetchall("SELECT id FROM ringbuffer_filtersets")}
     for item in body.items:
         if item.id not in known_ids:
             continue
-        await db.execute(
-            "UPDATE ringbuffer_filtersets SET topbar_order=?, updated_at=? WHERE id=?",
-            (int(item.topbar_order), now, item.id),
+        prior = await _fetch_user_state(db, current_user, item.id)
+        is_active = prior[0] if prior else True
+        topbar_active = prior[1] if prior else False
+        await _upsert_user_state(
+            db,
+            username=current_user,
+            filterset_id=item.id,
+            is_active=bool(is_active),
+            topbar_active=bool(topbar_active),
+            topbar_order=int(item.topbar_order),
         )
     await db.commit()
 
-    rows = await db.fetchall(
-        "SELECT * FROM ringbuffer_filtersets ORDER BY topbar_order, created_at, id",
-    )
-    return [_row_to_filterset(row) for row in rows]
+    rows = await db.fetchall("SELECT * FROM ringbuffer_filtersets")
+    states = {
+        row["filterset_id"]: (bool(row["is_active"]), bool(row["topbar_active"]), int(row["topbar_order"]))
+        for row in await db.fetchall(
+            "SELECT filterset_id, is_active, topbar_active, topbar_order FROM ringbuffer_filterset_user_state WHERE username=?",
+            (current_user,),
+        )
+    }
+    out = [_row_to_filterset(row, user_state=states.get(row["id"])) for row in rows]
+    out.sort(key=lambda fs: (fs.topbar_order, fs.created_at, fs.id))
+    return out
 
 
 @router.patch("/filtersets/{filterset_id}/topbar", response_model=RingBufferFiltersetOut)
 async def patch_ringbuffer_filterset_topbar(
     filterset_id: str,
     body: RingBufferFiltersetTopbarPatch,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> RingBufferFiltersetOut:
-    """Toggle the topbar activation and/or order of a single set.
+    """Update the per-user view (``is_active``, ``topbar_active``, ``topbar_order``).
 
-    A no-op body (both fields ``None``) still touches ``updated_at`` so the
-    frontend can rely on a single sync source after the call.
+    All three fields live in ``ringbuffer_filterset_user_state`` (#478) so every
+    authenticated user maintains their own active/pinned state. No ownership
+    check is required — this is the user's *own* view of the shared filterset.
     """
-    current = await _fetch_filterset(db, filterset_id)
-    if not current:
+    fs_row = await db.fetchone("SELECT id FROM ringbuffer_filtersets WHERE id=?", (filterset_id,))
+    if not fs_row:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
 
-    topbar_active = body.topbar_active if body.topbar_active is not None else current.topbar_active
-    topbar_order = body.topbar_order if body.topbar_order is not None else current.topbar_order
-    is_active = body.is_active if body.is_active is not None else current.is_active
+    prior = await _fetch_user_state(db, current_user, filterset_id)
+    cur_is_active = prior[0] if prior else True
+    cur_topbar_active = prior[1] if prior else False
+    cur_topbar_order = prior[2] if prior else 0
+
+    is_active = body.is_active if body.is_active is not None else cur_is_active
+    topbar_active = body.topbar_active if body.topbar_active is not None else cur_topbar_active
+    topbar_order = body.topbar_order if body.topbar_order is not None else cur_topbar_order
 
     # When the set transitions from "not in topbar" to "in topbar" *and* the
     # caller did not pin an explicit order, assign one that ranks the new
-    # set after every currently topbar-active set. This avoids many sets
-    # piling up at topbar_order=0, which breaks the deterministic first-
-    # color-wins tie-break in the UI and confuses drag-and-drop reordering.
-    if topbar_active and not current.topbar_active and body.topbar_order is None:
+    # set after every currently topbar-active set IN THIS USER'S VIEW. This
+    # avoids many sets piling up at topbar_order=0 and keeps the deterministic
+    # first-color-wins tie-break sane.
+    if topbar_active and not cur_topbar_active and body.topbar_order is None:
         max_row = await db.fetchone(
-            "SELECT COALESCE(MAX(topbar_order), -1) AS max_order FROM ringbuffer_filtersets WHERE topbar_active=1 AND id != ?",
-            (filterset_id,),
+            "SELECT COALESCE(MAX(topbar_order), -1) AS max_order FROM ringbuffer_filterset_user_state "
+            "WHERE username=? AND topbar_active=1 AND filterset_id != ?",
+            (current_user, filterset_id),
         )
         max_order = int(max_row["max_order"]) if max_row else -1
         topbar_order = max_order + 1
 
-    now = _now_iso()
-    await db.execute_and_commit(
-        "UPDATE ringbuffer_filtersets SET topbar_active=?, topbar_order=?, is_active=?, updated_at=? WHERE id=?",
-        (int(topbar_active), int(topbar_order), int(is_active), now, filterset_id),
+    await _upsert_user_state(
+        db,
+        username=current_user,
+        filterset_id=filterset_id,
+        is_active=bool(is_active),
+        topbar_active=bool(topbar_active),
+        topbar_order=int(topbar_order),
     )
+    await db.commit()
 
-    updated = await _fetch_filterset(db, filterset_id)
+    updated = await _fetch_filterset(db, filterset_id, username=current_user)
     if not updated:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
     return updated
@@ -1139,7 +1270,7 @@ async def patch_ringbuffer_filterset_topbar(
 @router.post("/filtersets/query", response_model=list[RingBufferMultiEntryOut])
 async def query_ringbuffer_filtersets_multi(
     body: RingBufferMultiQueryRequest,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> list[RingBufferMultiEntryOut]:
     if len(body.set_ids) > _FILTERSET_MULTI_QUERY_SET_CAP:
@@ -1165,10 +1296,12 @@ async def query_ringbuffer_filtersets_multi(
         entries = await _query_v2_entries(query)
         return [RingBufferMultiEntryOut(**entry.model_dump(), matched_set_ids=[]) for entry in entries]
 
-    # Resolve sets — skip missing/inactive ones rather than fail.
+    # Resolve sets — skip missing/inactive (per-user) ones rather than fail.
+    # ``is_active`` is now part of the caller's per-user state, so two users may
+    # see different OR-unions across the same set_ids.
     resolved: list[RingBufferFiltersetOut] = []
     for set_id in body.set_ids:
-        current = await _fetch_filterset(db, set_id)
+        current = await _fetch_filterset(db, set_id, username=current_user)
         if current is None:
             continue
         if not current.is_active:
@@ -1235,16 +1368,17 @@ async def query_ringbuffer_filtersets_multi(
 @router.post("/filtersets/{filterset_id}/query", response_model=list[RingBufferEntryOut])
 async def query_ringbuffer_filterset(
     filterset_id: str,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> list[RingBufferEntryOut]:
     """Single-set query (back-compat for callers that target one set at a time).
 
     The body is intentionally ignored — the time filter and pagination are
     fixed defaults here. Callers that need custom time/pagination should use
-    ``POST /filtersets/query`` with a single-element ``set_ids`` list.
+    ``POST /filtersets/query`` with a single-element ``set_ids`` list. The
+    set's ``is_active`` flag is taken from the caller's per-user state (#478).
     """
-    current = await _fetch_filterset(db, filterset_id)
+    current = await _fetch_filterset(db, filterset_id, username=current_user)
     if not current:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "ringbuffer filterset not found")
     if not current.is_active:
@@ -1265,6 +1399,8 @@ _EXPORT_SETTINGS_KEY = "ringbuffer.export_settings"
 async def _collect_multi_entries(
     body: RingBufferMultiExportRequest,
     db: Database,
+    *,
+    username: str | None = None,
 ) -> tuple[list[RingBufferEntryOut], dict[int, list[str]]]:
     """Collect the OR-union of entries across the requested filtersets.
 
@@ -1294,7 +1430,7 @@ async def _collect_multi_entries(
 
     resolved: list[RingBufferFiltersetOut] = []
     for set_id in body.set_ids:
-        current = await _fetch_filterset(db, set_id)
+        current = await _fetch_filterset(db, set_id, username=username)
         if current is None or not current.is_active:
             continue
         # Empty FilterCriteria → the set has no real filter configured yet.
@@ -1339,7 +1475,7 @@ async def _collect_multi_entries(
 @router.post("/filtersets/export/count", response_model=RingBufferMultiExportCountResponse)
 async def count_ringbuffer_filtersets_export(
     body: RingBufferMultiExportCountRequest,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> RingBufferMultiExportCountResponse:
     """Preflight: how many rows would the corresponding CSV export produce?
@@ -1347,9 +1483,11 @@ async def count_ringbuffer_filtersets_export(
     Used by the UI to warn the user before triggering a large download. The
     set/time semantics match ``POST /filtersets/export/csv`` exactly, so the
     returned count is the row count of the union the export would write.
+    Per-user ``is_active`` applies — a set the caller has deactivated for
+    themselves is excluded from the count too (#478).
     """
     export_body = RingBufferMultiExportRequest(set_ids=body.set_ids, time=body.time)
-    entries, _ = await _collect_multi_entries(export_body, db)
+    entries, _ = await _collect_multi_entries(export_body, db, username=current_user)
     return RingBufferMultiExportCountResponse(row_count=len(entries))
 
 
@@ -1357,7 +1495,7 @@ async def count_ringbuffer_filtersets_export(
 async def export_ringbuffer_filtersets_csv(
     body: RingBufferMultiExportRequest,
     background_tasks: BackgroundTasks,
-    _user: str = Depends(get_current_user),
+    current_user: str = Depends(get_current_user),
     db: Database = Depends(get_db),
 ) -> StreamingResponse:
     """Multi-set CSV/TSV export — OR-union of all requested active sets.
@@ -1365,8 +1503,9 @@ async def export_ringbuffer_filtersets_csv(
     Optional columns (``unit`` from #434, ``matched_set_ids`` from #431) and
     encoding (UTF-8 with optional BOM) are toggleable via the request body. The
     persisted user defaults live behind ``GET/PUT /ringbuffer/export/settings``.
+    Per-user ``is_active`` filters the OR-union to what the caller has enabled.
     """
-    entries, matched = await _collect_multi_entries(body, db)
+    entries, matched = await _collect_multi_entries(body, db, username=current_user)
     if len(entries) > _CSV_EXPORT_MAX_ROWS:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/obs/db/database.py
+++ b/obs/db/database.py
@@ -510,6 +510,49 @@ async def _migration_v32(conn: aiosqlite.Connection) -> None:
             raise
 
 
+async def _migration_v33(conn: aiosqlite.Connection) -> None:
+    """Fine-grained filterset ownership (#478).
+
+    Adds the ``created_by`` owner column to ``ringbuffer_filtersets`` and a
+    per-user state table that overrides the topbar pinning and ordering. The
+    global ``topbar_active`` / ``topbar_order`` columns on
+    ``ringbuffer_filtersets`` are no longer read by the API; they remain in
+    place for backward-compat-friendly schema diffs only.
+
+    Existing rows keep ``created_by = NULL`` and are treated as shared,
+    admin-only-editable by the API.
+    """
+    try:
+        await conn.execute("ALTER TABLE ringbuffer_filtersets ADD COLUMN created_by TEXT")
+    except aiosqlite.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+    await conn.execute("CREATE INDEX IF NOT EXISTS idx_rb_fs_created_by ON ringbuffer_filtersets(created_by)")
+
+    await conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ringbuffer_filterset_user_state (
+            username       TEXT NOT NULL,
+            filterset_id   TEXT NOT NULL REFERENCES ringbuffer_filtersets(id) ON DELETE CASCADE,
+            is_active      INTEGER NOT NULL DEFAULT 1,
+            topbar_active  INTEGER NOT NULL DEFAULT 0,
+            topbar_order   INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (username, filterset_id)
+        )
+        """
+    )
+    # ``is_active`` was added after the initial V33 draft. Guard the column-add
+    # for any DB that may have been created against the early shape.
+    try:
+        await conn.execute("ALTER TABLE ringbuffer_filterset_user_state ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1")
+    except aiosqlite.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+    await conn.execute("CREATE INDEX IF NOT EXISTS idx_rb_fs_user_state_active ON ringbuffer_filterset_user_state(username, topbar_active)")
+    await conn.execute("CREATE INDEX IF NOT EXISTS idx_rb_fs_user_state_order ON ringbuffer_filterset_user_state(username, topbar_order)")
+    await conn.execute("CREATE INDEX IF NOT EXISTS idx_rb_fs_user_state_is_active ON ringbuffer_filterset_user_state(username, is_active)")
+
+
 # List of (version, sql_or_callable) tuples — append new migrations here
 MIGRATIONS: list[tuple[int, str | Callable]] = [
     (1, _MIGRATION_V1),
@@ -546,6 +589,7 @@ MIGRATIONS: list[tuple[int, str | Callable]] = [
     # skipped so fresh DBs jump 29→32, while epic dev DBs at schema_version=31
     # see V32 as the next applicable migration.
     (32, _migration_v32),
+    (33, _migration_v33),
 ]
 
 

--- a/tests/integration/test_ringbuffer_filtersets.py
+++ b/tests/integration/test_ringbuffer_filtersets.py
@@ -478,69 +478,412 @@ async def test_single_set_query_returns_matching_entries(client, auth_headers):
 
 
 # ---------------------------------------------------------------------------
-# Access control
+# Access control (#478) — fine-grained ownership: admin can do everything,
+# non-admin users may only edit/delete sets they themselves created.
 # ---------------------------------------------------------------------------
 
 
-async def test_filterset_mutations_allowed_for_any_authenticated_user(client, auth_headers):
-    """Non-admin users can fully manage filtersets (until fine-grained ownership lands)."""
-    username = f"rb-user-{uuid.uuid4().hex[:8]}"
-    password = "test-password-123"
-    user_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=username, password=password)
+async def test_create_filterset_sets_created_by_to_current_user(client, auth_headers):
+    """POST /filtersets stamps created_by with the calling user's username."""
+    username = f"rb-owner-{uuid.uuid4().hex[:8]}"
+    user_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=username, password="pw-12345678")
+    created_id = None
+    try:
+        resp = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"Owned by user {uuid.uuid4()}", "filter": {"adapters": ["api"]}},
+            headers=user_headers,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        created_id = body["id"]
+        assert body["created_by"] == username
+    finally:
+        if created_id:
+            await _delete_filterset(client, auth_headers, created_id)
+        await client.delete(f"/api/v1/auth/users/{username}", headers=auth_headers)
+
+
+async def test_admin_can_mutate_any_filterset(client, auth_headers):
+    """Admin can rename and delete a set created by another user."""
+    username = f"rb-other-{uuid.uuid4().hex[:8]}"
+    user_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=username, password="pw-12345678")
     created_id = None
     try:
         create_resp = await client.post(
             "/api/v1/ringbuffer/filtersets",
-            json={"name": f"RB User Created {uuid.uuid4()}", "filter": {"adapters": ["api"]}},
+            json={"name": f"Owned by {username}", "filter": {"adapters": ["api"]}},
             headers=user_headers,
         )
         assert create_resp.status_code == 201, create_resp.text
         created_id = create_resp.json()["id"]
 
-        clone_id: str | None = None
-        # PUT — rename and keep the (required) non-empty filter criteria
+        # Admin renames the user's set.
         put_resp = await client.put(
             f"/api/v1/ringbuffer/filtersets/{created_id}",
-            json={"name": "renamed by user", "filter": {"adapters": ["api"]}},
+            json={"name": "renamed by admin", "filter": {"adapters": ["api"]}},
+            headers=auth_headers,
+        )
+        assert put_resp.status_code == 200, put_resp.text
+
+        # Admin deletes it.
+        del_resp = await client.delete(
+            f"/api/v1/ringbuffer/filtersets/{created_id}",
+            headers=auth_headers,
+        )
+        assert del_resp.status_code == 204, del_resp.text
+        created_id = None
+    finally:
+        if created_id:
+            await _delete_filterset(client, auth_headers, created_id)
+        await client.delete(f"/api/v1/auth/users/{username}", headers=auth_headers)
+
+
+async def test_user_can_mutate_own_filterset(client, auth_headers):
+    """Non-admin users may rename and delete sets they themselves created."""
+    username = f"rb-self-{uuid.uuid4().hex[:8]}"
+    user_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=username, password="pw-12345678")
+    created_id = None
+    try:
+        create_resp = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"Self-owned {uuid.uuid4()}", "filter": {"adapters": ["api"]}},
+            headers=user_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        created_id = create_resp.json()["id"]
+
+        put_resp = await client.put(
+            f"/api/v1/ringbuffer/filtersets/{created_id}",
+            json={"name": "renamed by owner", "filter": {"adapters": ["api"]}},
             headers=user_headers,
         )
         assert put_resp.status_code == 200, put_resp.text
-        # POST clone
-        clone_resp = await client.post(
-            f"/api/v1/ringbuffer/filtersets/{created_id}/clone",
-            json={"name": "user clone"},
-            headers=user_headers,
-        )
-        assert clone_resp.status_code == 201, clone_resp.text
-        clone_id = clone_resp.json()["id"]
-        # PATCH topbar
-        topbar_resp = await client.patch(
-            f"/api/v1/ringbuffer/filtersets/{created_id}/topbar",
-            json={"topbar_active": True},
-            headers=user_headers,
-        )
-        assert topbar_resp.status_code == 200, topbar_resp.text
-        # PATCH order
-        order_resp = await client.patch(
-            "/api/v1/ringbuffer/filtersets/order",
-            json={"items": [{"id": created_id, "topbar_order": 1}]},
-            headers=user_headers,
-        )
-        assert order_resp.status_code == 200, order_resp.text
-        # DELETE the original
+
         del_resp = await client.delete(
             f"/api/v1/ringbuffer/filtersets/{created_id}",
             headers=user_headers,
         )
         assert del_resp.status_code == 204, del_resp.text
         created_id = None
-        # DELETE the clone — also as the user.
-        del_clone = await client.delete(
-            f"/api/v1/ringbuffer/filtersets/{clone_id}",
-            headers=user_headers,
-        )
-        assert del_clone.status_code == 204, del_clone.text
     finally:
         if created_id:
             await _delete_filterset(client, auth_headers, created_id)
         await client.delete(f"/api/v1/auth/users/{username}", headers=auth_headers)
+
+
+async def test_user_cannot_update_others_filterset(client, auth_headers):
+    """A non-admin trying to PUT another user's filterset must get 403."""
+    owner = f"rb-owner-{uuid.uuid4().hex[:8]}"
+    intruder = f"rb-intruder-{uuid.uuid4().hex[:8]}"
+    owner_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=owner, password="pw-12345678")
+    intruder_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=intruder, password="pw-12345678")
+    created_id = None
+    try:
+        create_resp = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"Owner's set {uuid.uuid4()}", "filter": {"adapters": ["api"]}},
+            headers=owner_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        created_id = create_resp.json()["id"]
+
+        resp = await client.put(
+            f"/api/v1/ringbuffer/filtersets/{created_id}",
+            json={"name": "hijacked", "filter": {"adapters": ["api"]}},
+            headers=intruder_headers,
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        if created_id:
+            await _delete_filterset(client, auth_headers, created_id)
+        await client.delete(f"/api/v1/auth/users/{owner}", headers=auth_headers)
+        await client.delete(f"/api/v1/auth/users/{intruder}", headers=auth_headers)
+
+
+async def test_user_cannot_delete_others_filterset(client, auth_headers):
+    """A non-admin trying to DELETE another user's filterset must get 403."""
+    owner = f"rb-owner-{uuid.uuid4().hex[:8]}"
+    intruder = f"rb-intruder-{uuid.uuid4().hex[:8]}"
+    owner_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=owner, password="pw-12345678")
+    intruder_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=intruder, password="pw-12345678")
+    created_id = None
+    try:
+        create_resp = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"Owner's set {uuid.uuid4()}", "filter": {"adapters": ["api"]}},
+            headers=owner_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        created_id = create_resp.json()["id"]
+
+        resp = await client.delete(
+            f"/api/v1/ringbuffer/filtersets/{created_id}",
+            headers=intruder_headers,
+        )
+        assert resp.status_code == 403, resp.text
+
+        # Owner still sees their set.
+        check = await client.get(f"/api/v1/ringbuffer/filtersets/{created_id}", headers=owner_headers)
+        assert check.status_code == 200, check.text
+    finally:
+        if created_id:
+            await _delete_filterset(client, auth_headers, created_id)
+        await client.delete(f"/api/v1/auth/users/{owner}", headers=auth_headers)
+        await client.delete(f"/api/v1/auth/users/{intruder}", headers=auth_headers)
+
+
+async def test_user_can_clone_others_filterset_and_owns_clone(client, auth_headers):
+    """Cloning stays open for everyone; the clone's created_by is the cloning user."""
+    owner = f"rb-owner-{uuid.uuid4().hex[:8]}"
+    cloner = f"rb-cloner-{uuid.uuid4().hex[:8]}"
+    owner_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=owner, password="pw-12345678")
+    cloner_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=cloner, password="pw-12345678")
+    source_id = None
+    clone_id = None
+    try:
+        create_resp = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"Original by {owner}", "filter": {"adapters": ["api"]}},
+            headers=owner_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        source_id = create_resp.json()["id"]
+
+        clone_resp = await client.post(
+            f"/api/v1/ringbuffer/filtersets/{source_id}/clone",
+            json={"name": f"Clone by {cloner}"},
+            headers=cloner_headers,
+        )
+        assert clone_resp.status_code == 201, clone_resp.text
+        clone = clone_resp.json()
+        clone_id = clone["id"]
+        assert clone["created_by"] == cloner
+
+        # The cloner can now edit their clone …
+        edit_resp = await client.put(
+            f"/api/v1/ringbuffer/filtersets/{clone_id}",
+            json={"name": "renamed clone", "filter": {"adapters": ["api"]}},
+            headers=cloner_headers,
+        )
+        assert edit_resp.status_code == 200, edit_resp.text
+
+        # … but they still cannot edit the source.
+        forbid = await client.put(
+            f"/api/v1/ringbuffer/filtersets/{source_id}",
+            json={"name": "hijack source", "filter": {"adapters": ["api"]}},
+            headers=cloner_headers,
+        )
+        assert forbid.status_code == 403, forbid.text
+    finally:
+        if clone_id:
+            await _delete_filterset(client, auth_headers, clone_id)
+        if source_id:
+            await _delete_filterset(client, auth_headers, source_id)
+        await client.delete(f"/api/v1/auth/users/{owner}", headers=auth_headers)
+        await client.delete(f"/api/v1/auth/users/{cloner}", headers=auth_headers)
+
+
+async def test_legacy_set_without_owner_is_admin_only(client, auth_headers):
+    """Migration leaves existing rows with created_by=NULL.
+
+    Such "shared" sets must remain visible to everyone (read-only) but only
+    admins may mutate them; non-admins get 403 on PUT/DELETE.
+    """
+    from obs.db.database import get_db
+
+    db = get_db()
+    legacy_id = str(uuid.uuid4())
+    now = "2025-01-01T00:00:00Z"
+    await db.execute_and_commit(
+        """INSERT INTO ringbuffer_filtersets
+           (id, name, description, dsl_version, is_active, color,
+            topbar_active, topbar_order, filter_json, created_at, updated_at, created_by)
+           VALUES (?, 'Legacy set', '', 2, 1, '#3b82f6', 0, 0,
+                   '{"adapters":["api"]}', ?, ?, NULL)""",
+        (legacy_id, now, now),
+    )
+    username = f"rb-noowner-{uuid.uuid4().hex[:8]}"
+    user_headers = await _create_non_admin_user_and_headers(client, auth_headers, username=username, password="pw-12345678")
+    try:
+        # User can read it.
+        get_resp = await client.get(f"/api/v1/ringbuffer/filtersets/{legacy_id}", headers=user_headers)
+        assert get_resp.status_code == 200, get_resp.text
+        assert get_resp.json()["created_by"] is None
+
+        # User cannot edit it.
+        put_resp = await client.put(
+            f"/api/v1/ringbuffer/filtersets/{legacy_id}",
+            json={"name": "user-renamed", "filter": {"adapters": ["api"]}},
+            headers=user_headers,
+        )
+        assert put_resp.status_code == 403, put_resp.text
+
+        # Admin can edit it.
+        admin_put = await client.put(
+            f"/api/v1/ringbuffer/filtersets/{legacy_id}",
+            json={"name": "admin-renamed", "filter": {"adapters": ["api"]}},
+            headers=auth_headers,
+        )
+        assert admin_put.status_code == 200, admin_put.text
+    finally:
+        await db.execute_and_commit("DELETE FROM ringbuffer_filtersets WHERE id=?", (legacy_id,))
+        await client.delete(f"/api/v1/auth/users/{username}", headers=auth_headers)
+
+
+# ---------------------------------------------------------------------------
+# Per-user topbar state (#478)
+# ---------------------------------------------------------------------------
+
+
+async def test_topbar_state_is_per_user(client, auth_headers):
+    """user A pins a set; user B must NOT see it as pinned."""
+    user_a = f"rb-a-{uuid.uuid4().hex[:8]}"
+    user_b = f"rb-b-{uuid.uuid4().hex[:8]}"
+    headers_a = await _create_non_admin_user_and_headers(client, auth_headers, username=user_a, password="pw-12345678")
+    headers_b = await _create_non_admin_user_and_headers(client, auth_headers, username=user_b, password="pw-12345678")
+    created_id = None
+    try:
+        # User A creates a set (and pins it on creation).
+        create_resp = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"per-user topbar {uuid.uuid4()}", "filter": {"adapters": ["api"]}, "topbar_active": True},
+            headers=headers_a,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        created_id = create_resp.json()["id"]
+        # A sees it pinned.
+        assert create_resp.json()["topbar_active"] is True
+
+        # User B reads the same set: must see it un-pinned.
+        get_b = await client.get(f"/api/v1/ringbuffer/filtersets/{created_id}", headers=headers_b)
+        assert get_b.status_code == 200, get_b.text
+        assert get_b.json()["topbar_active"] is False
+
+        # User B pins it for himself.
+        patch_b = await client.patch(
+            f"/api/v1/ringbuffer/filtersets/{created_id}/topbar",
+            json={"topbar_active": True},
+            headers=headers_b,
+        )
+        assert patch_b.status_code == 200, patch_b.text
+        assert patch_b.json()["topbar_active"] is True
+
+        # User B un-pins it again — must not flip A's view.
+        patch_b_off = await client.patch(
+            f"/api/v1/ringbuffer/filtersets/{created_id}/topbar",
+            json={"topbar_active": False},
+            headers=headers_b,
+        )
+        assert patch_b_off.status_code == 200, patch_b_off.text
+
+        get_a = await client.get(f"/api/v1/ringbuffer/filtersets/{created_id}", headers=headers_a)
+        assert get_a.status_code == 200, get_a.text
+        assert get_a.json()["topbar_active"] is True
+    finally:
+        if created_id:
+            await _delete_filterset(client, auth_headers, created_id)
+        await client.delete(f"/api/v1/auth/users/{user_a}", headers=auth_headers)
+        await client.delete(f"/api/v1/auth/users/{user_b}", headers=auth_headers)
+
+
+async def test_is_active_is_per_user_and_open_to_everyone(client, auth_headers):
+    """``is_active`` is a per-user override too: every authenticated user may
+    toggle their own active state on any set without Owner / Admin restriction
+    (#478 — corrected). User A deactivating a set must not affect user B's view.
+    """
+    owner = f"rb-act-owner-{uuid.uuid4().hex[:8]}"
+    other = f"rb-act-other-{uuid.uuid4().hex[:8]}"
+    headers_owner = await _create_non_admin_user_and_headers(client, auth_headers, username=owner, password="pw-12345678")
+    headers_other = await _create_non_admin_user_and_headers(client, auth_headers, username=other, password="pw-12345678")
+    created_id = None
+    try:
+        # Owner creates the set, active by default.
+        create = await client.post(
+            "/api/v1/ringbuffer/filtersets",
+            json={"name": f"per-user is_active {uuid.uuid4()}", "filter": {"adapters": ["api"]}},
+            headers=headers_owner,
+        )
+        assert create.status_code == 201, create.text
+        created_id = create.json()["id"]
+        assert create.json()["is_active"] is True
+
+        # User "other" deactivates it for themselves — must succeed (no 403).
+        patch = await client.patch(
+            f"/api/v1/ringbuffer/filtersets/{created_id}/topbar",
+            json={"is_active": False},
+            headers=headers_other,
+        )
+        assert patch.status_code == 200, patch.text
+        assert patch.json()["is_active"] is False
+
+        # Owner's view is unaffected.
+        get_owner = await client.get(f"/api/v1/ringbuffer/filtersets/{created_id}", headers=headers_owner)
+        assert get_owner.status_code == 200, get_owner.text
+        assert get_owner.json()["is_active"] is True
+
+        # And the owner can flip their own is_active too.
+        patch_owner = await client.patch(
+            f"/api/v1/ringbuffer/filtersets/{created_id}/topbar",
+            json={"is_active": False},
+            headers=headers_owner,
+        )
+        assert patch_owner.status_code == 200, patch_owner.text
+        assert patch_owner.json()["is_active"] is False
+    finally:
+        if created_id:
+            await _delete_filterset(client, auth_headers, created_id)
+        await client.delete(f"/api/v1/auth/users/{owner}", headers=auth_headers)
+        await client.delete(f"/api/v1/auth/users/{other}", headers=auth_headers)
+
+
+async def test_topbar_order_is_per_user(client, auth_headers):
+    """PATCH /filtersets/order writes per-user ordering, not the global default."""
+    user_a = f"rb-ord-a-{uuid.uuid4().hex[:8]}"
+    user_b = f"rb-ord-b-{uuid.uuid4().hex[:8]}"
+    headers_a = await _create_non_admin_user_and_headers(client, auth_headers, username=user_a, password="pw-12345678")
+    headers_b = await _create_non_admin_user_and_headers(client, auth_headers, username=user_b, password="pw-12345678")
+    a_id = None
+    b_id = None
+    try:
+        a = (
+            await client.post(
+                "/api/v1/ringbuffer/filtersets",
+                json={"name": f"Order A {uuid.uuid4()}", "filter": {"tags": ["rb-order-per-user"]}},
+                headers=headers_a,
+            )
+        ).json()
+        a_id = a["id"]
+        b = (
+            await client.post(
+                "/api/v1/ringbuffer/filtersets",
+                json={"name": f"Order B {uuid.uuid4()}", "filter": {"tags": ["rb-order-per-user"]}},
+                headers=headers_a,
+            )
+        ).json()
+        b_id = b["id"]
+
+        # User A orders A=5, B=2 …
+        resp = await client.patch(
+            "/api/v1/ringbuffer/filtersets/order",
+            json={"items": [{"id": a_id, "topbar_order": 5}, {"id": b_id, "topbar_order": 2}]},
+            headers=headers_a,
+        )
+        assert resp.status_code == 200, resp.text
+        by_id_a = {row["id"]: row for row in resp.json()}
+        assert by_id_a[a_id]["topbar_order"] == 5
+        assert by_id_a[b_id]["topbar_order"] == 2
+
+        # User B sees the defaults (0/0) — A's order must not leak.
+        list_b = await client.get("/api/v1/ringbuffer/filtersets", headers=headers_b)
+        assert list_b.status_code == 200, list_b.text
+        by_id_b = {row["id"]: row for row in list_b.json() if row["id"] in (a_id, b_id)}
+        assert by_id_b[a_id]["topbar_order"] == 0
+        assert by_id_b[b_id]["topbar_order"] == 0
+    finally:
+        if a_id:
+            await _delete_filterset(client, auth_headers, a_id)
+        if b_id:
+            await _delete_filterset(client, auth_headers, b_id)
+        await client.delete(f"/api/v1/auth/users/{user_a}", headers=auth_headers)
+        await client.delete(f"/api/v1/auth/users/{user_b}", headers=auth_headers)

--- a/tests/unit/test_ringbuffer_api_coverage_boost.py
+++ b/tests/unit/test_ringbuffer_api_coverage_boost.py
@@ -232,7 +232,7 @@ async def test_fetch_filterset_returns_none_or_flat_structure():
 
 @pytest.mark.asyncio
 async def test_get_filterset_returns_404_when_missing(monkeypatch):
-    async def _fetch_none(_db, _id):
+    async def _fetch_none(_db, _id, *, username=None):
         return None
 
     monkeypatch.setattr(rb_api, "_fetch_filterset", _fetch_none)
@@ -244,7 +244,7 @@ async def test_get_filterset_returns_404_when_missing(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_single_set_query_returns_404_when_missing(monkeypatch):
-    async def _fetch_none(_db, _id):
+    async def _fetch_none(_db, _id, *, username=None):
         return None
 
     monkeypatch.setattr(rb_api, "_fetch_filterset", _fetch_none)
@@ -270,7 +270,7 @@ async def test_single_set_query_returns_empty_when_inactive(monkeypatch):
         updated_at="2026-01-01T00:00:00Z",
     )
 
-    async def _fetch(_db, _id):
+    async def _fetch(_db, _id, *, username=None):
         return fs
 
     monkeypatch.setattr(rb_api, "_fetch_filterset", _fetch)

--- a/tests/unit/test_ringbuffer_filtersets_migration.py
+++ b/tests/unit/test_ringbuffer_filtersets_migration.py
@@ -22,7 +22,10 @@ async def test_db_migration_creates_flat_ringbuffer_filterset_table():
     try:
         tables = await db.fetchall("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'ringbuffer_filterset%' ORDER BY name")
         names = [row["name"] for row in tables]
-        assert names == ["ringbuffer_filtersets"], "legacy ringbuffer_filterset_groups/_rules tables must be dropped by V29"
+        # V33 adds the per-user state table alongside the main filterset table.
+        assert names == ["ringbuffer_filterset_user_state", "ringbuffer_filtersets"], (
+            "legacy ringbuffer_filterset_groups/_rules tables must be dropped by V29; V33 adds the per-user state table"
+        )
 
         columns = await db.fetchall("PRAGMA table_info(ringbuffer_filtersets)")
         column_names = {row["name"] for row in columns}
@@ -30,6 +33,8 @@ async def test_db_migration_creates_flat_ringbuffer_filterset_table():
         assert {"color", "topbar_active", "topbar_order", "filter_json"} <= column_names
         # Existing columns preserved.
         assert {"id", "name", "description", "dsl_version", "is_active"} <= column_names
+        # #478 adds the owner column.
+        assert "created_by" in column_names
         # The legacy is_default column was dropped by V31 (Epic #36 — default
         # sets were superseded by the topbar).
         assert "is_default" not in column_names
@@ -46,5 +51,25 @@ async def test_db_migration_creates_topbar_indexes():
         names = {row["name"] for row in indexes}
         assert "idx_rb_fs_topbar_active" in names
         assert "idx_rb_fs_topbar_order" in names
+        # #478 added an index on created_by for fast owner lookups.
+        assert "idx_rb_fs_created_by" in names
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_v33_creates_user_state_table_and_indexes():
+    """V33 (#478) adds the per-user topbar override table and its indexes."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        columns = await db.fetchall("PRAGMA table_info(ringbuffer_filterset_user_state)")
+        column_names = {row["name"] for row in columns}
+        assert {"username", "filterset_id", "topbar_active", "topbar_order"} <= column_names
+
+        indexes = await db.fetchall("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='ringbuffer_filterset_user_state'")
+        names = {row["name"] for row in indexes}
+        assert "idx_rb_fs_user_state_active" in names
+        assert "idx_rb_fs_user_state_order" in names
     finally:
         await db.disconnect()


### PR DESCRIPTION
## Summary

- Replaces the coarse "any authenticated user may mutate any filterset" gate (PR #404) with admin-or-owner write access on the shared payload (name, description, filter criteria, color); helper `_require_filterset_ownership` mirrors the API-key admin-or-owner pattern in `obs/api/auth.py`.
- Adds a fully per-user view via a new `ringbuffer_filterset_user_state(username, filterset_id, is_active, topbar_active, topbar_order)` table. Every authenticated user maintains their own active/pinned/ordered topbar — toggling `●/○`, pinning, drag-reorder and `+ Filter` / `× remove` write only the caller's row. Multi-query and single-set query filter through that per-user view.
- Clone stays open for everyone; the clone is owned by the cloning user, so non-admins get a writable copy of an admin-curated set.
- DB migration V33 (idempotent): `ALTER TABLE ringbuffer_filtersets ADD COLUMN created_by TEXT` + new user_state table + indexes. Pre-V33 rows with `created_by IS NULL` are treated as "shared, admin-only editable".
- Frontend: `FilterEditor.vue` shows an owner banner (`Eigenes Set` / `Eigentümer: <name>` / `Geteiltes Set`) and disables Save/Delete when the caller has no write access. `TopbarFilterChips.vue` keeps every per-user action open for everyone and renders a subtle `@<owner>` hint + 🔒 marker (when read-only) on foreign sets so every user — including admin — sees who owns a set.

## Test plan

- [x] `pytest tests/unit tests/adapters tests/contracts tests/integration` — 1463 passed
- [x] `./tools/lint.sh --check` — clean
- [x] `cd gui && npm run build` — ok
- [x] Manual UI smoke: admin + second user in parallel sessions, owner visible at chip + editor, `●/○` per-user, PUT/DELETE 403 for non-owners, legacy `created_by IS NULL` set admin-only-editable
- [x] DB migration V33 applied on a fresh container build

Closes #478