### PR TITLE
[Codex] Harden /etc/obs.env permissions in LXC template first-boot flow

### DIFF
--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -366,6 +366,7 @@ jobs:
           OBS_DATABASE__PATH=/data/obs.db
           OBS_CONFIG=/data/config.yaml
           EOF
+          chmod 600 /etc/obs.env
 
           cat > /etc/systemd/system/obs.service << 'EOF'
           [Unit]
@@ -433,6 +434,7 @@ jobs:
           OBS_MOSQUITTO__SERVICE_USERNAME=obs
           OBS_MOSQUITTO__SERVICE_PASSWORD=$MQTT_PASSWORD
           EOF
+          chmod 600 /etc/obs.env
           FIRSTBOOT
           chmod +x /opt/obs/obs-first-boot.sh
 


### PR DESCRIPTION
### Motivation
- Prevent leaking generated MQTT service credentials by ensuring `/etc/obs.env` is not world-readable after initial creation or after the first-boot append.

### Description
- Add `chmod 600 /etc/obs.env` in `.github/workflows/lxc-template.yml` immediately after the file is created in the chroot install step and again after the first-boot script appends the generated MQTT credentials.

### Testing
- Verified the change and file contents with `sed -n '330,460p' .github/workflows/lxc-template.yml` and `nl -ba .github/workflows/lxc-template.yml | sed -n '360,445p'`, confirmed the diff with `git diff -- .github/workflows/lxc-template.yml`, and created a commit which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0362a891608329ad3b36980512c337)