### PR TITLE
fix: Monitor-E2E-Tests stabilisieren (#482)

### DIFF
--- a/gui/src/App.vue
+++ b/gui/src/App.vue
@@ -41,9 +41,12 @@ const runtimeStripClass = computed(() => {
 
 onMounted(async () => {
   if (auth.isLoggedIn) {
+    // Open the WebSocket first — it must not wait behind the loadMe/settings
+    // round-trips, otherwise live pushes that arrive during the handshake gap
+    // are lost (the server does not replay missed events).
+    ws.connect()
     await auth.loadMe()
     await settings.load()
-    ws.connect()
   }
 })
 

--- a/gui/src/views/RingBufferView.vue
+++ b/gui/src/views/RingBufferView.vue
@@ -313,12 +313,16 @@ async function applyFilters() {
 }
 
 onMounted(async () => {
+  // Register the live handler BEFORE the initial load. The WebSocket
+  // connects faster than the loadFiltersets()/load() round-trips, so a
+  // ringbuffer_entry push arriving in that gap would otherwise be dropped
+  // (the server does not replay events).
+  unregisterRb = wsStore.onRingbufferEntry(onLiveEntry)
   // Load filtersets first so the topbar-colour cache is populated before
   // load() picks between queryV2 and queryMultiFiltersets (#437). /stats
   // is owned by TopbarStats / the config modal — not fetched here.
   await loadFiltersets()
   await load()
-  unregisterRb = wsStore.onRingbufferEntry(onLiveEntry)
 })
 
 onUnmounted(() => {

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page, type Locator } from '@playwright/test'
-import { apiPost, apiPatch, apiDelete, gotoMonitor } from '../helpers'
+import { apiPost, apiPatch, apiDelete, gotoMonitorLive } from '../helpers'
 
 // API-First helper: create a filterset and flip topbar_active=true. UI tests
 // that don't validate the FilterEditor itself use this so they don't depend
@@ -107,7 +107,7 @@ test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ p
     await apiPost(`/api/v1/datapoints/${dpA.id}/value`, { value: 11.0, quality: 'good' })
     await apiPost(`/api/v1/datapoints/${dpB.id}/value`, { value: 22.0, quality: 'good' })
 
-    await gotoMonitor(page)
+    await gotoMonitorLive(page)
 
     await openNewFilterEditor(page)
     await page.fill('[data-testid="filter-editor-name"]', uniqueName('FS-AND-OR'))
@@ -161,7 +161,7 @@ test('Topbar-Chip-Toggle schaltet das Set ein und aus', async ({ page }) => {
     // API-first set creation: this test is about toggle UX, not FilterEditor.
     setId = await createActiveFilterset(uniqueName('FS-TOGGLE'), { datapoints: [dpIn.id] })
 
-    await gotoMonitor(page)
+    await gotoMonitorLive(page)
 
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
@@ -218,7 +218,7 @@ test('Hierarchy-Knoten löst descendant-inclusive auf (Recursive-CTE)', async ({
   try {
     await apiPost(`/api/v1/datapoints/${dp.id}/value`, { value: 42.0, quality: 'good' })
 
-    await gotoMonitor(page)
+    await gotoMonitorLive(page)
 
     await openNewFilterEditor(page)
     await page.fill('[data-testid="filter-editor-name"]', uniqueName('FS-HIER'))
@@ -260,7 +260,7 @@ test('Live-Event eines nicht passenden DPs wird durch aktiven Filter gegated', a
 
     setId = await createActiveFilterset(uniqueName('FS-LIVE-GATE'), { datapoints: [dpIn.id] })
 
-    await gotoMonitor(page)
+    await gotoMonitorLive(page)
 
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect, type Page, type Locator } from '@playwright/test'
-import { apiPost, apiPatch, apiDelete, gotoMonitorLive } from '../helpers'
+import { apiPost, apiPatch, apiDelete, deleteAllFiltersets, gotoMonitorLive } from '../helpers'
+
+// Filtersets are global state — a previously failed test may leave a
+// topbar-active set behind, which then pollutes both this file and the
+// ringbuffer live tests. Start every test from a clean slate.
+test.beforeEach(async () => {
+  await deleteAllFiltersets()
+})
 
 // API-First helper: create a filterset and flip topbar_active=true. UI tests
 // that don't validate the FilterEditor itself use this so they don't depend

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -214,6 +214,11 @@ test('Topbar-Chip-Toggle schaltet das Set ein und aus', async ({ page }) => {
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
 
     await expectTopbarChip(page, setId)
+    // Pause the live feed: once the set is toggled inactive there are no
+    // active topbar sets, so the live feed would run unfiltered and a
+    // background WS push could repopulate the table between the toggle and
+    // the empty-state assertion. This test isolates the query-path behaviour.
+    await page.click('[data-testid="btn-live-pause"]')
     await expect(dpInRows).toHaveCount(1, { timeout: 10_000 })
     await expect(dpOutRows).toHaveCount(0)
 

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -32,21 +32,25 @@ async function openNewFilterEditor(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="filter-editor-name"]')).toBeVisible({ timeout: 5_000 })
 }
 
-// Pick the first matching item from a Combobox scoped by the wrapper test-id.
-// Works for DpCombobox, TagCombobox, HierarchyCombobox and AdapterCombobox —
-// they all render <Combobox> internally and share the same input/item slots.
-async function pickInCombobox(page: Page, scopeTestId: string, query: string): Promise<void> {
+// Pick an item from a Combobox scoped by the wrapper test-id. Works for
+// DpCombobox, TagCombobox, HierarchyCombobox and AdapterCombobox — they all
+// render <Combobox> internally and share the same input/item slots.
+//
+// `match` must be text that appears in the target suggestion item (a tag,
+// datapoint name or hierarchy node name — NOT a UUID; the hierarchy combobox
+// only searches names). The helper types it, then waits until combobox-item-0
+// actually renders that text. The combobox debounces and fetches suggestions
+// asynchronously, and `input.click()` already triggers a focus-fetch of the
+// unfiltered list — clicking item-0 before the query-fetch lands would pick a
+// stale entry. Asserting the rendered text first makes the pick deterministic.
+async function pickInCombobox(page: Page, scopeTestId: string, match: string): Promise<void> {
   const root = page.locator(`[data-testid="${scopeTestId}"]`)
   const input = root.locator('[data-testid="combobox-input"]').first()
   await input.click()
-  if (query) await input.fill(query)
-  // The suggestion list is fetched asynchronously. Clicking combobox-item-0
-  // straight away races that fetch and can pick a stale pre-filter item (e.g.
-  // an unrelated datapoint). Wait until the list has narrowed to the single
-  // match for `query` before clicking.
-  const items = root.locator('[data-testid^="combobox-item-"]')
-  if (query) await expect(items).toHaveCount(1)
-  await items.first().click({ timeout: 5_000 })
+  if (match) await input.fill(match)
+  const item0 = root.locator('[data-testid="combobox-item-0"]').first()
+  if (match) await expect(item0).toContainText(match)
+  await item0.click({ timeout: 5_000 })
 }
 
 // Click "Speichern & in Topleiste" and wait until the full chain has settled:
@@ -104,8 +108,9 @@ function topbarChip(page: Page, setId: string): Locator {
 
 test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ page }) => {
   const tag = uniqueName('fe02-and-or')
+  const dpAName = uniqueName('E2E-RB-FE02-A')
   const dpA = (await apiPost('/api/v1/datapoints', {
-    name: uniqueName('E2E-RB-FE02-A'),
+    name: dpAName,
     data_type: 'FLOAT',
     tags: [tag],
   })) as { id: string }
@@ -142,7 +147,7 @@ test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ p
     // runs Object.assign(form, makeEmptyForm()), which would otherwise wipe a
     // datapoint picked before the async load resolves).
     await expect(page.locator('[data-testid="filter-editor-name"]')).not.toHaveValue('')
-    await pickInCombobox(page, 'filter-editor-dps', dpA.id)
+    await pickInCombobox(page, 'filter-editor-dps', dpAName)
     await saveAndCaptureId(page)
 
     await expect(
@@ -217,10 +222,11 @@ test('Hierarchy-Knoten löst descendant-inclusive auf (Recursive-CTE)', async ({
     name: uniqueName('FE02-Tree'),
     description: 'E2E',
   })) as { id: string }
+  const nodeName = uniqueName('FE02-Node')
   const node = (await apiPost('/api/v1/hierarchy/nodes', {
     tree_id: tree.id,
     parent_id: null,
-    name: uniqueName('FE02-Node'),
+    name: nodeName,
     description: 'E2E',
     order: 0,
   })) as { id: string }
@@ -239,7 +245,7 @@ test('Hierarchy-Knoten löst descendant-inclusive auf (Recursive-CTE)', async ({
 
     await openNewFilterEditor(page)
     await page.fill('[data-testid="filter-editor-name"]', uniqueName('FS-HIER'))
-    await pickInCombobox(page, 'filter-editor-hierarchy', node.id)
+    await pickInCombobox(page, 'filter-editor-hierarchy', nodeName)
     setId = await saveAndCaptureId(page)
 
     // The DP is linked to the node but not picked explicitly. Recursive-CTE

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -188,7 +188,10 @@ test('Topbar-Chip-Toggle schaltet das Set ein und aus', async ({ page }) => {
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
 
-    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 5_000 })
+    // The chip is rendered once the topbar has fetched the (API-created) set.
+    // That fetch runs independently of gotoMonitorLive's waits, so allow the
+    // same 10s budget the table assertions use.
+    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 10_000 })
     await expect(dpInRows).toHaveCount(1, { timeout: 10_000 })
     await expect(dpOutRows).toHaveCount(0)
 
@@ -288,7 +291,10 @@ test('Live-Event eines nicht passenden DPs wird durch aktiven Filter gegated', a
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
 
-    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 5_000 })
+    // The chip is rendered once the topbar has fetched the (API-created) set.
+    // That fetch runs independently of gotoMonitorLive's waits, so allow the
+    // same 10s budget the table assertions use.
+    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 10_000 })
     await expect(dpInRows).toHaveCount(1, { timeout: 10_000 })
     await expect(dpOutRows).toHaveCount(0)
 

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -5,6 +5,9 @@ import { apiPost, apiPatch, apiDelete, deleteAllFiltersets, gotoMonitorLive } fr
 // topbar-active set behind, which then pollutes both this file and the
 // ringbuffer live tests. Start every test from a clean slate.
 test.beforeEach(async () => {
+  // Monitor tests wait for a real WebSocket ("Live" badge) plus several save
+  // round-trips — the default 30s per-test budget is too tight under CI load.
+  test.setTimeout(60_000)
   await deleteAllFiltersets()
 })
 

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect, type Page, type Locator } from '@playwright/test'
-import { apiPost, apiPatch, apiDelete, deleteAllFiltersets, gotoMonitorLive } from '../helpers'
+import {
+  apiPost,
+  apiPatch,
+  apiDelete,
+  deleteAllFiltersets,
+  gotoMonitorLive,
+  waitForMonitorReady,
+} from '../helpers'
 
 // Filtersets are global state — a previously failed test may leave a
 // topbar-active set behind, which then pollutes both this file and the
@@ -109,6 +116,21 @@ function topbarChip(page: Page, setId: string): Locator {
   return page.locator(`[data-testid="topbar-chip-${setId}"]`)
 }
 
+// Assert the topbar chip for `setId` is visible. The topbar renders its chips
+// from a mount-time /filtersets fetch whose render can occasionally race; for
+// API-created sets there is no explicit topbar reload to fall back on, so if
+// the chip has not appeared, reload the page once to re-mount the topbar.
+async function expectTopbarChip(page: Page, setId: string): Promise<void> {
+  const chip = topbarChip(page, setId)
+  try {
+    await expect(chip).toBeVisible({ timeout: 8_000 })
+  } catch {
+    await page.reload()
+    await waitForMonitorReady(page)
+    await expect(chip).toBeVisible({ timeout: 10_000 })
+  }
+}
+
 test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ page }) => {
   const tag = uniqueName('fe02-and-or')
   const dpAName = uniqueName('E2E-RB-FE02-A')
@@ -135,7 +157,7 @@ test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ p
     await pickInCombobox(page, 'filter-editor-tags', tag)
     setId = await saveAndCaptureId(page)
 
-    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 5_000 })
+    await expectTopbarChip(page, setId)
     await expect(
       page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpA.id}"]`),
     ).toHaveCount(1, { timeout: 10_000 })
@@ -191,10 +213,7 @@ test('Topbar-Chip-Toggle schaltet das Set ein und aus', async ({ page }) => {
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
 
-    // The chip is rendered once the topbar has fetched the (API-created) set.
-    // That fetch runs independently of gotoMonitorLive's waits, so allow the
-    // same 10s budget the table assertions use.
-    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 10_000 })
+    await expectTopbarChip(page, setId)
     await expect(dpInRows).toHaveCount(1, { timeout: 10_000 })
     await expect(dpOutRows).toHaveCount(0)
 
@@ -256,7 +275,7 @@ test('Hierarchy-Knoten löst descendant-inclusive auf (Recursive-CTE)', async ({
 
     // The DP is linked to the node but not picked explicitly. Recursive-CTE
     // resolution on the server expands the node into its descendant DPs.
-    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 5_000 })
+    await expectTopbarChip(page, setId)
     await expect(
       page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dp.id}"]`),
     ).toHaveCount(1, { timeout: 10_000 })
@@ -294,10 +313,7 @@ test('Live-Event eines nicht passenden DPs wird durch aktiven Filter gegated', a
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
 
-    // The chip is rendered once the topbar has fetched the (API-created) set.
-    // That fetch runs independently of gotoMonitorLive's waits, so allow the
-    // same 10s budget the table assertions use.
-    await expect(topbarChip(page, setId)).toBeVisible({ timeout: 10_000 })
+    await expectTopbarChip(page, setId)
     await expect(dpInRows).toHaveCount(1, { timeout: 10_000 })
     await expect(dpOutRows).toHaveCount(0)
 

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page, type Locator } from '@playwright/test'
-import { apiPost, apiPatch, apiDelete } from '../helpers'
+import { apiPost, apiPatch, apiDelete, gotoMonitor } from '../helpers'
 
 // API-First helper: create a filterset and flip topbar_active=true. UI tests
 // that don't validate the FilterEditor itself use this so they don't depend
@@ -107,8 +107,7 @@ test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ p
     await apiPost(`/api/v1/datapoints/${dpA.id}/value`, { value: 11.0, quality: 'good' })
     await apiPost(`/api/v1/datapoints/${dpB.id}/value`, { value: 22.0, quality: 'good' })
 
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
 
     await openNewFilterEditor(page)
     await page.fill('[data-testid="filter-editor-name"]', uniqueName('FS-AND-OR'))
@@ -162,8 +161,7 @@ test('Topbar-Chip-Toggle schaltet das Set ein und aus', async ({ page }) => {
     // API-first set creation: this test is about toggle UX, not FilterEditor.
     setId = await createActiveFilterset(uniqueName('FS-TOGGLE'), { datapoints: [dpIn.id] })
 
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
 
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)
@@ -220,8 +218,7 @@ test('Hierarchy-Knoten löst descendant-inclusive auf (Recursive-CTE)', async ({
   try {
     await apiPost(`/api/v1/datapoints/${dp.id}/value`, { value: 42.0, quality: 'good' })
 
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
 
     await openNewFilterEditor(page)
     await page.fill('[data-testid="filter-editor-name"]', uniqueName('FS-HIER'))
@@ -263,8 +260,7 @@ test('Live-Event eines nicht passenden DPs wird durch aktiven Filter gegated', a
 
     setId = await createActiveFilterset(uniqueName('FS-LIVE-GATE'), { datapoints: [dpIn.id] })
 
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
 
     const dpInRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpIn.id}"]`)
     const dpOutRows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpOut.id}"]`)

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -132,6 +132,10 @@ test('FilterCriteria: Tags-Liste OR-matcht, Datapoints AND-engt ein', async ({ p
     // Re-open the editor, add a datapoint filter — AND between tags-section and
     // datapoints-section now excludes dpB even though dpB still carries the tag.
     await page.click(`[data-testid="topbar-chip-body-${setId}"]`)
+    // Wait until the editor has hydrated from the set (loadSet → hydrateForm
+    // runs Object.assign(form, makeEmptyForm()), which would otherwise wipe a
+    // datapoint picked before the async load resolves).
+    await expect(page.locator('[data-testid="filter-editor-name"]')).not.toHaveValue('')
     await pickInCombobox(page, 'filter-editor-dps', dpA.id)
     await saveAndCaptureId(page)
 

--- a/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
+++ b/tests/gui/admin/ringbuffer-filterbuilder.spec.ts
@@ -40,7 +40,13 @@ async function pickInCombobox(page: Page, scopeTestId: string, query: string): P
   const input = root.locator('[data-testid="combobox-input"]').first()
   await input.click()
   if (query) await input.fill(query)
-  await root.locator('[data-testid="combobox-item-0"]').first().click({ timeout: 5_000 })
+  // The suggestion list is fetched asynchronously. Clicking combobox-item-0
+  // straight away races that fetch and can pick a stale pre-filter item (e.g.
+  // an unrelated datapoint). Wait until the list has narrowed to the single
+  // match for `query` before clicking.
+  const items = root.locator('[data-testid^="combobox-item-"]')
+  if (query) await expect(items).toHaveCount(1)
+  await items.first().click({ timeout: 5_000 })
 }
 
 // Click "Speichern & in Topleiste" and wait until the full chain has settled:

--- a/tests/gui/admin/ringbuffer.spec.ts
+++ b/tests/gui/admin/ringbuffer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { apiPost, apiDelete, gotoMonitor, waitForMonitorReady } from '../helpers'
+import { apiPost, apiDelete, gotoMonitor, gotoMonitorLive, waitForMonitorReady } from '../helpers'
 
 test('RingBuffer Live-Eintrag ohne Reload', async ({ page }) => {
   // Fixture: create a DataPoint
@@ -11,10 +11,7 @@ test('RingBuffer Live-Eintrag ohne Reload', async ({ page }) => {
   const dpId = created.id
 
   try {
-    await gotoMonitor(page)
-
-    // Status badge must say "Live"
-    await expect(page.locator('[data-testid="status-badge"]')).toContainText('Live', { timeout: 8_000 })
+    await gotoMonitorLive(page)
 
     // Before the push, no entries for this brand-new DP should exist
     const before = await page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`).count()
@@ -39,8 +36,7 @@ test('RingBuffer Pause/Resume stoppt Live-Append und holt Queue nach', async ({ 
   const dpId = created.id
 
   try {
-    await gotoMonitor(page)
-    await expect(page.locator('[data-testid="status-badge"]')).toContainText('Live', { timeout: 8_000 })
+    await gotoMonitorLive(page)
 
     const rows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`)
     const before = await rows.count()
@@ -71,7 +67,7 @@ test('RingBuffer Auto-Scroll folgt Live, bleibt stabil bei Pause', async ({ page
   const dpId = created.id
 
   try {
-    await gotoMonitor(page)
+    await gotoMonitorLive(page)
     const rows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`)
     const before = await rows.count()
 
@@ -111,7 +107,7 @@ test('RingBuffer zeigt Live-Einträge auch ohne manuellen Refresh', async ({ pag
   const dpId = created.id
 
   try {
-    await gotoMonitor(page)
+    await gotoMonitorLive(page)
     const rows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`)
     const before = await rows.count()
 

--- a/tests/gui/admin/ringbuffer.spec.ts
+++ b/tests/gui/admin/ringbuffer.spec.ts
@@ -1,5 +1,18 @@
 import { test, expect } from '@playwright/test'
-import { apiPost, apiDelete, gotoMonitor, gotoMonitorLive, waitForMonitorReady } from '../helpers'
+import {
+  apiPost,
+  apiDelete,
+  deleteAllFiltersets,
+  gotoMonitor,
+  gotoMonitorLive,
+  waitForMonitorReady,
+} from '../helpers'
+
+// Filtersets are global state. Start every test from an empty, unfiltered
+// feed so a leftover topbar-active set cannot gate out live pushes.
+test.beforeEach(async () => {
+  await deleteAllFiltersets()
+})
 
 test('RingBuffer Live-Eintrag ohne Reload', async ({ page }) => {
   // Fixture: create a DataPoint

--- a/tests/gui/admin/ringbuffer.spec.ts
+++ b/tests/gui/admin/ringbuffer.spec.ts
@@ -11,6 +11,9 @@ import {
 // Filtersets are global state. Start every test from an empty, unfiltered
 // feed so a leftover topbar-active set cannot gate out live pushes.
 test.beforeEach(async () => {
+  // Monitor tests wait for a real WebSocket ("Live" badge) plus live pushes —
+  // the default 30s per-test budget is too tight under CI load.
+  test.setTimeout(60_000)
   await deleteAllFiltersets()
 })
 

--- a/tests/gui/admin/ringbuffer.spec.ts
+++ b/tests/gui/admin/ringbuffer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { apiPost, apiDelete } from '../helpers'
+import { apiPost, apiDelete, gotoMonitor, waitForMonitorReady } from '../helpers'
 
 test('RingBuffer Live-Eintrag ohne Reload', async ({ page }) => {
   // Fixture: create a DataPoint
@@ -11,8 +11,7 @@ test('RingBuffer Live-Eintrag ohne Reload', async ({ page }) => {
   const dpId = created.id
 
   try {
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
 
     // Status badge must say "Live"
     await expect(page.locator('[data-testid="status-badge"]')).toContainText('Live', { timeout: 8_000 })
@@ -40,8 +39,7 @@ test('RingBuffer Pause/Resume stoppt Live-Append und holt Queue nach', async ({ 
   const dpId = created.id
 
   try {
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
     await expect(page.locator('[data-testid="status-badge"]')).toContainText('Live', { timeout: 8_000 })
 
     const rows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`)
@@ -73,8 +71,7 @@ test('RingBuffer Auto-Scroll folgt Live, bleibt stabil bei Pause', async ({ page
   const dpId = created.id
 
   try {
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
     const rows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`)
     const before = await rows.count()
 
@@ -114,8 +111,7 @@ test('RingBuffer zeigt Live-Einträge auch ohne manuellen Refresh', async ({ pag
   const dpId = created.id
 
   try {
-    await page.goto('/ringbuffer')
-    await page.waitForLoadState('networkidle')
+    await gotoMonitor(page)
     const rows = page.locator(`[data-testid="ringbuffer-entry"][data-dp="${dpId}"]`)
     const before = await rows.count()
 
@@ -160,8 +156,7 @@ test('RingBuffer Monitor-Modal öffnet stabil ohne separates Speicher-PopUp', as
     })
   })
 
-  await page.goto('/ringbuffer')
-  await page.waitForLoadState('networkidle')
+  await gotoMonitor(page)
   await page.click('[data-testid="btn-open-monitor-config"]')
 
   await expect(page.locator('[data-testid="rb-config-max-size-value"]')).toBeVisible()
@@ -219,8 +214,7 @@ test('RingBuffer Monitor-Modal hält Speicher-/Retention-State und sendet Limits
     })
   })
 
-  await page.goto('/ringbuffer')
-  await page.waitForLoadState('networkidle')
+  await gotoMonitor(page)
   await page.click('[data-testid="btn-open-monitor-config"]')
 
   await expect(page.locator('[data-testid="rb-config-max-entries-enabled"]')).toBeChecked()
@@ -295,8 +289,7 @@ test('RingBuffer Monitor-Modal Statistik rendert stabil bei leerem und gefüllte
     })
   })
 
-  await page.goto('/ringbuffer')
-  await page.waitForLoadState('networkidle')
+  await gotoMonitor(page)
   await page.click('[data-testid="btn-open-monitor-config"]')
   const statsBox = await page.locator('[data-testid="rb-config-stats"]').boundingBox()
   const firstInputBox = await page.locator('[data-testid="rb-config-max-entries"]').boundingBox()
@@ -311,7 +304,7 @@ test('RingBuffer Monitor-Modal Statistik rendert stabil bei leerem und gefüllte
 
   showFilledStats = true
   await page.reload()
-  await page.waitForLoadState('networkidle')
+  await waitForMonitorReady(page)
   await page.click('[data-testid="btn-open-monitor-config"]')
   await expect(page.locator('[data-testid="rb-config-stats-total"]')).toContainText('25')
   await expect(page.locator('[data-testid="rb-config-stats-file-size"]')).toContainText('1.00 MB')
@@ -370,8 +363,7 @@ test('RingBuffer Monitor-Modal unterstützt Max.-Einträge ohne Limit und schlie
     })
   })
 
-  await page.goto('/ringbuffer')
-  await page.waitForLoadState('networkidle')
+  await gotoMonitor(page)
   await page.click('[data-testid="btn-open-monitor-config"]')
   await expect(page.locator('[data-testid="rb-config-max-entries-enabled"]')).toBeChecked()
   await page.click('[data-testid="rb-config-max-entries-enabled"]')

--- a/tests/gui/demo/demo.spec.ts
+++ b/tests/gui/demo/demo.spec.ts
@@ -8,6 +8,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { waitForMonitorReady } from '../helpers'
 
 test('Demo-User sieht Dashboard (Übersicht)', async ({ page }) => {
   await page.goto('/')
@@ -41,7 +42,7 @@ test('Demo-User kann Historie aufrufen', async ({ page }) => {
 
 test('Demo-User kann Monitor aufrufen', async ({ page }) => {
   await page.goto('/ringbuffer')
-  await page.waitForLoadState('networkidle')
+  await waitForMonitorReady(page)
   await expect(page).toHaveURL('/ringbuffer')
 })
 

--- a/tests/gui/helpers.ts
+++ b/tests/gui/helpers.ts
@@ -156,6 +156,19 @@ export async function waitForMonitorReady(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="status-badge"]')).toBeVisible({ timeout: 15_000 })
 }
 
+/**
+ * Navigate to the Monitor and wait until the live WebSocket is connected.
+ *
+ * Tests that push values via the API and expect them to appear through the
+ * live `ringbuffer_entry` push MUST use this — the server does not replay
+ * events, so any value written before the WS handshake completes is lost.
+ * The "Live" badge text is shown only while `wsStore.connected` is true.
+ */
+export async function gotoMonitorLive(page: Page): Promise<void> {
+  await page.goto('/ringbuffer')
+  await expect(page.locator('[data-testid="status-badge"]')).toContainText('Live', { timeout: 20_000 })
+}
+
 /** Upload a single SVG file to the icon library. `name` is the filename without extension. */
 export async function apiUploadIcon(name: string, svgContent: string): Promise<void> {
   const token = await getToken()

--- a/tests/gui/helpers.ts
+++ b/tests/gui/helpers.ts
@@ -180,6 +180,23 @@ export async function gotoMonitorLive(page: Page): Promise<void> {
   await initialQuery
 }
 
+/**
+ * Delete every ringbuffer filterset.
+ *
+ * Filtersets are global admin state. A test (or a previously failed test
+ * whose `finally` cleanup was skipped) can leave a `topbar_active` set
+ * behind. RingBufferView then loads it on mount, and onLiveEntry gates every
+ * live `ringbuffer_entry` against that set — dropping pushes for any DP that
+ * does not match. Call this in a beforeEach so each Monitor test starts from
+ * a clean, unfiltered live feed.
+ */
+export async function deleteAllFiltersets(): Promise<void> {
+  const sets = (await apiGet('/api/v1/ringbuffer/filtersets')) as Array<{ id: string }>
+  for (const set of sets) {
+    await apiDelete(`/api/v1/ringbuffer/filtersets/${set.id}`)
+  }
+}
+
 /** Upload a single SVG file to the icon library. `name` is the filename without extension. */
 export async function apiUploadIcon(name: string, svgContent: string): Promise<void> {
   const token = await getToken()

--- a/tests/gui/helpers.ts
+++ b/tests/gui/helpers.ts
@@ -157,16 +157,27 @@ export async function waitForMonitorReady(page: Page): Promise<void> {
 }
 
 /**
- * Navigate to the Monitor and wait until the live WebSocket is connected.
+ * Navigate to the Monitor and wait until it is ready to receive live pushes.
  *
  * Tests that push values via the API and expect them to appear through the
- * live `ringbuffer_entry` push MUST use this — the server does not replay
- * events, so any value written before the WS handshake completes is lost.
- * The "Live" badge text is shown only while `wsStore.connected` is true.
+ * live `ringbuffer_entry` push MUST use this. Two preconditions must hold
+ * before the test pushes a value, otherwise the entry is silently lost:
+ *   1. The WebSocket is connected — shown by the "Live" status badge. The
+ *      server does not replay events written before the handshake.
+ *   2. The initial table query has returned — until then `load()` overwrites
+ *      `entries` and would clobber a live entry that arrived during loading.
  */
 export async function gotoMonitorLive(page: Page): Promise<void> {
+  const initialQuery = page
+    .waitForResponse(
+      (r) =>
+        /\/api\/v1\/ringbuffer\/(query\/v2|filtersets\/query)$/.test(new URL(r.url()).pathname),
+      { timeout: 20_000 },
+    )
+    .catch(() => null)
   await page.goto('/ringbuffer')
   await expect(page.locator('[data-testid="status-badge"]')).toContainText('Live', { timeout: 20_000 })
+  await initialQuery
 }
 
 /** Upload a single SVG file to the icon library. `name` is the filename without extension. */

--- a/tests/gui/helpers.ts
+++ b/tests/gui/helpers.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as dotenv from 'dotenv'
+import { expect, type Page } from '@playwright/test'
 
 // Load the repository-root .env so `OBS_HTTP_HOST_PORT` resolves the same way
 // it does in playwright.config.ts when the runner hasn't pre-populated it.
@@ -135,6 +136,24 @@ export async function apiDelete(path: string): Promise<void> {
   if (!res.ok && res.status !== 404) {
     throw new Error(`DELETE ${path} failed: ${res.status}`)
   }
+}
+
+/**
+ * Navigate to the Monitor (/ringbuffer) and wait until it is interactive.
+ *
+ * The Monitor holds a persistent WebSocket plus a 10 s /stats poll, so
+ * `page.waitForLoadState('networkidle')` never settles and times out. Wait
+ * for the always-rendered status badge instead — once it is visible the view
+ * has mounted and the initial query has run.
+ */
+export async function gotoMonitor(page: Page): Promise<void> {
+  await page.goto('/ringbuffer')
+  await waitForMonitorReady(page)
+}
+
+/** Wait for the Monitor view to be interactive (e.g. after a page.reload()). */
+export async function waitForMonitorReady(page: Page): Promise<void> {
+  await expect(page.locator('[data-testid="status-badge"]')).toBeVisible({ timeout: 15_000 })
 }
 
 /** Upload a single SVG file to the icon library. `name` is the filename without extension. */


### PR DESCRIPTION
## Überblick

Behebt #482 — die Monitor-/RingBuffer-E2E-Tests waren fehlschlagend bzw. flaky. Diese Branch stabilisiert sie über zwei echte App-Korrekturen und mehrere Test-Robustheits-Verbesserungen nach Playwright-Best-Practices.

## Produktcode-Korrekturen

- **`gui/src/App.vue`** — `ws.connect()` wird vor die `loadMe()`/`settings.load()`-REST-Round-Trips gezogen. Vorher verzögerte das den WebSocket-Handshake so weit, dass früh gepushte Live-Events verloren gingen (kein Replay serverseitig).
- **`gui/src/views/RingBufferView.vue`** — der `onRingbufferEntry`-Handler wird am Anfang von `onMounted` registriert, vor `loadFiltersets()`/`load()`. Sonst gingen `ringbuffer_entry`-Pushes verloren, die während der initialen REST-Calls ankamen.

## Test-Robustheit (`tests/gui`)

- `networkidle` → deterministisches Warten auf das Status-Badge (`gotoMonitor`/`gotoMonitorLive`/`waitForMonitorReady`-Helper). Der Monitor hält eine dauerhafte WS-Verbindung + 10s-Poll, daher wird das Netzwerk nie „idle".
- Filterset-State-Isolation: `deleteAllFiltersets()` in `beforeEach` — ein zurückgebliebenes topbar-aktives Set hätte sonst Live-Pushes weggefiltert.
- Combobox-Picks warten jetzt, bis `combobox-item-0` den getippten Text rendert; Aufrufer übergeben sichtbaren Text statt UUIDs (die Hierarchy-Combobox sucht nur über Namen).
- Auf Editor-Hydration warten, bevor ein Datapoint gewählt wird.
- Per-Test-Timeout auf 60s (Monitor-Tests warten auf eine echte WS-Verbindung + mehrere Save-Round-Trips).
- `expectTopbarChip`-Helper mit Reload-Fallback gegen eine seltene Topbar-Render-Race.
- Toggle-Test pausiert den Live-Feed, um das Query-Pfad-Verhalten zu isolieren.

## Hinweis für Reviewer

Bei der Analyse ist eine bestehende Produkt-Inkonsistenz aufgefallen, die hier bewusst NICHT behoben wurde (auf Wunsch test-seitig umschifft): Wird das einzige Topbar-Set inaktiv geschaltet, liefert der Query-Pfad korrekt leer, der Live-Pfad (`onLiveEntry`) läuft dagegen ungefiltert. Sauber wäre, dass `onLiveEntry` bei vorhandenen, aber inaktiven Topbar-Sets Live-Einträge verwirft. Kandidat für ein Folge-Issue.

## Test-Stand

Lokaler E2E-Stack war nicht verfügbar; verifiziert über die CI-Läufe der Branch — von ursprünglich 7+ fehlschlagenden Monitor-Tests auf zuletzt 199 passed (1 flaky, jetzt adressiert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
