### PR TITLE
feat: binding migration between adapter instances

### DIFF
--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -114,6 +114,8 @@ export const adapterApi = {
   deleteInstance:  (id)         => api.delete(`/adapters/instances/${id}`),
   testInstance:       (id, config)      => api.post(`/adapters/instances/${id}/test`, { config }),
   restartInstance:    (id)              => api.post(`/adapters/instances/${id}/restart`),
+  migrateBindings:    (sourceId, targetInstanceId) =>
+    api.post(`/adapters/instances/${sourceId}/bindings/migrate`, { target_instance_id: targetInstanceId }),
   mqttBrowseTopics:   (id, timeout = 5) => api.get(`/adapters/instances/${id}/mqtt/browse`, { params: { timeout }, timeout: (timeout + 3) * 1000 }),
   mqttSamplePayload:  (id, topic, timeout = 5) => api.get(`/adapters/instances/${id}/mqtt/sample`, { params: { topic, timeout }, timeout: (timeout + 3) * 1000 }),
   iobrokerBrowseStates: (id, q = '', limit = 50) => api.get(`/adapters/instances/${id}/iobroker/states`, { params: { q, limit } }),

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -236,6 +236,19 @@
       "previewError": "Vorschau konnte nicht geladen werden",
       "importFailed": "Import fehlgeschlagen"
     },
+    "migration": {
+      "openButton": "Bindings migrieren",
+      "openTitle": "Alle Verknüpfungen dieser Instanz auf eine andere Instanz desselben Typs migrieren",
+      "modalTitle": "Bindings migrieren",
+      "modalTitleFull": "Bindings migrieren — {name}",
+      "description": "Alle Verknüpfungen der Quell-Instanz werden auf die Ziel-Instanz desselben Adapter-Typs verschoben. Bereits vorhandene Verknüpfungen am Ziel werden übersprungen.",
+      "targetLabel": "Ziel-Instanz",
+      "targetPlaceholder": "Ziel wählen …",
+      "targetBindingCount": "{n} Verknüpfungen",
+      "confirmButton": "Migrieren",
+      "result": "{migrated} Verknüpfungen migriert, {skipped} übersprungen.",
+      "failed": "Migration fehlgeschlagen"
+    },
     "anwesenheit": {
       "modalTitle": "Anwesenheitssimulation",
       "modalTitleFull": "Anwesenheitssimulation — {name}",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -236,6 +236,19 @@
       "previewError": "Preview could not be loaded",
       "importFailed": "Import failed"
     },
