### PR TITLE
[Codex] Propagate readonly prop to Grundriss mini-widgets

### DIFF
--- a/frontend/src/widgets/Grundriss/Widget.vue
+++ b/frontend/src/widgets/Grundriss/Widget.vue
@@ -37,6 +37,7 @@ const props = defineProps<{
   value: DataPointValue | null
   statusValue: DataPointValue | null
   editorMode: boolean
+  readonly?: boolean
 }>()
 
 const router  = useRouter()
@@ -252,6 +253,7 @@ function handleAreaClick(area: GrundrissArea) {
           :value="mw.datapointId ? dpStore.getValue(mw.datapointId) : null"
           :status-value="mw.statusDatapointId ? dpStore.getValue(mw.statusDatapointId) : null"
           :editor-mode="editorMode"
+          :readonly="props.readonly"
           :h="Math.round(mw.hPx / 80)"
         />
         <div v-else class="flex items-center justify-center h-full text-xs text-gray-500">


### PR DESCRIPTION
### Motivation
- The Grundriss (floorplan) widget did not accept or forward the `readonly` prop to embedded mini-widgets, which allowed interactive child widgets to remain writable on pages intended to be read-only.

### Description
- Add `readonly?: boolean` to the props in `frontend/src/widgets/Grundriss/Widget.vue` so the floorplan participates in the viewer's readonly contract.
- Forward `:readonly="props.readonly"` to each nested mini-widget component rendered inside the Grundriss overlay so child controls (e.g. `Toggle`, `Slider`) suppress writes when the page is readonly.
- Change is limited to a single frontend file and is intentionally minimal to preserve existing behavior.

### Testing
- No automated tests were executed for this minimal prop/forwarding change; recommend running the repository's frontend unit and end-to-end tests in CI to validate UI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a064df8bb4c8329b67371a3315ea867)