### PR TITLE
[Codex] fix(logic): restrict graph mutation/run endpoints to admin users

### DIFF
--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
-from obs.api.auth import get_current_user
+from obs.api.auth import get_admin_user, get_current_user
 from obs.db.database import Database, get_db
 from obs.logic.models import (
     FlowData,
@@ -69,7 +69,7 @@ async def list_graphs(
 @router.post("/graphs", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def create_graph(
     body: LogicGraphCreate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -114,7 +114,7 @@ async def get_graph(
 async def update_graph_full(
     graph_id: str,
     body: LogicGraphCreate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -150,7 +150,7 @@ async def update_graph_full(
 async def update_graph_partial(
     graph_id: str,
     body: LogicGraphUpdate,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     now = datetime.now(UTC).isoformat()
@@ -184,7 +184,7 @@ async def update_graph_partial(
 @router.delete("/graphs/{graph_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> None:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -202,7 +202,7 @@ async def delete_graph(
 @router.post("/graphs/import", response_model=LogicGraphOut, status_code=status.HTTP_201_CREATED)
 async def import_graph(
     body: LogicGraphImport,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     if body.obs_export != "logic_graph":
@@ -276,7 +276,7 @@ async def import_graph(
 @router.post("/graphs/{graph_id}/run", status_code=status.HTTP_200_OK)
 async def run_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> dict:
     row = await db.fetchone("SELECT id FROM logic_graphs WHERE id=?", (graph_id,))
@@ -298,7 +298,7 @@ async def run_graph(
 )
 async def duplicate_graph(
     graph_id: str,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
     row = await db.fetchone("SELECT * FROM logic_graphs WHERE id=?", (graph_id,))


### PR DESCRIPTION
### Motivation
- The Logic Engine endpoints allowed any authenticated user to create, save, duplicate, import, delete, or run graphs that can contain high-impact node types (`api_client`, `datapoint_write`, `python_script`), enabling SSRF, device actuation, and DoS risks. 
- The intent is to restrict state-changing and execution operations to admin users while retaining read access for normal users.

### Description
- Updated `obs/api/v1/logic.py` to require `get_admin_user` instead of `get_current_user` for graph write/execute endpoints: `POST /graphs`, `PUT /graphs/{id}`, `PATCH /graphs/{id}`, `DELETE /graphs/{id}`, `POST /graphs/import`, `POST /graphs/{id}/run`, and `POST /graphs/{id}/duplicate`.
- Kept read-only endpoints (`GET /node-types`, `GET /graphs`, `GET /graphs/{id}`, `GET /graphs/{id}/export`) using `get_current_user` so authenticated users retain listing and viewing capabilities.
- Preserved existing behavior such as executor cache reload/invalidate and database interactions; no functional changes to execution or node handling were made.

### Testing
- `python -m py_compile obs/api/v1/logic.py` completed successfully.
- `pytest -q tests/integration/test_duplication.py` could not be executed in this environment due to a missing test dependency (`pytest_asyncio`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039673e4488329a6929eb5aae8fcc5)