+    "migration": {
+      "openButton": "Migrate bindings",
+      "openTitle": "Move all bindings of this instance to another instance of the same adapter type",
+      "modalTitle": "Migrate bindings",
+      "modalTitleFull": "Migrate bindings — {name}",
+      "description": "All bindings from the source instance are moved to the target instance of the same adapter type. Existing bindings on the target are skipped.",
+      "targetLabel": "Target instance",
+      "targetPlaceholder": "Select target …",
+      "targetBindingCount": "{n} bindings",
+      "confirmButton": "Migrate",
+      "result": "{migrated} bindings migrated, {skipped} skipped.",
+      "failed": "Migration failed"
+    },
     "anwesenheit": {
       "modalTitle": "Presence simulation",
       "modalTitleFull": "Presence simulation — {name}",

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -229,6 +229,14 @@
               :title="$t('adapters.manageObjectsTitle')">
               {{ $t('adapters.manageObjects') }}
             </button>
+            <button
+              @click="openBindingMigration(a)"
+              class="btn-secondary btn-sm"
+              :disabled="migrationTargetsFor(a).length === 0"
+              :data-testid="`btn-open-migrate-bindings-${a.id}`"
+              :title="$t('adapters.migration.openTitle')">
+              {{ $t('adapters.migration.openButton') }}
+            </button>
             <button @click="confirmDelete(a)" class="ml-auto btn-danger btn-sm" :disabled="busy[a.id] === 'delete'"
               :title="$t('adapters.deleteConfirm')"
               data-testid="btn-delete-instance">
@@ -252,6 +260,51 @@
     <!-- Anwesenheitssimulation: Objekte verwalten -->
     <Modal v-model="anwesenheitOpen" :title="anwesenheitInstance ? $t('adapters.anwesenheit.modalTitleFull', { name: anwesenheitInstance.name }) : $t('adapters.anwesenheit.modalTitle')" max-width="xl">
       <AnwesenheitDatapointSelector v-if="anwesenheitOpen && anwesenheitInstance" :instance-id="anwesenheitInstance.id" />
+    </Modal>
+
+    <Modal
+      v-model="migrationOpen"
+      :title="migrationSource ? $t('adapters.migration.modalTitleFull', { name: migrationSource.name }) : $t('adapters.migration.modalTitle')"
+      max-width="lg">
+      <div class="flex flex-col gap-4">
+        <p class="text-sm text-slate-500">
+          {{ $t('adapters.migration.description') }}
+        </p>
+        <div class="form-group">
+          <label class="label">{{ $t('adapters.migration.targetLabel') }}</label>
+          <select v-model="migrationTargetId" class="input" data-testid="select-migration-target">
+            <option value="">{{ $t('adapters.migration.targetPlaceholder') }}</option>
+            <option
+              v-for="item in migrationSourceTargets"
+              :key="item.id"
+              :value="item.id">
+              {{ item.name }} ({{ $t('adapters.migration.targetBindingCount', { n: item.bindings }) }})
+            </option>
+          </select>
+        </div>
+
+        <div v-if="migrationError" class="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
+          {{ migrationError }}
+        </div>
+        <div
+          v-if="migrationResult"
+          class="p-3 bg-green-500/10 border border-green-500/30 rounded-lg text-sm text-green-500"
+          data-testid="migration-result">
+          {{ $t('adapters.migration.result', { migrated: migrationResult.migrated, skipped: migrationResult.skipped }) }}
+        </div>
+
+        <div class="flex gap-3">
+          <button class="btn-secondary btn-sm" @click="migrationOpen = false">{{ $t('common.cancel') }}</button>
+          <button
+            class="btn-primary btn-sm"
+            :disabled="migrationBusy || !migrationTargetId"
+            data-testid="btn-migrate-bindings-confirm"
+            @click="executeBindingMigration">
+            <Spinner v-if="migrationBusy" size="xs" color="white" />
+            {{ $t('adapters.migration.confirmButton') }}
+          </button>
+        </div>
+      </div>
     </Modal>
 
     <Modal v-model="importOpen" :title="importInstance ? $t('adapters.iobroker.modalTitleFull', { name: importInstance.name }) : $t('adapters.iobroker.modalTitle')" max-width="2xl" resizable>
@@ -374,6 +427,14 @@ const createError       = ref(null)
 const deleteTarget      = ref(null)
 const showDeleteConfirm = ref(false)
 
+// Binding-Migration
+const migrationOpen = ref(false)
+const migrationSource = ref(null)
+const migrationTargetId = ref('')
+const migrationBusy = ref(false)
+const migrationError = ref(null)
+const migrationResult = ref(null)
+
 // Anwesenheitssimulation — Objekte verwalten + Health
 const anwesenheitOpen     = ref(false)
 const anwesenheitInstance = ref(null)
@@ -413,6 +474,11 @@ const selectedImportCount = computed(() => selectedImportStates.value.length)
 const allImportSelected = computed(() => {
   const selectable = importPreview.value.filter(i => !i.exists).map(i => i.state_id)
   return selectable.length > 0 && selectable.every(id => selectedImportStates.value.includes(id))
+})
+const migrationSourceTargets = computed(() => {
+  const src = migrationSource.value
+  if (!src) return []
+  return store.instances.filter((item) => item.id !== src.id && item.adapter_type === src.adapter_type)
 })
 
 let refreshTimer = null
@@ -656,6 +722,39 @@ async function executeIoBrokerImport() {
     importError.value = e.response?.data?.detail ?? t('adapters.iobroker.importFailed')
   } finally {
     importBusy.value = null
+  }
+}
+
+function migrationTargetsFor(source) {
+  return store.instances.filter((item) => item.id !== source.id && item.adapter_type === source.adapter_type)
+}
+
+function openBindingMigration(source) {
+  migrationSource.value = source
+  migrationTargetId.value = ''
+  migrationError.value = null
+  migrationResult.value = null
+  migrationOpen.value = true
+}
+
+async function executeBindingMigration() {
+  const source = migrationSource.value
+  if (!source || !migrationTargetId.value) return
+  migrationBusy.value = true
+  migrationError.value = null
+  migrationResult.value = null
+  try {
+    const { data } = await adapterApi.migrateBindings(source.id, migrationTargetId.value)
+    migrationResult.value = data
+    feedback[source.id] = {
+      success: true,
+      detail: `${data.migrated} Verknüpfungen migriert, ${data.skipped} übersprungen`,
+    }
+    await refreshInstances()
+  } catch (e) {
+    migrationError.value = e.response?.data?.detail ?? 'Migration fehlgeschlagen'
+  } finally {
+    migrationBusy.value = false
   }
 }
 

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -66,6 +66,18 @@ class InstanceBindingEntry(BaseModel):
     config: dict
 
 
