### PR TITLE
[Codex] fix: stop exposing WebSocket JWTs in URL query strings

### DIFF
--- a/gui/src/stores/websocket.js
+++ b/gui/src/stores/websocket.js
@@ -72,7 +72,9 @@ export const useWebSocketStore = defineStore('websocket', () => {
       connected.value = false
       clearInterval(_pingInterval)
       // Reconnect after 5 s
-      setTimeout(() => { connect() }, 5000)
+      setTimeout(() => {
+        if (localStorage.getItem('access_token')) connect()
+      }, 5000)
     }
 
     ws.onerror = () => ws.close()

--- a/gui/src/stores/websocket.js
+++ b/gui/src/stores/websocket.js
@@ -24,11 +24,8 @@ export const useWebSocketStore = defineStore('websocket', () => {
   function connect() {
     if (_ws.value?.readyState === WebSocket.OPEN) return
 
-    const token = localStorage.getItem('access_token')
-    if (!token) return
-
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    const url   = `${proto}://${window.location.host}/api/v1/ws?token=${token}`
+    const url   = `${proto}://${window.location.host}/api/v1/ws`
     const ws    = new WebSocket(url)
     _ws.value   = ws
 
@@ -75,7 +72,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
       connected.value = false
       clearInterval(_pingInterval)
       // Reconnect after 5 s
-      setTimeout(() => { if (localStorage.getItem('access_token')) connect() }, 5000)
+      setTimeout(() => { connect() }, 5000)
     }
 
     ws.onerror = () => ws.close()

--- a/obs/api/v1/websocket.py
+++ b/obs/api/v1/websocket.py
@@ -1,7 +1,6 @@
 """WebSocket API — Phase 4
 
-Preferred auth: Authorization: Bearer {jwt}   (header — token not logged)
-Legacy fallback: WS /api/v1/ws?token={jwt}    (query param — avoid in production)
+Preferred auth: Authorization: Bearer {jwt}   (header; no URL token leakage)
 
 Client → Server:
   {"action": "subscribe",   "ids": ["uuid1", "uuid2"]}
@@ -22,7 +21,7 @@ import logging
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +193,6 @@ def init_ws_manager() -> WebSocketManager:
 @router.websocket("/ws")
 async def websocket_endpoint(
     ws: WebSocket,
-    token: str | None = Query(None, description="JWT access token (legacy — prefer Authorization header)"),
 ) -> None:
     # Auth: optional — authenticated users get a user context, anonymous users
     # can still subscribe to public datapoints (read-only push channel).
@@ -203,9 +201,6 @@ async def websocket_endpoint(
     auth_header = ws.headers.get("authorization", "")
     if auth_header.startswith("Bearer "):
         resolved_token: str | None = auth_header[7:]
-    elif token:
-        logger.debug("WS auth via query param — prefer Authorization header in production")
-        resolved_token = token
     else:
         resolved_token = None
 


### PR DESCRIPTION
### Motivation
- The GUI was embedding reusable JWT access tokens in the WebSocket URL query string, which risks token leakage via reverse-proxy/load-balancer/app logs and enables replay against the REST API.
- The server accepted a `token` query parameter as a valid JWT, making the client behaviour routinely unsafe and replayable while tokens are valid.

### Description
- Removed client-side URL token injection in `gui/src/stores/websocket.js` so the client now opens `ws(s)://<host>/api/v1/ws` without `?token=...` and no longer reads the access token for URL construction.
- Kept reconnect behaviour but removed the reconnect gate that only attempted reconnect when a token existed in `localStorage` so reconnects still occur without URL tokens.
- Removed the server-side WebSocket query-parameter fallback by deleting the `token: str | None = Query(...)` parameter and the branch that accepted `?token=...` in `obs/api/v1/websocket.py`, leaving only `Authorization: Bearer ...` header validation.
- Updated the module comment/imports in `obs/api/v1/websocket.py` to reflect the removal of URL-token auth and avoid unused `Query` imports.

### Testing
- Attempted to run `python -m pytest tests/integration/test_auth.py tests/contracts/test_fastapi_contract.py -q` but the run failed due to a missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`) referenced by the integration `conftest.py`.
- No automated tests were able to be completed in this environment; changes are narrowly scoped and aim to preserve existing behaviour other than removing URL-token acceptance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a0f0d9dc8329a45e93e9ff202863)