### PR TITLE
feat(datapoints): filter object list by one or more adapters

### DIFF
--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -58,6 +58,15 @@
           </button>
         </div>
 
+        <!-- Adapter (Multi-Select) -->
+        <div class="min-w-56" data-testid="adapter-filter">
+          <AdapterCombobox
+            :model-value="filters.adapters"
+            placeholder="Alle Adapter"
+            @update:modelValue="setAdapterFilter"
+          />
+        </div>
+
         <!-- Tag (Multi-Select) -->
         <div class="relative" ref="tagFilterRef" data-testid="tag-filter">
           <button
@@ -396,6 +405,7 @@ import Spinner       from '@/components/ui/Spinner.vue'
 import Modal         from '@/components/ui/Modal.vue'
 import PathLabel     from '@/components/ui/PathLabel.vue'
 import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import AdapterCombobox from '@/components/ui/AdapterCombobox.vue'
 import DataPointForm from '@/components/datapoints/DataPointForm.vue'
 
 // Inline sort-indicator
@@ -417,7 +427,7 @@ const qualityOptions = [
 const store = useDatapointStore()
 const ws    = useWebSocketStore()
 
-const filters      = ref({ q: '', tags: [], quality: '', type: '', node_ids: [], tree_ids: [] })
+const filters      = ref({ q: '', tags: [], adapters: [], quality: '', type: '', node_ids: [], tree_ids: [] })
 const showForm     = ref(false)
 const showConfirm  = ref(false)
 const editTarget   = ref(null)
@@ -439,7 +449,15 @@ let observer      = null
 let unsubWs       = null
 
 const hasActiveFilters = computed(() =>
-  !!(filters.value.q || filters.value.tags.length || filters.value.quality || filters.value.type || filters.value.node_ids.length || filters.value.tree_ids.length)
+  !!(
+    filters.value.q
+    || filters.value.tags.length
+    || filters.value.adapters.length
+    || filters.value.quality
+    || filters.value.type
+    || filters.value.node_ids.length
+    || filters.value.tree_ids.length
+  )
 )
 
 const hierarchyFilterLabel = computed(() => {
@@ -466,6 +484,7 @@ onMounted(async () => {
     Object.assign(filters.value, {
       ...saved.filters,
       tags:     saved.filters?.tags     ?? [],
+      adapters: saved.filters?.adapters ?? [],
       node_ids: saved.filters?.node_ids ?? [],
       tree_ids: saved.filters?.tree_ids ?? [],
     })
@@ -533,6 +552,7 @@ function apiFilters() {
   return {
     q:       filters.value.q,
     tag:     filters.value.tags.join(','),
+    adapter: filters.value.adapters.join(','),
     quality: filters.value.quality,
     type:    filters.value.type,
     node_id: filters.value.node_ids.map(n => n.node_id).join(','),
@@ -564,6 +584,11 @@ function setTagFilter(tag) {
   }
 }
 
+function setAdapterFilter(adapters) {
+  filters.value.adapters = Array.isArray(adapters) ? adapters : []
+  onSearch()
+}
+
 function clearFilter(key) {
   if (key === 'node_ids' || key === 'node_id') {
     filters.value.node_ids = []
@@ -573,6 +598,8 @@ function clearFilter(key) {
     filters.value.tree_ids = []
   } else if (key === 'tags') {
     filters.value.tags = []
+  } else if (key === 'adapters') {
+    filters.value.adapters = []
   } else {
     filters.value[key] = ''
   }
@@ -580,7 +607,7 @@ function clearFilter(key) {
 }
 
 function clearAllFilters() {
-  filters.value = { q: '', tags: [], quality: '', type: '', node_ids: [], tree_ids: [] }
+  filters.value = { q: '', tags: [], adapters: [], quality: '', type: '', node_ids: [], tree_ids: [] }
   nodeSearchQ.value = ''
   nodeResults.value = []
   onSearch()

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -6,7 +6,7 @@ Server-side filtered search over DataPoints.
   q       — substring match on name OR UUID OR any binding config field (case-insensitive)
   tag     — exact tag match
   type    — data_type match (e.g. FLOAT)
-  adapter — at least one binding with this adapter_type
+  adapter — comma-separated adapter_type list (OR logic), at least one binding required
   quality — runtime quality filter: good | bad | uncertain
   sort    — sort column: name | data_type | created_at | updated_at  (default: name)
   order   — sort direction: asc | desc                               (default: asc)
@@ -101,7 +101,10 @@ async def search(
     q: str = Query("", description="Substring match on name, UUID, or binding config fields"),
     tag: str = Query("", description="Comma-separated tag list — OR logic (e.g. 'heating,lighting')"),
     type: str = Query("", description="data_type match"),
-    adapter: str = Query("", description="Has binding with this adapter_type"),
+    adapter: str = Query(
+        "",
+        description="Comma-separated adapter_type list — OR logic (e.g. 'KNX,MQTT')",
+    ),
     quality: str = Query("", description="Runtime quality filter: good | bad | uncertain"),
     node_id: str = Query("", description="Comma-separated node IDs — OR logic"),
     tree_id: str = Query("", description="Comma-separated tree IDs — matches any node in these trees"),
@@ -124,14 +127,17 @@ async def search(
         tag_list = [t.strip() for t in tag.split(",") if t.strip()]
         results = [dp for dp in results if any(t in dp.tags for t in tag_list)]
 
-    # 3. adapter filter (one DB query)
+    # 3. adapter filter (one DB query) — comma-separated, OR logic
     if adapter:
-        rows = await db.fetchall(
-            "SELECT DISTINCT datapoint_id FROM adapter_bindings WHERE adapter_type=?",
-            (adapter,),
-        )
-        matched_ids = {r["datapoint_id"] for r in rows}
-        results = [dp for dp in results if str(dp.id) in matched_ids]
+        adapter_list = [a.strip() for a in adapter.split(",") if a.strip()]
+        if adapter_list:
+            placeholders = ",".join("?" * len(adapter_list))
+            rows = await db.fetchall(
+                f"SELECT DISTINCT datapoint_id FROM adapter_bindings WHERE adapter_type IN ({placeholders})",
+                adapter_list,
+            )
+            matched_ids = {r["datapoint_id"] for r in rows}
+            results = [dp for dp in results if str(dp.id) in matched_ids]
 
     # 4. q filter: all-token match on name, UUID, or binding config text (one DB query)
     #

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -58,7 +58,7 @@ async def _write_value(client, auth_headers, dp_id: str, value) -> None:
     assert resp.status_code == 204, f"write failed: {resp.text}"
 
 
-async def _insert_binding(dp_id: str, config: dict) -> None:
+async def _insert_binding(dp_id: str, config: dict, adapter_type: str = "KNX") -> None:
     """Insert a raw adapter binding row directly into the DB.
 
     Used to avoid the adapter-instance requirement of the binding API.
@@ -75,7 +75,7 @@ async def _insert_binding(dp_id: str, config: dict) -> None:
         (
             str(uuid.uuid4()),
             dp_id,
-            "KNX",
+            adapter_type,
             "SOURCE",
             json.dumps(config),
             1,
@@ -221,6 +221,48 @@ async def test_search_tag_filter(client, auth_headers):
     finally:
         await _delete(client, auth_headers, dp_tagged["id"])
         await _delete(client, auth_headers, dp_untagged["id"])
+
+
+# ---------------------------------------------------------------------------
+# Adapter filter
+# ---------------------------------------------------------------------------
+
+
+async def test_search_adapter_filter_single(client, auth_headers):
+    suffix = uuid.uuid4().hex[:6]
+    dp_knx = await _create(client, auth_headers, f"SRH-Adapter-KNX-{suffix}")
+    dp_mqtt = await _create(client, auth_headers, f"SRH-Adapter-MQTT-{suffix}")
+    try:
+        await _insert_binding(dp_knx["id"], {"group_address": "1/2/3"}, adapter_type="KNX")
+        await _insert_binding(dp_mqtt["id"], {"topic": "obs/test"}, adapter_type="MQTT")
+
+        body = await _search(client, auth_headers, adapter="KNX")
+        assert dp_knx["id"] in _ids(body)
+        assert dp_mqtt["id"] not in _ids(body)
+    finally:
+        await _delete(client, auth_headers, dp_knx["id"])
+        await _delete(client, auth_headers, dp_mqtt["id"])
+
+
+async def test_search_adapter_filter_multiple_or_logic(client, auth_headers):
+    suffix = uuid.uuid4().hex[:6]
+    dp_knx = await _create(client, auth_headers, f"SRH-Adapter-KNX2-{suffix}")
+    dp_mqtt = await _create(client, auth_headers, f"SRH-Adapter-MQTT2-{suffix}")
+    dp_modbus = await _create(client, auth_headers, f"SRH-Adapter-MODBUS-{suffix}")
+    try:
+        await _insert_binding(dp_knx["id"], {"group_address": "1/2/4"}, adapter_type="KNX")
+        await _insert_binding(dp_mqtt["id"], {"topic": "obs/test2"}, adapter_type="MQTT")
+        await _insert_binding(dp_modbus["id"], {"address": 42}, adapter_type="MODBUS_TCP")
+
+        body = await _search(client, auth_headers, adapter="KNX,MQTT")
+        ids = _ids(body)
+        assert dp_knx["id"] in ids
+        assert dp_mqtt["id"] in ids
+        assert dp_modbus["id"] not in ids
+    finally:
+        await _delete(client, auth_headers, dp_knx["id"])
+        await _delete(client, auth_headers, dp_mqtt["id"])
+        await _delete(client, auth_headers, dp_modbus["id"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add adapter filtering in the objects view with multi-select support
- pass selected adapters as comma-separated `adapter` query param
- extend search API to support comma-separated adapter values with OR logic
- add integration tests for single and multiple adapter filter behavior

Fixes #324