+class BindingMigrationRequest(BaseModel):
+    target_instance_id: uuid.UUID
+
+
+class BindingMigrationResult(BaseModel):
+    source_instance_id: uuid.UUID
+    target_instance_id: uuid.UUID
+    total_source_bindings: int
+    migrated: int
+    skipped: int
+
+
 class AdapterInstanceCreate(BaseModel):
     adapter_type: str
     name: str
@@ -391,6 +403,73 @@ async def restart_instance_route(
     row = await db.fetchone("SELECT * FROM adapter_instances WHERE id=?", (str(instance_id),))
     instance = adapter_registry.get_instance_by_id(str(instance_id))
     return _instance_out(row, instance)
+
+
+@router.post("/instances/{source_instance_id}/bindings/migrate", response_model=BindingMigrationResult)
+async def migrate_instance_bindings(
+    source_instance_id: uuid.UUID,
+    body: BindingMigrationRequest,
+    _user: str = Depends(get_current_user),
+    db: Database = Depends(lambda: get_db()),
+) -> BindingMigrationResult:
+    source_id = str(source_instance_id)
+    target_id = str(body.target_instance_id)
+    if source_id == target_id:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "Quell- und Ziel-Instanz dürfen nicht identisch sein")
+
+    source_row = await db.fetchone("SELECT id, adapter_type FROM adapter_instances WHERE id=?", (source_id,))
+    if source_row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Quell-Instanz nicht gefunden")
+
+    target_row = await db.fetchone("SELECT id, adapter_type FROM adapter_instances WHERE id=?", (target_id,))
+    if target_row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Ziel-Instanz nicht gefunden")
+
+    if source_row["adapter_type"] != target_row["adapter_type"]:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "Migration ist nur zwischen Instanzen desselben Adapter-Typs erlaubt",
+        )
+
+    source_bindings = await db.fetchall(
+        "SELECT id, datapoint_id FROM adapter_bindings WHERE adapter_instance_id=? ORDER BY created_at",
+        (source_id,),
+    )
+    target_bindings = await db.fetchall(
+        "SELECT datapoint_id FROM adapter_bindings WHERE adapter_instance_id=?",
+        (target_id,),
+    )
+    target_datapoint_ids = {row["datapoint_id"] for row in target_bindings}
+
+    migrated = 0
+    skipped = 0
+    total_source_bindings = len(source_bindings)
+    now = datetime.now(UTC).isoformat()
+
+    for binding_row in source_bindings:
+        if binding_row["datapoint_id"] in target_datapoint_ids:
+            skipped += 1
+            continue
+        await db.execute(
+            "UPDATE adapter_bindings SET adapter_instance_id=?, updated_at=? WHERE id=?",
+            (target_id, now, binding_row["id"]),
+        )
+        target_datapoint_ids.add(binding_row["datapoint_id"])
+        migrated += 1
+
+    if migrated > 0:
+        await db.commit()
+
+    await adapter_registry.reload_instance_bindings(source_id, db)
+    await adapter_registry.reload_instance_bindings(target_id, db)
+
+    return BindingMigrationResult(
+        source_instance_id=source_instance_id,
+        target_instance_id=body.target_instance_id,
+        total_source_bindings=total_source_bindings,
+        migrated=migrated,
+        skipped=skipped,
+    )
 
 
 @router.get("/instances/{instance_id}/bindings", response_model=list[InstanceBindingEntry])

--- a/tests/gui/admin/adapters.spec.ts
+++ b/tests/gui/admin/adapters.spec.ts
@@ -228,3 +228,86 @@ test('HA Binding mit entity_id anlegen', async () => {
     await apiDelete(`/api/v1/adapters/instances/${instance.id}`)
   }
 })
