### PR TITLE
[Codex] fix: validate DataValueEvent before bridge propagation

### DIFF
--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -100,11 +100,7 @@ class WriteRouter:
         dt = DataTypeRegistry.get(dp.data_type)
         value = event.value
         if dt.name != "UNKNOWN" and not isinstance(value, dt.python_type):
-            allow_float_numeric = (
-                dt.name == "FLOAT"
-                and isinstance(value, int | float)
-                and not isinstance(value, bool)
-            )
+            allow_float_numeric = dt.name == "FLOAT" and isinstance(value, int | float) and not isinstance(value, bool)
             if not allow_float_numeric:
                 logger.warning(
                     "WriteRouter: skip DataValueEvent for dp=%s due to type mismatch (expected=%s got=%s)",

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -100,7 +100,12 @@ class WriteRouter:
         dt = DataTypeRegistry.get(dp.data_type)
         value = event.value
         if dt.name != "UNKNOWN" and not isinstance(value, dt.python_type):
-            if not (dt.name == "FLOAT" and isinstance(value, int | float)):
+            allow_float_numeric = (
+                dt.name == "FLOAT"
+                and isinstance(value, int | float)
+                and not isinstance(value, bool)
+            )
+            if not allow_float_numeric:
                 logger.warning(
                     "WriteRouter: skip DataValueEvent for dp=%s due to type mismatch (expected=%s got=%s)",
                     event.datapoint_id,

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -80,7 +80,36 @@ class WriteRouter:
             event.value,
             event.binding_id,
         )
-        await self._write_to_dest_bindings(event.datapoint_id, event.value, skip_binding_id=event.binding_id)
+
+        if event.quality != "good" or event.value is None:
+            logger.warning(
+                "WriteRouter: skip DataValueEvent propagation for dp=%s due to quality=%s value=%r",
+                event.datapoint_id,
+                event.quality,
+                event.value,
+            )
+            return
+
+        dp = self._registry.get(event.datapoint_id)
+        if dp is None:
+            logger.warning("DataValueEvent for unknown DataPoint %s — ignored", event.datapoint_id)
+            return
+
+        from obs.models.types import DataTypeRegistry
+
+        dt = DataTypeRegistry.get(dp.data_type)
+        value = event.value
+        if dt.name != "UNKNOWN" and not isinstance(value, dt.python_type):
+            if not (dt.name == "FLOAT" and isinstance(value, int | float)):
+                logger.warning(
+                    "WriteRouter: skip DataValueEvent for dp=%s due to type mismatch (expected=%s got=%s)",
+                    event.datapoint_id,
+                    dt.python_type.__name__,
+                    type(value).__name__,
+                )
+                return
+
+        await self._write_to_dest_bindings(event.datapoint_id, value, skip_binding_id=event.binding_id)
 
     # ------------------------------------------------------------------
     # Shared helper

--- a/tests/test_write_router_value_event.py
+++ b/tests/test_write_router_value_event.py
@@ -1,0 +1,89 @@
+import uuid
+
+import pytest
+
+from obs.core.event_bus import DataValueEvent
+from obs.core.write_router import WriteRouter
+
+
+class _Registry:
+    def __init__(self, data_type: str = "BOOLEAN") -> None:
+        self.data_type = data_type
+
+    def get(self, _dp_id):
+        return type("DP", (), {"data_type": self.data_type, "name": "dp"})()
+
+
+@pytest.mark.anyio
+async def test_handle_value_event_skips_bad_quality_and_none(monkeypatch):
+    router = WriteRouter(db=None, registry=_Registry())
+    called = False
+
+    async def _fake_write(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(router, "_write_to_dest_bindings", _fake_write)
+
+    event = DataValueEvent(
+        datapoint_id=uuid.uuid4(),
+        value=None,
+        quality="bad",
+        source_adapter="modbus_tcp",
+        binding_id=uuid.uuid4(),
+    )
+
+    await router.handle_value_event(event)
+
+    assert called is False
+
+
+@pytest.mark.anyio
+async def test_handle_value_event_skips_type_mismatch(monkeypatch):
+    router = WriteRouter(db=None, registry=_Registry(data_type="BOOLEAN"))
+    called = False
+
+    async def _fake_write(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(router, "_write_to_dest_bindings", _fake_write)
+
+    event = DataValueEvent(
+        datapoint_id=uuid.uuid4(),
+        value="not-bool",
+        quality="good",
+        source_adapter="modbus_tcp",
+        binding_id=uuid.uuid4(),
+    )
+
+    await router.handle_value_event(event)
+
+    assert called is False
+
+
+@pytest.mark.anyio
+async def test_handle_value_event_propagates_good_typed_value(monkeypatch):
+    router = WriteRouter(db=None, registry=_Registry(data_type="BOOLEAN"))
+    received = {}
+
+    async def _fake_write(dp_id, value, skip_binding_id):
+        received["dp_id"] = dp_id
+        received["value"] = value
+        received["skip_binding_id"] = skip_binding_id
+
+    monkeypatch.setattr(router, "_write_to_dest_bindings", _fake_write)
+
+    event = DataValueEvent(
+        datapoint_id=uuid.uuid4(),
+        value=True,
+        quality="good",
+        source_adapter="modbus_tcp",
+        binding_id=uuid.uuid4(),
+    )
+
+    await router.handle_value_event(event)
+
+    assert received["dp_id"] == event.datapoint_id
+    assert received["value"] is True
+    assert received["skip_binding_id"] == event.binding_id

--- a/tests/test_write_router_value_event.py
+++ b/tests/test_write_router_value_event.py
@@ -15,7 +15,31 @@ class _Registry:
 
 
 @pytest.mark.anyio
-async def test_handle_value_event_skips_bad_quality_and_none(monkeypatch):
+async def test_handle_value_event_skips_bad_quality(monkeypatch):
+    router = WriteRouter(db=None, registry=_Registry())
+    called = False
+
+    async def _fake_write(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(router, "_write_to_dest_bindings", _fake_write)
+
+    event = DataValueEvent(
+        datapoint_id=uuid.uuid4(),
+        value=True,
+        quality="bad",
+        source_adapter="modbus_tcp",
+        binding_id=uuid.uuid4(),
+    )
+
+    await router.handle_value_event(event)
+
+    assert called is False
+
+
+@pytest.mark.anyio
+async def test_handle_value_event_skips_none_value(monkeypatch):
     router = WriteRouter(db=None, registry=_Registry())
     called = False
 
@@ -28,7 +52,7 @@ async def test_handle_value_event_skips_bad_quality_and_none(monkeypatch):
     event = DataValueEvent(
         datapoint_id=uuid.uuid4(),
         value=None,
-        quality="bad",
+        quality="good",
         source_adapter="modbus_tcp",
         binding_id=uuid.uuid4(),
     )
@@ -52,6 +76,30 @@ async def test_handle_value_event_skips_type_mismatch(monkeypatch):
     event = DataValueEvent(
         datapoint_id=uuid.uuid4(),
         value="not-bool",
+        quality="good",
+        source_adapter="modbus_tcp",
+        binding_id=uuid.uuid4(),
+    )
+
+    await router.handle_value_event(event)
+
+    assert called is False
+
+
+@pytest.mark.anyio
+async def test_handle_value_event_skips_bool_for_float_datapoint(monkeypatch):
+    router = WriteRouter(db=None, registry=_Registry(data_type="FLOAT"))
+    called = False
+
+    async def _fake_write(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(router, "_write_to_dest_bindings", _fake_write)
+
+    event = DataValueEvent(
+        datapoint_id=uuid.uuid4(),
+        value=True,
         quality="good",
         source_adapter="modbus_tcp",
         binding_id=uuid.uuid4(),


### PR DESCRIPTION
### Motivation
- Prevent adapter-originated bad or failure `DataValueEvent`s from being forwarded to writable DEST/BOTH bindings and causing unintended actuator writes.
- Ensure propagated events are type-safe and only applied when the destination datapoint exists and expects the value type.

### Description
- Add guards in `WriteRouter.handle_value_event` to skip propagation when `event.quality != "good"` or `event.value is None`.
- Validate that the datapoint exists via `self._registry.get(...)` and reject the event if unknown.
- Check the event value against the datapoint's data type using `DataTypeRegistry` and allow `int` for `FLOAT` where appropriate, otherwise skip propagation.
- Add `tests/test_write_router_value_event.py` with focused tests covering bad/None events, type-mismatch rejection, and successful propagation for valid events.

### Testing
- Ran `pytest -q tests/test_write_router_value_event.py` and the three new tests passed (3 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039e5a0e2483298c4b11c4401f314a)