### PR TITLE
[codex] Surface ioBroker socket severity diagnostics

### DIFF
--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -36,6 +36,8 @@ import json
 import logging
 import random
 import time
+from collections import deque
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -46,6 +48,10 @@ from obs.core.event_bus import DataValueEvent
 from obs.core.transformation import apply_source_type, apply_value_map
 
 logger = logging.getLogger(__name__)
+
+SOCKET_INSTABILITY_DETAIL = "ioBroker Socket.IO-Verbindung instabil: mehrere Disconnects in kurzer Zeit."
+SOCKET_STABLE_DETAIL = "ioBroker Socket.IO-Verbindung stabil."
+WATCHDOG_SUBSCRIBE_WARNING_DETAIL = "ioBroker Subscription-Watchdog konnte States nicht erneut abonnieren."
 
 
 class _EngineIOQueueFilter(logging.Filter):
@@ -73,6 +79,8 @@ class IoBrokerAdapterConfig(BaseModel):
     resubscribe_interval_seconds: int = Field(default=60, ge=0)
     reconnect_interval_seconds: int = Field(default=5, ge=1)
     reconnect_max_interval_seconds: int = Field(default=60, ge=1)
+    socket_instability_threshold: int = Field(default=3, ge=1)
+    socket_instability_window_s: int = Field(default=300, ge=1)
 
 
 class IoBrokerBindingConfig(BaseModel):
@@ -153,6 +161,12 @@ class IoBrokerAdapter(AdapterBase):
         self._socketio: Any | None = None
         self._connect_url: str | None = None
         self._connect_kwargs: dict[str, Any] = {}
+        self._disconnect_times: deque[datetime] = deque()
+        self._instability_warning_active = False
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(UTC)
 
     def _socket_is_connected(self) -> bool:
         if self._socket is None:
@@ -173,7 +187,7 @@ class IoBrokerAdapter(AdapterBase):
             import socketio
         except ImportError:
             logger.error("python-socketio not installed — ioBroker adapter disabled")
