### PR TITLE
[Codex] fix(security): restrict config export/import to admins

### DIFF
--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -146,7 +146,7 @@ class ClearResult(BaseModel):
 
 @router.get("/export", response_model=ConfigExport)
 async def export_config(
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> ConfigExport:
     reg = get_registry()
@@ -289,7 +289,7 @@ async def export_db(
 @router.post("/import", response_model=ImportResult, status_code=status.HTTP_200_OK)
 async def import_config(
     body: ConfigExport,
-    _user: str = Depends(get_current_user),
+    _user: str = Depends(get_admin_user),
     db: Database = Depends(lambda: get_db()),
 ) -> ImportResult:
     result = ImportResult(


### PR DESCRIPTION
### Motivation
- Close a privilege escalation and data-exposure gap where the backup `export`/`import` endpoints allowed any authenticated user or API key to export secret-bearing `logic_graphs.flow_data` and import enabled executable logic.

### Description
- Require admin authorization by changing the dependency from `get_current_user` to `get_admin_user` for `GET /api/v1/config/export` and `POST /api/v1/config/import` in `obs/api/v1/config.py` so only admins can export or restore logic graphs.

### Testing
- Attempted to run integration tests with `pytest -q tests/integration/test_auth.py`, but the run failed due to a missing test dependency (`pytest_asyncio`) in the local environment, so no tests passed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0396f10a8c8329b69d120636f9a06a)