+
+
+// ---------------------------------------------------------------------------
+// Test 8: Bindings per GUI von Instanz A nach B migrieren (Issue #419)
+// ---------------------------------------------------------------------------
+
+test('Bindings via GUI von Quelle nach Ziel migrieren', async ({ page }) => {
+  const sourceName = `E2E-Migrate-Src-${Date.now()}`
+  const targetName = `E2E-Migrate-Dst-${Date.now()}`
+  let sourceId: string | null = null
+  let targetId: string | null = null
+  let dp1Id: string | null = null
+  let dp2Id: string | null = null
+
+  try {
+    const source = await apiPost('/api/v1/adapters/instances', {
+      adapter_type: 'ANWESENHEITSSIMULATION',
+      name: sourceName,
+      config: {},
+      enabled: false,
+    }) as { id: string }
+    sourceId = source.id
+
+    const target = await apiPost('/api/v1/adapters/instances', {
+      adapter_type: 'ANWESENHEITSSIMULATION',
+      name: targetName,
+      config: {},
+      enabled: false,
+    }) as { id: string }
+    targetId = target.id
+
+    const dp1 = await apiPost('/api/v1/datapoints', {
+      name: `E2E-Migrate-DP1-${Date.now()}`,
+      data_type: 'BOOLEAN',
+      tags: [],
+    }) as { id: string }
+    dp1Id = dp1.id
+
+    const dp2 = await apiPost('/api/v1/datapoints', {
+      name: `E2E-Migrate-DP2-${Date.now()}`,
+      data_type: 'BOOLEAN',
+      tags: [],
+    }) as { id: string }
+    dp2Id = dp2.id
+
+    await apiPost(`/api/v1/datapoints/${dp1.id}/bindings`, {
+      adapter_instance_id: source.id,
+      direction: 'SOURCE',
+      config: {},
+      enabled: true,
+    })
+    await apiPost(`/api/v1/datapoints/${dp2.id}/bindings`, {
+      adapter_instance_id: source.id,
+      direction: 'SOURCE',
+      config: {},
+      enabled: true,
+    })
+
+    await page.goto('/adapters')
+    await page.waitForLoadState('networkidle')
+
+    const sourceRow = page.locator(`[data-testid="adapter-row-${source.id}"]`)
+    await expect(sourceRow).toBeVisible({ timeout: 8_000 })
+    await sourceRow.locator(`[data-testid="btn-expand-${source.id}"]`).click()
+
+    await sourceRow.locator(`[data-testid="btn-open-migrate-bindings-${source.id}"]`).click()
+    await expect(page.locator('[data-testid="select-migration-target"]')).toBeVisible({ timeout: 3_000 })
+    await page.selectOption('[data-testid="select-migration-target"]', target.id)
+    await page.click('[data-testid="btn-migrate-bindings-confirm"]')
+
+    await expect(page.locator('[data-testid="migration-result"]')).toContainText('2 Verknüpfungen migriert', { timeout: 5_000 })
+
+    const sourceBindings = await apiGet(`/api/v1/adapters/instances/${source.id}/bindings`) as Array<{ binding_id: string }>
+    const targetBindings = await apiGet(`/api/v1/adapters/instances/${target.id}/bindings`) as Array<{ binding_id: string }>
+    expect(sourceBindings).toHaveLength(0)
+    expect(targetBindings).toHaveLength(2)
+  } finally {
+    if (dp1Id) await apiDelete(`/api/v1/datapoints/${dp1Id}`)
+    if (dp2Id) await apiDelete(`/api/v1/datapoints/${dp2Id}`)
+    if (sourceId) await apiDelete(`/api/v1/adapters/instances/${sourceId}`)
+    if (targetId) await apiDelete(`/api/v1/adapters/instances/${targetId}`)
+  }
+})

