### PR TITLE
[Codex] Harden tag handling in LXC release workflow

### DIFF
--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -33,10 +33,17 @@ jobs:
 
       - name: Set template metadata
         id: meta
+        env:
+          GITHUB_REF_SAFE: ${{ github.ref }}
+          GITHUB_REF_NAME_SAFE: ${{ github.ref_name }}
         run: |
           # On a tag push use the tag name directly; fall back for manual runs
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            VERSION="${{ github.ref_name }}"
+          if [[ "$GITHUB_REF_SAFE" == refs/tags/* ]]; then
+            VERSION="$GITHUB_REF_NAME_SAFE"
+            if ! [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]]; then
+              echo "Invalid tag format: $VERSION" >&2
+              exit 1
+            fi
           else
             VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "0.0.0")
           fi
@@ -529,18 +536,30 @@ jobs:
       - name: Upload LXC assets to existing release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_REPO: ${{ github.repository }}
         run: |
+          if ! [[ "$RELEASE_TAG" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "Invalid tag format: $RELEASE_TAG" >&2
+            exit 1
+          fi
           find artifacts/ -type f \( -name "*.tar.zst" -o -name "*.tar.gz" -o -name "*.sha512" \) \
-            | xargs gh release upload "${{ github.ref_name }}" \
-              --repo "${{ github.repository }}" \
+            | xargs gh release upload "$RELEASE_TAG" \
+              --repo "$RELEASE_REPO" \
               --clobber
 
       - name: Insert LXC checksums into release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_REPO: ${{ github.repository }}
         run: |
-          gh release view "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}" --json body -q .body \
+          if ! [[ "$RELEASE_TAG" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "Invalid tag format: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          gh release view "$RELEASE_TAG" \
+            --repo "$RELEASE_REPO" --json body -q .body \
             > /tmp/release_body.txt
 
           python3 <<'PYEOF' > /tmp/new_body.txt
@@ -585,6 +604,6 @@ jobs:
           print(body.replace(marker, section), end='')
           PYEOF
 
-          gh release edit "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}" \
+          gh release edit "$RELEASE_TAG" \
+            --repo "$RELEASE_REPO" \
             --notes-file /tmp/new_body.txt


### PR DESCRIPTION
### Motivation

- Close a command-injection vector where `${{ github.ref }}` / `${{ github.ref_name }}` were interpolated directly into `run:` shell blocks on tag pushes, allowing malicious tag names to execute on the runner. 
- Ensure release artifact upload and release-note editing treat tag names as data and fail fast on unexpected formats to protect release integrity. 

### Description

- Stop embedding `github.ref` / `github.ref_name` directly into shell script text by exporting them to step-level env vars and reading them from shell variables (`GITHUB_REF_SAFE`, `GITHUB_REF_NAME_SAFE`, `RELEASE_TAG`, `RELEASE_REPO`).
- Add allowlist validation for tag values using the regex `^[0-9A-Za-z._-]+$` and exit with an error if a tag does not match, preventing use of tags with shell metacharacters.
- Replace vulnerable uses of `${{ github.ref_name }}` / `${{ github.repository }}` inside `run:` blocks with the validated shell variables `$RELEASE_TAG` and `$RELEASE_REPO` (and use `$GITHUB_REF_NAME_SAFE` for metadata versioning).

### Testing

- Performed an automated pattern search with `rg` to confirm sensitive expression contexts are no longer directly present inside `run:` blocks, and the expected safe env variables are present. (search succeeded)
- Applied and validated the patch to `.github/workflows/lxc-template.yml` and inspected the resulting diff to confirm the replacements and added validation appear in the file. (patch application and diff inspection succeeded)
- No unit or CI tests were executed as this change only hardens the GitHub Actions workflow logic and was validated via static checks described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036e8409a48329ac6477488a270e5e)