### PR TITLE
[Codex] fix(config): validate imported binding formulas

### DIFF
--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -21,6 +21,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from obs.api.auth import get_admin_user, get_current_user
+from obs.core.formula import validate_formula
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
 from obs.models.datapoint import DataPoint
@@ -402,6 +403,11 @@ async def import_config(
     for b_data in body.bindings:
         try:
             b_id = b_data.id
+            formula = (b_data.value_formula or "").strip() or None
+            if formula:
+                err = validate_formula(formula)
+                if err:
+                    raise ValueError(f"Ungültige Formel: {err}")
             row = await db.fetchone("SELECT id FROM adapter_bindings WHERE id=?", (b_id,))
             if row:
                 await db.execute_and_commit(
@@ -415,7 +421,7 @@ async def import_config(
                         b_data.direction,
                         json.dumps(b_data.config),
                         int(b_data.enabled),
-                        b_data.value_formula,
+                        formula,
                         b_data.send_throttle_ms,
                         int(b_data.send_on_change),
                         b_data.send_min_delta,
@@ -442,7 +448,7 @@ async def import_config(
                         b_data.direction,
                         json.dumps(b_data.config),
                         int(b_data.enabled),
-                        b_data.value_formula,
+                        formula,
                         b_data.send_throttle_ms,
                         int(b_data.send_on_change),
                         b_data.send_min_delta,


### PR DESCRIPTION
### Motivation

- The config import path accepted `value_formula` from backups and persisted it without running `validate_formula`, creating a validation bypass compared to the normal bindings API. 
- Persisted formulas are later evaluated by `apply_formula` using `eval`, so an attacker could import a crafted backup to execute arbitrary code in the server process. 

### Description

- Added an import of `validate_formula` in `obs/api/v1/config.py` and normalize incoming `value_formula` with `.strip()` to treat empty strings as `NULL`. 
- Call `validate_formula` for each imported binding and raise an error when validation fails so the existing per-binding error aggregation surface reports the problem. 
- Store the normalized, validated `formula` value in both the UPDATE and INSERT branches when upserting `adapter_bindings`, preserving behavior for valid and blank formulas. 

### Testing

- Ran `python -m compileall obs/api/v1/config.py` and the module compiled successfully. 
- No additional automated test suite was executed locally as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0399c2ecfc8329a3fae8a92c43d886)