-            await self._publish_status(False, "python-socketio nicht installiert")
+            await self._publish_status(False, "python-socketio nicht installiert", severity="error")
             return
         for noisy_logger in (
             "socketio",
@@ -214,7 +228,7 @@ class IoBrokerAdapter(AdapterBase):
 
         connected = await self._connect_socket()
         if not connected:
-            await self._publish_status(False, "Socket.IO Verbindung fehlgeschlagen")
+            await self._publish_status(False, "Socket.IO Verbindung fehlgeschlagen", severity="error")
             self._ensure_reconnect_task()
 
         logger.info(
@@ -236,6 +250,8 @@ class IoBrokerAdapter(AdapterBase):
                 logger.exception("ioBroker Socket.IO disconnect failed")
             self._socket = None
 
+        self._disconnect_times.clear()
+        self._instability_warning_active = False
         self._state_map.clear()
         self._last_source_values.clear()
         self._source_filter_last_sent.clear()
@@ -301,6 +317,15 @@ class IoBrokerAdapter(AdapterBase):
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
+    async def _publish_warning_status(self, detail: str) -> None:
+        if self.connected:
+            self._connected = True
+        await self._publish_status(
+            self.connected,
+            detail,
+            severity="warning",
+        )
+
     async def _close_socket(self, sio: Any | None) -> None:
         if sio is None:
             return
@@ -325,6 +350,7 @@ class IoBrokerAdapter(AdapterBase):
                 raise
             except Exception:
                 logger.exception("ioBroker subscription watchdog failed")
+                await self._publish_warning_status(WATCHDOG_SUBSCRIBE_WARNING_DETAIL)
 
     def _build_socket(self) -> Any:
         assert self._socketio is not None
@@ -342,7 +368,7 @@ class IoBrokerAdapter(AdapterBase):
                 return
             logger.info("ioBroker Socket.IO connected → %s", self._connect_url)
             if self._cfg is not None:
-                await self._publish_status(True, f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
+                await self._publish_connected_status(f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
             await self._subscribe_bound_states(force_publish_initial=True)
 
         @sio.event
@@ -352,6 +378,7 @@ class IoBrokerAdapter(AdapterBase):
             logger.info("ioBroker Socket.IO disconnected")
             self._socket = None
             await self._publish_status(False, "Socket.IO getrennt")
+            await self._record_disconnect()
             self._ensure_reconnect_task()
 
         @sio.on("stateChange")
@@ -423,6 +450,55 @@ class IoBrokerAdapter(AdapterBase):
             await asyncio.sleep(max(0.1, delay + jitter))
             attempt += 1
 
+    def _prune_disconnects(self, now: datetime) -> None:
+        if self._cfg is not None:
+            window_s = self._cfg.socket_instability_window_s
+        else:
+            try:
+                window_s = int(self._config.get("socket_instability_window_s", 300))
+            except (TypeError, ValueError):
+                window_s = 300
+        cutoff = now.timestamp() - window_s
+        while self._disconnect_times and self._disconnect_times[0].timestamp() < cutoff:
+            self._disconnect_times.popleft()
+
+    def _disconnect_threshold(self) -> int:
+        if self._cfg is not None:
+            return self._cfg.socket_instability_threshold
+        try:
+            return int(self._config.get("socket_instability_threshold", 3))
+        except (TypeError, ValueError):
+            return 3
+
+    async def _record_disconnect(self) -> None:
+        now = self._now()
+        self._disconnect_times.append(now)
+        self._prune_disconnects(now)
+        if self._instability_warning_active:
+            return
+        if len(self._disconnect_times) < self._disconnect_threshold():
+            return
+        self._instability_warning_active = True
+        await self._publish_warning_status(SOCKET_INSTABILITY_DETAIL)
+        logger.warning(
+            "ioBroker Socket.IO instability suspected: %d disconnects in last %ss",
+            len(self._disconnect_times),
+            self._cfg.socket_instability_window_s if self._cfg is not None else self._config.get("socket_instability_window_s", 300),
+        )
+
+    async def _publish_connected_status(self, detail: str) -> None:
+        now = self._now()
+        self._prune_disconnects(now)
+        if self._instability_warning_active and self._disconnect_times:
+            self._connected = True
+            await self._publish_status(True, SOCKET_INSTABILITY_DETAIL, severity="warning")
+            return
+        if self._instability_warning_active:
+            self._instability_warning_active = False
+            await self._publish_status(True, SOCKET_STABLE_DETAIL)
+            return
+        await self._publish_status(True, detail)
+
     async def _subscribe_bound_states(self, *, force_publish_initial: bool = True) -> bool:
         if not self._socket_is_connected() or not self._state_map:
             return self._socket_is_connected()
@@ -433,10 +509,13 @@ class IoBrokerAdapter(AdapterBase):
                 await self._call_socket("subscribe", states)
                 logger.info("ioBroker Socket.IO subscribed: %s", states)
                 if self._cfg is not None:
-                    await self._publish_status(True, f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
+                    await self._publish_connected_status(f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
             except Exception:
                 logger.exception("ioBroker Socket.IO subscribe failed")
-                await self._publish_status(False, "Subscribe fehlgeschlagen")
+                if force_publish_initial:
+                    await self._publish_status(False, "Subscribe fehlgeschlagen", severity="error")
+                else:
+                    await self._publish_warning_status(WATCHDOG_SUBSCRIBE_WARNING_DETAIL)
                 return False
 
             # subscribe only reports future changes. After connect/reconnect we

--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -369,7 +369,7 @@ class IoBrokerAdapter(AdapterBase):
             logger.info("ioBroker Socket.IO connected → %s", self._connect_url)
             if self._cfg is not None:
                 await self._publish_connected_status(f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
-            await self._subscribe_bound_states(force_publish_initial=True)
+            await self._subscribe_bound_states(force_publish_initial=True, publish_connected_status=False)
 
         @sio.event
         async def disconnect():  # noqa: ANN202
@@ -499,7 +499,12 @@ class IoBrokerAdapter(AdapterBase):
             return
         await self._publish_status(True, detail)
 
-    async def _subscribe_bound_states(self, *, force_publish_initial: bool = True) -> bool:
+    async def _subscribe_bound_states(
+        self,
+        *,
+        force_publish_initial: bool = True,
+        publish_connected_status: bool = True,
+    ) -> bool:
         if not self._socket_is_connected() or not self._state_map:
             return self._socket_is_connected()
 
@@ -508,7 +513,7 @@ class IoBrokerAdapter(AdapterBase):
             try:
                 await self._call_socket("subscribe", states)
                 logger.info("ioBroker Socket.IO subscribed: %s", states)
-                if self._cfg is not None:
+                if publish_connected_status and self._cfg is not None:
                     await self._publish_connected_status(f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
             except Exception:
                 logger.exception("ioBroker Socket.IO subscribe failed")

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -6,13 +6,14 @@ Keine echte ioBroker-Instanz erforderlich — Socket.IO-Client wird gemockt.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from obs.core.event_bus import AdapterStatusEvent, DataValueEvent
 from tests.adapters.conftest import make_binding
-from obs.adapters.iobroker.adapter import IoBrokerAdapter, _EngineIOQueueFilter, _coerce_iobroker_value
+from obs.adapters.iobroker.adapter import IoBrokerAdapter, IoBrokerAdapterConfig, _EngineIOQueueFilter, _coerce_iobroker_value
 
 
 @pytest.fixture
@@ -251,6 +252,34 @@ class TestSubscribe:
         assert status_events
         assert status_events[-1].connected is True
 
+    @pytest.mark.asyncio
+    async def test_initial_subscribe_failure_publishes_error_severity(self, adapter, mock_bus):
+        binding = make_binding({"state_id": "0_userdata.0.temp"})
+        adapter._state_map["0_userdata.0.temp"] = [binding]
+        adapter._socket.call = AsyncMock(side_effect=RuntimeError("subscribe failed"))
+
+        result = await adapter._subscribe_bound_states(force_publish_initial=True)
+
+        assert result is False
+        status_events = [call.args[0] for call in mock_bus.publish.await_args_list if isinstance(call.args[0], AdapterStatusEvent)]
+        assert status_events[-1].severity == "error"
+        assert status_events[-1].connected is False
+        assert status_events[-1].detail == "Subscribe fehlgeschlagen"
+
+    @pytest.mark.asyncio
+    async def test_watchdog_subscribe_failure_publishes_warning_severity(self, adapter, mock_bus):
+        binding = make_binding({"state_id": "0_userdata.0.temp"})
+        adapter._state_map["0_userdata.0.temp"] = [binding]
+        adapter._socket.call = AsyncMock(side_effect=RuntimeError("subscribe failed"))
+
+        result = await adapter._subscribe_bound_states(force_publish_initial=False)
+
+        assert result is False
+        status_events = [call.args[0] for call in mock_bus.publish.await_args_list if isinstance(call.args[0], AdapterStatusEvent)]
+        assert status_events[-1].severity == "warning"
+        assert status_events[-1].connected is True
+        assert "Subscription-Watchdog" in status_events[-1].detail
+
 
 class TestReconnect:
     def test_build_socket_disables_socketio_internal_reconnect(self, adapter):
@@ -391,6 +420,136 @@ class TestReconnect:
         await adapter._reconnect_loop()
 
         adapter._connect_socket.assert_not_called()
+
+
+class TestSeverityDiagnostics:
+    @staticmethod
+    def _status_events(mock_bus):
+        return [call.args[0] for call in mock_bus.publish.await_args_list if isinstance(call.args[0], AdapterStatusEvent)]
+
+    @staticmethod
+    def _severity_events(mock_bus, severity):
+        return [event for event in TestSeverityDiagnostics._status_events(mock_bus) if event.severity == severity]
+
+    def test_socket_instability_config_defaults(self):
+        cfg = IoBrokerAdapterConfig()
+
+        assert cfg.socket_instability_threshold == 3
+        assert cfg.socket_instability_window_s == 300
+
+    @pytest.mark.asyncio
+    async def test_disconnect_older_than_window_is_pruned(self, adapter, monkeypatch):
+        t0 = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+        adapter._cfg = adapter.config_schema(
+            **{
+                **adapter._config,
+                "socket_instability_threshold": 3,
+                "socket_instability_window_s": 300,
+            }
+        )
+
+        monkeypatch.setattr(adapter, "_now", lambda: t0)
+        await adapter._record_disconnect()
+        monkeypatch.setattr(adapter, "_now", lambda: t0 + timedelta(seconds=301))
+        await adapter._record_disconnect()
+
+        assert list(adapter._disconnect_times) == [t0 + timedelta(seconds=301)]
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_publishes_no_warning(self, adapter, mock_bus, monkeypatch):
+        t0 = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+        adapter._cfg = adapter.config_schema(
+            **{
+                **adapter._config,
+                "socket_instability_threshold": 3,
+                "socket_instability_window_s": 300,
+            }
+        )
+
+        for offset in (0, 30):
+            monkeypatch.setattr(adapter, "_now", lambda offset=offset: t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        assert self._severity_events(mock_bus, "warning") == []
+
+    @pytest.mark.asyncio
+    async def test_threshold_reached_publishes_single_warning(self, adapter, mock_bus, monkeypatch):
+        t0 = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+        adapter._cfg = adapter.config_schema(
+            **{
+                **adapter._config,
+                "socket_instability_threshold": 3,
+                "socket_instability_window_s": 300,
+            }
+        )
+
+        for offset in (0, 30, 60, 90):
+            monkeypatch.setattr(adapter, "_now", lambda offset=offset: t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        warnings = self._severity_events(mock_bus, "warning")
+        assert len(warnings) == 1
+        assert warnings[0].adapter_type == "IOBROKER"
+        assert warnings[0].severity == "warning"
+        assert "Socket.IO-Verbindung instabil" in warnings[0].detail
+
+    @pytest.mark.asyncio
+    async def test_reconnect_inside_window_keeps_warning_active(self, adapter, mock_bus, monkeypatch):
+        t0 = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+        adapter._cfg = adapter.config_schema(
+            **{
+                **adapter._config,
+                "socket_instability_threshold": 3,
+                "socket_instability_window_s": 300,
+            }
+        )
+
+        for offset in (0, 30, 60):
+            monkeypatch.setattr(adapter, "_now", lambda offset=offset: t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        monkeypatch.setattr(adapter, "_now", lambda: t0 + timedelta(seconds=90))
+        await adapter._publish_connected_status("Verbunden mit 192.168.1.50:8084")
+
+        assert adapter._instability_warning_active is True
+        assert self._status_events(mock_bus)[-1].severity == "warning"
+        assert self._status_events(mock_bus)[-1].connected is True
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_quiet_window_clears_warning(self, adapter, mock_bus, monkeypatch):
+        t0 = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+        adapter._cfg = adapter.config_schema(
+            **{
+                **adapter._config,
+                "socket_instability_threshold": 3,
+                "socket_instability_window_s": 300,
+            }
+        )
+
+        for offset in (0, 30, 60):
+            monkeypatch.setattr(adapter, "_now", lambda offset=offset: t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        monkeypatch.setattr(adapter, "_now", lambda: t0 + timedelta(seconds=400))
+        await adapter._publish_connected_status("Verbunden mit 192.168.1.50:8084")
+
+        assert adapter._instability_warning_active is False
+        assert self._status_events(mock_bus)[-1].severity == "ok"
+        assert self._status_events(mock_bus)[-1].connected is True
+        assert self._status_events(mock_bus)[-1].detail == "ioBroker Socket.IO-Verbindung stabil."
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_publishes_error_severity(self, mock_bus):
+        adapter = IoBrokerAdapter(event_bus=mock_bus, config={"host": "127.0.0.1", "port": 8084})
+        adapter._connect_socket = AsyncMock(return_value=False)
+        adapter._ensure_reconnect_task = MagicMock()
+
+        await adapter.connect()
+
+        status_events = self._status_events(mock_bus)
+        assert status_events[-1].severity == "error"
+        assert status_events[-1].connected is False
+        assert status_events[-1].detail == "Socket.IO Verbindung fehlgeschlagen"
 
 
 class TestBrowseStates:

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -539,6 +539,66 @@ class TestSeverityDiagnostics:
         assert self._status_events(mock_bus)[-1].detail == "ioBroker Socket.IO-Verbindung stabil."
 
     @pytest.mark.asyncio
+    async def test_connect_handler_subscribe_success_keeps_recovery_status(self, adapter, mock_bus, monkeypatch):
+        class FakeSocket:
+            connected = True
+
+            def __init__(self):
+                self.calls = []
+
+            def event(self, handler):
+                setattr(self, handler.__name__, handler)
+                return handler
+
+            def on(self, _event):
+                def decorator(handler):
+                    setattr(self, handler.__name__, handler)
+                    return handler
+
+                return decorator
+
+            async def call(self, event, *args, timeout=10.0):
+                self.calls.append((event, args, timeout))
+                if event == "subscribe":
+                    return [None, None]
+                if event == "getState":
+                    return [None, {"val": 22.0}]
+                raise AssertionError(f"unexpected ioBroker call: {event}")
+
+        t0 = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+        adapter._cfg = adapter.config_schema(
+            **{
+                **adapter._config,
+                "socket_instability_threshold": 3,
+                "socket_instability_window_s": 300,
+            }
+        )
+        adapter._connect_url = "http://192.168.1.50:8084"
+        binding = make_binding({"state_id": "0_userdata.0.temp"})
+        adapter._state_map["0_userdata.0.temp"] = [binding]
+
+        socket = FakeSocket()
+        adapter._socket = socket
+        adapter._register_socket_handlers(socket)
+
+        for offset in (0, 30, 60):
+            monkeypatch.setattr(adapter, "_now", lambda offset=offset: t0 + timedelta(seconds=offset))
+            await adapter._record_disconnect()
+
+        monkeypatch.setattr(adapter, "_now", lambda: t0 + timedelta(seconds=400))
+        await socket.connect()
+
+        status_events = self._status_events(mock_bus)
+        data_events = [call.args[0] for call in mock_bus.publish.await_args_list if isinstance(call.args[0], DataValueEvent)]
+        assert status_events[-1].severity == "ok"
+        assert status_events[-1].connected is True
+        assert status_events[-1].detail == "ioBroker Socket.IO-Verbindung stabil."
+        assert socket.calls[0][0] == "subscribe"
+        assert socket.calls[0][1] == (["0_userdata.0.temp"],)
+        assert socket.calls[1][0] == "getState"
+        assert data_events[-1].value == pytest.approx(22.0)
+
+    @pytest.mark.asyncio
     async def test_connect_failure_publishes_error_severity(self, mock_bus):
         adapter = IoBrokerAdapter(event_bus=mock_bus, config={"host": "127.0.0.1", "port": 8084})
         adapter._connect_socket = AsyncMock(return_value=False)


### PR DESCRIPTION
## Summary

- classify hard ioBroker dependency/connect/initial-subscribe failures as `severity="error"`
- detect repeated Socket.IO disconnects with a configurable sliding window and publish `severity="warning"`
- keep warning states non-spammy and only clear them after a quiet reconnect window
- publish watchdog resubscribe failures as visible warnings without forcing the adapter red when the socket is still up
- cover the new severity lifecycle in ioBroker adapter tests

## Why

PR #476 added the generic adapter severity/status-detail surface for KNX tunnel-pool overloads. The ioBroker adapter can use the same generic path so unstable Socket.IO connections and hard connection failures are visible in the existing adapter card/sidebar/dashboard UI instead of being buried in logs.

## Validation

Local checks:

- `python -m compileall obs/adapters/iobroker/adapter.py`
- `pytest tests/adapters/test_iobroker.py -q` -> 40 passed
- `pytest tests/adapters/test_iobroker.py tests/contracts/test_socketio_contract.py -q` -> 53 passed
- `pytest tests/adapters/ tests/contracts/ -q` -> 543 passed, 6 skipped
- `pytest tests/adapters/ tests/contracts/ tests/unit/ -q` -> 1209 passed, 7 skipped
- `ruff check .`
- `ruff format . --check`
- `cd gui && npm run build`

Full `pytest tests/ -q` was also run locally: 1214 passed before integration fixtures errored because this local environment has no `docker` binary. The errors were all setup-time `FileNotFoundError: docker`, matching the known local integration-test limitation.

MM12 verification after deploy:

- backup: `/opt/obs/backups/openbridgeserver-build-pre-iobroker-severity-20260519-223142.tar.gz`
- image: `obs-openbridgeserver:iobroker-ws` -> `sha256:45a8e49418af7ddf5d4f686c18c7004a24deb11ad6328298a1a2c52b72f5748e`
- `/api/v1/system/health` -> ok, 256 datapoints, 2 adapters running
- AEGIS -> healthy, running, risk none, stability quiet
- `/api/v1/adapters/instances` shows both ioBroker instances connected with `severity="ok"`
- `engineio_count_5m=0`, `error_count_5m=0`, `iobroker_disconnect_count_5m=0`
- container smoke tests confirmed simulated connect failure emits `severity="error"` and simulated disconnect threshold emits `severity="warning"`
