### PR TITLE
fix(monitor): stabilize ringbuffer pause/resume against late load race

### DIFF
--- a/gui/src/views/RingBufferView.vue
+++ b/gui/src/views/RingBufferView.vue
@@ -210,6 +210,7 @@ async function onTimeFilterChanged() {
 
 const tableWrapRef = ref(null)
 const filtersets = ref([])
+let liveIngressSeq = 0
 
 const { paused, queuedCount, enqueue: enqueueLive, pause: pauseLive, resume: resumeLive, clear: clearLiveQueue, dispose: disposeLiveQueue } =
   useLiveQueue(entries, {
@@ -219,6 +220,34 @@ const { paused, queuedCount, enqueue: enqueueLive, pause: pauseLive, resume: res
       if (tableWrapRef.value) tableWrapRef.value.scrollTop = 0
     },
   })
+
+function markAndEnqueueLive(entry) {
+  liveIngressSeq += 1
+  enqueueLive(entry)
+}
+
+function entryIdentity(entry) {
+  return [
+    entry?.datapoint_id ?? '',
+    entry?.ts ?? '',
+    entry?.source_adapter ?? '',
+    JSON.stringify(entry?.new_value ?? null),
+    JSON.stringify(entry?.old_value ?? null),
+  ].join('|')
+}
+
+function mergeEntriesKeepingLiveFirst(liveFirst, loaded) {
+  const merged = []
+  const seen = new Set()
+  for (const entry of [...liveFirst, ...loaded]) {
+    const key = entryIdentity(entry)
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(entry)
+    if (merged.length >= DEFAULT_QUERY_LIMIT) break
+  }
+  return merged
+}
 
 const wsConnected = computed(() => wsStore.connected)
 
@@ -295,16 +324,16 @@ function onLiveEntry(entry) {
   const presetMatched = Array.isArray(entry?.matched_set_ids) ? entry.matched_set_ids : null
 
   if (activeSets.length === 0) {
-    enqueueLive({ ...entry, matched_set_ids: presetMatched ?? [] })
+    markAndEnqueueLive({ ...entry, matched_set_ids: presetMatched ?? [] })
     return
   }
   if (presetMatched && presetMatched.length > 0) {
-    enqueueLive({ ...entry, matched_set_ids: presetMatched })
+    markAndEnqueueLive({ ...entry, matched_set_ids: presetMatched })
     return
   }
   const ids = matchedSetIds(entry, activeSets)
   if (ids.length === 0) return
-  enqueueLive({ ...entry, matched_set_ids: ids })
+  markAndEnqueueLive({ ...entry, matched_set_ids: ids })
 }
 
 async function applyFilters() {
@@ -342,6 +371,7 @@ function activeTopbarSetIds() {
 async function load() {
   loading.value = true
   listError.value = ''
+  const liveSeqAtLoadStart = liveIngressSeq
   try {
     const setIds = activeTopbarSetIds()
     let data
@@ -358,7 +388,11 @@ async function load() {
       const resp = await ringbufferApi.queryV2(buildQueryV2())
       data = resp.data
     }
-    entries.value = data
+    const loadedEntries = Array.isArray(data) ? data : []
+    const liveArrivedDuringLoad = liveIngressSeq !== liveSeqAtLoadStart
+    entries.value = liveArrivedDuringLoad
+      ? mergeEntriesKeepingLiveFirst(entries.value, loadedEntries)
+      : loadedEntries
     await nextTick()
     if (!paused.value && tableWrapRef.value) tableWrapRef.value.scrollTop = 0
   } catch (error) {

--- a/gui/tests/views/RingBufferView.live-queue.spec.js
+++ b/gui/tests/views/RingBufferView.live-queue.spec.js
@@ -119,4 +119,39 @@ describe('RingBufferView live WebSocket queue', () => {
     expect(wrapper.findAll('[data-testid="ringbuffer-entry"]').length).toBe(250)
   })
 
+  it('keeps resumed live entries when initial load resolves afterwards', async () => {
+    const { mountRingBufferView, flushPromises, makeRingbufferApiMock } = await import('../helpers/mountRingBufferView.js')
+
+    let resolveInitialQuery
+    const initialQuery = new Promise((resolve) => {
+      resolveInitialQuery = resolve
+    })
+
+    const ringbufferApi = makeRingbufferApiMock({
+      queryV2: vi.fn(() => initialQuery),
+      listFiltersets: vi.fn().mockResolvedValue({ data: [] }),
+    })
+
+    const { wrapper, emitLive } = await mountRingBufferView({ wsConnected: true, ringbufferApi })
+
+    await wrapper.find('[data-testid="btn-live-pause"]').trigger('click')
+    await flushPromises()
+
+    emitLive(makeEntry(1, { datapoint_id: 'dp-race' }))
+    emitLive(makeEntry(2, { datapoint_id: 'dp-race' }))
+    await flushPromises()
+
+    await wrapper.find('[data-testid="btn-live-resume"]').trigger('click')
+    await new Promise((r) => setTimeout(r, 100))
+    await flushPromises()
+
+    // Initial mount query resolves after resume and must not clobber the
+    // already flushed live entries.
+    resolveInitialQuery({ data: [] })
+    await flushPromises()
+
+    const rows = wrapper.findAll('[data-testid="ringbuffer-entry"]')
+    expect(rows.length).toBe(2)
+  })
+
 })


### PR DESCRIPTION
## Summary
- fix a race in `RingBufferView` where a late initial `load()` response could overwrite already flushed live queue entries
- track live ingress during in-flight loads and merge late query results without dropping newer live rows
- add a regression test covering pause/resume with delayed initial query resolution

## Verification
- `npm --prefix gui test -- tests/views/RingBufferView.live-queue.spec.js`
- `BASE_URL=http://localhost:8090 npm --prefix tests/gui test -- --project=admin --retries=0 admin/ringbuffer.spec.ts -g "RingBuffer Pause/Resume stoppt Live-Append und holt Queue nach"` (5x)
- `BASE_URL=http://localhost:8082 npm --prefix tests/gui test -- --project=admin --retries=0 admin/ringbuffer.spec.ts -g "RingBuffer Pause/Resume stoppt Live-Append und holt Queue nach"` (5x)
- `BASE_URL=http://localhost:8090 npm --prefix tests/gui test -- --project=admin --retries=0 admin/ringbuffer.spec.ts`
- `BASE_URL=http://localhost:8082 npm --prefix tests/gui test -- --project=admin --retries=0 admin/ringbuffer.spec.ts`

Closes #495
