### PR TITLE
[Codex] fix(auth): restore admin-only access for datapoint and logic mutations

### DIFF
--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -17,7 +17,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, field_serializer
 
-from obs.api.auth import get_current_user, optional_current_user
+from obs.api.auth import get_admin_user, get_current_user, optional_current_user
 from obs.api.v1.sessions import validate_session
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -162,7 +162,7 @@ async def list_datapoints(
 @router.post("/", response_model=DataPointOut, status_code=status.HTTP_201_CREATED)
 async def create_datapoint(
     body: DataPointCreate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
 ) -> DataPointOut:
     from obs.models.types import DataTypeRegistry
 
@@ -191,7 +191,7 @@ async def get_datapoint(
 async def update_datapoint(
     dp_id: uuid.UUID,
     body: DataPointUpdate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
 ) -> DataPointOut:
     reg = get_registry()
     if reg.get(dp_id) is None:
@@ -211,7 +211,7 @@ async def update_datapoint(
 @router.delete("/{dp_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_datapoint(
     dp_id: uuid.UUID,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
 ) -> None:
     reg = get_registry()
     if reg.get(dp_id) is None:
@@ -315,7 +315,11 @@ async def write_value(
     if reg.get(dp_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
 
-    if user is None:
+    if user is not None:
+        row = await db.fetchone("SELECT is_admin FROM users WHERE username=?", (user,))
+        if not row or not row["is_admin"]:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Admin access required")
+    else:
         page_id = request.headers.get("X-Page-Id")
         if not page_id:
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")

--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
-from obs.api.auth import get_current_user
+from obs.api.auth import get_admin_user, get_current_user
 from obs.db.database import Database, get_db
 from obs.logic.models import (
     FlowData,
@@ -70,7 +70,7 @@ async def list_graphs(
 @router.post("/graphs", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def create_graph(
     body: LogicGraphCreate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -115,7 +115,7 @@ async def get_graph(
 async def update_graph_full(
     graph_id: str,
     body: LogicGraphCreate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -151,7 +151,7 @@ async def update_graph_full(
 async def update_graph_partial(
     graph_id: str,
     body: LogicGraphUpdate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -185,7 +185,7 @@ async def update_graph_partial(
 @router.delete("/graphs/{graph_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> None:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -203,7 +203,7 @@ async def delete_graph(
 @router.post("/graphs/import", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def import_graph(
     body: LogicGraphImport,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     if body.obs_export != "logic_graph":
@@ -277,7 +277,7 @@ async def import_graph(
 @router.post("/graphs/{graph_id}/run", status_code=status.HTTP_200_OK)
 async def run_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> dict:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))


### PR DESCRIPTION
### Motivation
- Revert an authorization regression that allowed any authenticated user or API key to create/update/delete DataPoints and Logic graphs and to publish datapoint writes, which could actuate devices or run attacker-controlled outbound requests.
- Restore least-privilege behaviour so only admin principals can perform high-impact automation and execution operations while preserving read and page-context write flows.

### Description
- Require `get_admin_user` for datapoint mutation endpoints in `obs/api/v1/datapoints.py` (`POST /api/v1/datapoints`, `PATCH /api/v1/datapoints/{id}`, `DELETE /api/v1/datapoints/{id}`).
- Reintroduce an explicit admin check in `POST /api/v1/datapoints/{id}/value` so authenticated users are allowed to write values only if `users.is_admin`, and keep the existing page/session checks for unauthenticated page-context writes.
- Require `get_admin_user` for logic graph mutation and execution endpoints in `obs/api/v1/logic.py` (`POST /graphs`, `PUT/PATCH/DELETE /graphs/{id}`, `POST /graphs/import`, `POST /graphs/{id}/run`) while leaving read/list endpoints protected by `get_current_user`.
- Changes are minimal and surgical: swapped dependencies to `get_admin_user` and added a single DB lookup-based admin guard for the direct write path; no changes to event routing or adapter write logic.

### Testing
- Ran `pytest -q tests/api/test_datapoints.py tests/api/test_logic.py`, which failed because the specified test paths are not present in this checkout (collection error due to missing files).
- Ran `pytest -q -k 'datapoint or logic'`, which attempted collection but aborted with `ModuleNotFoundError: No module named 'pytest_asyncio'`, so tests could not be executed to completion in this environment.
- No automated test failures were produced by the change itself in this environment because full test execution was blocked by missing test dependencies or test files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ce8400d083298fee296d78e6b8e4)