--- a/tests/integration/test_binding_migration.py
+++ b/tests/integration/test_binding_migration.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_instance(client, auth_headers, adapter_type: str, name: str) -> dict:
+    resp = await client.post(
+        "/api/v1/adapters/instances",
+        json={
+            "adapter_type": adapter_type,
+            "name": name,
+            "config": {},
+            "enabled": False,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_dp(client, auth_headers, suffix: str) -> dict:
+    resp = await client.post(
+        "/api/v1/datapoints/",
+        json={
+            "name": f"binding-migration-{suffix}-{uuid.uuid4().hex[:6]}",
+            "data_type": "BOOLEAN",
+            "tags": ["integration", "binding-migration"],
+            "persist_value": False,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_binding(client, auth_headers, dp_id: str, instance_id: str, *, enabled: bool = True, config: dict | None = None) -> dict:
+    resp = await client.post(
+        f"/api/v1/datapoints/{dp_id}/bindings",
+        json={
+            "adapter_instance_id": instance_id,
+            "direction": "SOURCE",
+            "config": config or {},
+            "enabled": enabled,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _list_instance_bindings(client, auth_headers, instance_id: str) -> list[dict]:
+    resp = await client.get(f"/api/v1/adapters/instances/{instance_id}/bindings", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_migrate_bindings_moves_all_bindings_to_target_instance(client, auth_headers):
+    source = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"src-{uuid.uuid4().hex[:6]}")
+    target = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"dst-{uuid.uuid4().hex[:6]}")
+
+    dp1 = await _create_dp(client, auth_headers, "m1")
+    dp2 = await _create_dp(client, auth_headers, "m2")
+
+    b1 = await _create_binding(client, auth_headers, dp1["id"], source["id"], config={"offset_override": 3})
+    b2 = await _create_binding(client, auth_headers, dp2["id"], source["id"], enabled=False)
+
+    migrate = await client.post(
+        f"/api/v1/adapters/instances/{source['id']}/bindings/migrate",
+        json={"target_instance_id": target["id"]},
+        headers=auth_headers,
+    )
+
+    assert migrate.status_code == 200, migrate.text
+    body = migrate.json()
+    assert body["migrated"] == 2
+    assert body["skipped"] == 0
+    assert body["total_source_bindings"] == 2
+
+    source_bindings = await _list_instance_bindings(client, auth_headers, source["id"])
+    target_bindings = await _list_instance_bindings(client, auth_headers, target["id"])
+
+    assert source_bindings == []
+    migrated_ids = {b1["id"], b2["id"]}
+    assert migrated_ids.issubset({item["binding_id"] for item in target_bindings})
+
+
+async def test_migrate_bindings_skips_datapoints_already_bound_on_target(client, auth_headers):
+    source = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"src-{uuid.uuid4().hex[:6]}")
+    target = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"dst-{uuid.uuid4().hex[:6]}")
+
+    dp1 = await _create_dp(client, auth_headers, "s1")
+    dp2 = await _create_dp(client, auth_headers, "s2")
+
+    moved_binding = await _create_binding(client, auth_headers, dp1["id"], source["id"])
+    skipped_binding = await _create_binding(client, auth_headers, dp2["id"], source["id"])
+    existing_target = await _create_binding(client, auth_headers, dp2["id"], target["id"])
+
+    migrate = await client.post(
+        f"/api/v1/adapters/instances/{source['id']}/bindings/migrate",
+        json={"target_instance_id": target["id"]},
+        headers=auth_headers,
+    )
+
+    assert migrate.status_code == 200, migrate.text
+    body = migrate.json()
+    assert body["migrated"] == 1
+    assert body["skipped"] == 1
+    assert body["total_source_bindings"] == 2
+
+    source_bindings = await _list_instance_bindings(client, auth_headers, source["id"])
+    target_bindings = await _list_instance_bindings(client, auth_headers, target["id"])
+
+    source_ids = {item["binding_id"] for item in source_bindings}
+    target_ids = {item["binding_id"] for item in target_bindings}
+
+    assert moved_binding["id"] in target_ids
+    assert existing_target["id"] in target_ids
+    assert skipped_binding["id"] in source_ids
+
+
+async def test_migrate_bindings_rejects_same_source_and_target(client, auth_headers):
+    source = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"src-{uuid.uuid4().hex[:6]}")
+
+    resp = await client.post(
+        f"/api/v1/adapters/instances/{source['id']}/bindings/migrate",
+        json={"target_instance_id": source["id"]},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_migrate_bindings_returns_404_for_missing_source_instance(client, auth_headers):
+    target = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"dst-{uuid.uuid4().hex[:6]}")
+
+    resp = await client.post(
+        "/api/v1/adapters/instances/00000000-0000-0000-0000-000000000000/bindings/migrate",
+        json={"target_instance_id": target["id"]},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 404
+
+
+async def test_migrate_bindings_rejects_different_adapter_types(client, auth_headers):
+    source = await _create_instance(client, auth_headers, "ANWESENHEITSSIMULATION", f"src-{uuid.uuid4().hex[:6]}")
+    target = await _create_instance(client, auth_headers, "ZEITSCHALTUHR", f"dst-{uuid.uuid4().hex[:6]}")
+
+    dp1 = await _create_dp(client, auth_headers, "x1")
+    await _create_binding(client, auth_headers, dp1["id"], source["id"])
+
+    resp = await client.post(
+        f"/api/v1/adapters/instances/{source['id']}/bindings/migrate",
+        json={"target_instance_id": target["id"]},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- add backend endpoint to migrate all bindings from one adapter instance to another instance of the same adapter type
- enforce migration guards (source/target exist, source != target, same adapter type)
- skip conflicts where target already has a binding for the same datapoint and return migrated/skipped counters
- add GUI flow in Adapters view to run binding migration interactively
- add API client method and Playwright coverage for the GUI migration flow
- add integration tests for backend migration behavior

## Testing
- `pytest tests/integration/test_binding_migration.py -q`
- `pytest tests/integration/test_datapoints.py -q`
- `npm --prefix gui run build`
- `cd tests/gui && npx playwright test --project=admin admin/adapters.spec.ts -g "Bindings via GUI von Quelle nach Ziel migrieren"`

Closes #419
