### PR TITLE
ci(i18n): add diff-scoped hard gate for PR changes (#537)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+echo "[pre-push] i18n hard gate"
+./scripts/check-i18n-hardcoded-strings.sh

--- a/.github/workflows/i18n-guard.yml
+++ b/.github/workflows/i18n-guard.yml
@@ -1,0 +1,43 @@
+name: i18n Guard
+
+on:
+  push:
+    branches:
+      - main
+      - bugfix/*
+      - feature/*
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  i18n-guard:
+    name: i18n-guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Run i18n hard gate (pull_request)
+        if: github.event_name == 'pull_request'
+        env:
+          I18N_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+          I18N_DIFF_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/check-i18n-hardcoded-strings.sh
+
+      - name: Run i18n hard gate (push)
+        if: github.event_name == 'push'
+        env:
+          I18N_DIFF_BASE: ${{ github.event.before }}
+          I18N_DIFF_HEAD: ${{ github.sha }}
+        run: ./scripts/check-i18n-hardcoded-strings.sh

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -77,6 +77,21 @@ pytest tests/integration                          # mit Docker
 Wenn rot: nicht pushen, sondern fixen. Gilt für Haupt-Sessions **und** für Subagents — bitte
 explizit in den Subagent-Prompt schreiben, weil deren Kontext leer startet.
 
+Zusätzlich für i18n-Änderungen (Admin GUI + Visu) gilt ein harter Diff-Gate:
+
+```bash
+# Diff-basierter i18n Hard-Gate (Hardcoded user-facing strings + locale parity)
+./scripts/check-i18n-hardcoded-strings.sh
+```
+
+Optional als lokaler Push-Hook aktivieren:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Danach läuft der i18n-Gate automatisch vor jedem `git push`.
+
 ## Local Development Setup
 
 ### Prerequisites
@@ -263,9 +278,19 @@ When adding a new view, widget config, or significant UI component:
 5. Pure utility functions must return keys, not translated strings.
 6. Run `npm run build` in `gui/` (and `frontend/` if Visu was touched) — a missing key does not throw at dev time but will surface as `[namespace.key]` in production.
 
+#### Hard-Gate (local + CI)
+
+`./scripts/check-i18n-hardcoded-strings.sh` enforces two checks on the PR/push diff:
+
+1. Changed files under `gui/src` and `frontend/src` with extension `.vue`, `.js`, `.ts` are scanned file-wide for hardcoded user-facing strings outside `$t()` / `t()`.
+2. If locale files changed, `de.json` and `en.json` are compared pairwise (`gui/src/locales/` and `frontend/src/locales/`); missing counterpart keys fail the gate.
+
+Allowlisted technical literals are maintained in `scripts/i18n-allowlist.txt`. Keep the list minimal and reviewable.
+
 #### Known exception — `gui/src/utils/hierarchyDepthOptions.js`
 
 This utility builds option labels that mix tree node names (runtime data) with structural level names. It cannot cleanly return plain i18n keys because the labels are composite strings (e.g. `"1 — EG Test (nur \"Wohnzimmer\")"`). It currently uses hardcoded German strings. This is a known gap; do not copy this pattern for new utilities.
+The current gate allowlists only these specific legacy string patterns in `scripts/i18n-allowlist.txt`.
 
 #### E2E tests (Playwright) and locale
 
@@ -389,6 +414,22 @@ One file per external library. Each test verifies the exact import paths and API
 ## Release & CI
 
 ### Workflows
+
+PR/branch quality workflows:
+
+| Workflow | Purpose |
+|---|---|
+| `.github/workflows/lint.yml` | Ruff lint + format-check via `./tools/lint.sh --check` |
+| `.github/workflows/unittest.yml` | Python test matrix + coverage upload |
+| `.github/workflows/e2e.yml` | Full-stack Playwright E2E |
+| `.github/workflows/i18n-guard.yml` | Hard gate for i18n in changed frontend files + locale parity checks |
+
+GitHub CI enforcement (required for merge gate):
+
+1. Open `Settings` → `Branches` in `abeggled/openbridgeserver`.
+2. Edit the branch protection rule for `main`.
+3. Enable `Require status checks to pass before merging`.
+4. Add `i18n-guard` as a required status check.
 
 Two workflows run on every tag push (`push: tags: '*'`):
 

--- a/scripts/check-i18n-hardcoded-strings.sh
+++ b/scripts/check-i18n-hardcoded-strings.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+BASE_REF="${I18N_DIFF_BASE:-}"
+HEAD_REF="${I18N_DIFF_HEAD:-}"
+
+if [[ -n "$BASE_REF" && -n "$HEAD_REF" ]]; then
+  exec python3 "$SCRIPT_DIR/check_i18n_guard.py" --base "$BASE_REF" --head "$HEAD_REF" "$@"
+fi
+
+exec python3 "$SCRIPT_DIR/check_i18n_guard.py" "$@"

--- a/scripts/check_i18n_guard.py
+++ b/scripts/check_i18n_guard.py
@@ -24,13 +24,9 @@ ATTR_RE = re.compile(
     r"\b(label|title|placeholder|alt|aria-label|helper-text|tooltip|caption|headline|confirm-text|cancel-text|no-data-text|loading-text)\s*=\s*(['\"])(.*?)\2"
 )
 TEXT_NODE_RE = re.compile(r">([^<{][^<]*)<")
-UI_CALL_RE = re.compile(
-    r"\b(?:alert|confirm|prompt|toast(?:\.[A-Za-z_][A-Za-z0-9_]*)?|notify(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s*\(\s*(['\"`])(.+?)\1"
-)
+UI_CALL_RE = re.compile(r"\b(?:alert|confirm|prompt|toast(?:\.[A-Za-z_][A-Za-z0-9_]*)?|notify(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s*\(\s*(['\"`])(.+?)\1")
 ERROR_RE = re.compile(r"\b(?:throw\s+new\s+Error|new\s+Error)\s*\(\s*(['\"`])(.+?)\1")
-ASSIGN_RE = re.compile(
-    r"\b(?:errorMessage|warningMessage|successMessage|message|label|title|placeholder|tooltip|caption)\s*[:=]\s*(['\"`])(.+?)\1"
-)
+ASSIGN_RE = re.compile(r"\b(?:errorMessage|warningMessage|successMessage|message|label|title|placeholder|tooltip|caption)\s*[:=]\s*(['\"`])(.+?)\1")
 COMMENT_RE = re.compile(r"<!--.*?-->")
 
 
@@ -67,15 +63,15 @@ class Allowlist:
 def run_git_diff(repo_root: Path, base: str | None, head: str | None) -> list[str]:
     candidates: list[list[str]] = []
     if base and head:
+        candidates.append(["git", "diff", "--name-only", f"{base}...{head}"])
         candidates.append(["git", "diff", "--name-only", base, head])
-    else:
-        candidates.extend(
-            [
-                ["git", "diff", "--name-only", "origin/main...HEAD"],
-                ["git", "diff", "--name-only", "main...HEAD"],
-                ["git", "diff", "--name-only", "HEAD~1...HEAD"],
-            ]
-        )
+    candidates.extend(
+        [
+            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            ["git", "diff", "--name-only", "main...HEAD"],
+            ["git", "diff", "--name-only", "HEAD~1...HEAD"],
+        ]
+    )
 
     for cmd in candidates:
         proc = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)
@@ -346,10 +342,7 @@ def main() -> int:
         print("i18n guard: FAILED")
         return 1
 
-    print(
-        "i18n guard: OK "
-        f"(scanned {len(scan_files)} changed frontend files; locale-app-checks: {', '.join(sorted(touched_apps)) or 'none'})"
-    )
+    print(f"i18n guard: OK (scanned {len(scan_files)} changed frontend files; locale-app-checks: {', '.join(sorted(touched_apps)) or 'none'})")
     return 0
 
 

--- a/scripts/check_i18n_guard.py
+++ b/scripts/check_i18n_guard.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Diff-scoped i18n hard gate for frontend files.
+
+Checks:
+1) Hardcoded user-facing strings in changed gui/src + frontend/src .vue/.js/.ts files.
+2) Locale key parity between de.json and en.json when locale files are changed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+TARGET_FILE_RE = re.compile(r"^(gui/src|frontend/src)/.+\.(vue|js|ts)$")
+LOCALE_FILE_RE = re.compile(r"^(gui|frontend)/src/locales/(de|en)\.json$")
+TEMPLATE_BLOCK_RE = re.compile(r"<template\b[^>]*>(.*?)</template>", re.IGNORECASE | re.DOTALL)
+ATTR_RE = re.compile(
+    r"\b(label|title|placeholder|alt|aria-label|helper-text|tooltip|caption|headline|confirm-text|cancel-text|no-data-text|loading-text)\s*=\s*(['\"])(.*?)\2"
+)
+TEXT_NODE_RE = re.compile(r">([^<{][^<]*)<")
+UI_CALL_RE = re.compile(
+    r"\b(?:alert|confirm|prompt|toast(?:\.[A-Za-z_][A-Za-z0-9_]*)?|notify(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s*\(\s*(['\"`])(.+?)\1"
+)
+ERROR_RE = re.compile(r"\b(?:throw\s+new\s+Error|new\s+Error)\s*\(\s*(['\"`])(.+?)\1")
+ASSIGN_RE = re.compile(
+    r"\b(?:errorMessage|warningMessage|successMessage|message|label|title|placeholder|tooltip|caption)\s*[:=]\s*(['\"`])(.+?)\1"
+)
+COMMENT_RE = re.compile(r"<!--.*?-->")
+
+
+@dataclass
+class Violation:
+    path: str
+    line: int
+    kind: str
+    snippet: str
+
+
+class Allowlist:
+    def __init__(self, path: Path):
+        self.literal: set[str] = set()
+        self.patterns: list[re.Pattern[str]] = []
+        if not path.exists():
+            return
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("re:"):
+                self.patterns.append(re.compile(line[3:]))
+            else:
+                self.literal.add(line)
+
+    def contains(self, text: str) -> bool:
+        value = " ".join(text.split())
+        if value in self.literal:
+            return True
+        return any(p.search(value) for p in self.patterns)
+
+
+def run_git_diff(repo_root: Path, base: str | None, head: str | None) -> list[str]:
+    candidates: list[list[str]] = []
+    if base and head:
+        candidates.append(["git", "diff", "--name-only", base, head])
+    else:
+        candidates.extend(
+            [
+                ["git", "diff", "--name-only", "origin/main...HEAD"],
+                ["git", "diff", "--name-only", "main...HEAD"],
+                ["git", "diff", "--name-only", "HEAD~1...HEAD"],
+            ]
+        )
+
+    for cmd in candidates:
+        proc = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)
+        if proc.returncode == 0:
+            files = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+            if files:
+                return sorted(set(files))
+            return []
+
+    tried = " | ".join(" ".join(c) for c in candidates)
+    raise RuntimeError(f"Could not determine changed files via git diff ({tried})")
+
+
+def flatten_keys(data: dict, prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    for key, value in data.items():
+        joined = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            keys.update(flatten_keys(value, joined))
+        else:
+            keys.add(joined)
+    return keys
+
+
+def has_letters(text: str) -> bool:
+    return re.search(r"[A-Za-zÄÖÜäöüß]", text) is not None
+
+
+def normalize_text(text: str) -> str:
+    return " ".join(text.strip().split())
+
+
+def is_technical_token(text: str) -> bool:
+    compact = text.strip()
+    if compact.startswith(("http://", "https://", "/", "./", "../", "#")):
+        return True
+    if compact.startswith("[") and compact.endswith("]"):
+        return True
+    if compact.upper() == compact and re.fullmatch(r"[A-Z0-9_./:+-]+", compact):
+        return True
+    if re.fullmatch(r"[A-Za-z0-9_./:+-]+", compact):
+        return True
+    return False
+
+
+def should_flag(candidate: str, allowlist: Allowlist) -> bool:
+    text = normalize_text(candidate)
+    if len(text) < 2:
+        return False
+    if not has_letters(text):
+        return False
+    if "{{" in text or "}}" in text:
+        return False
+    if "$t(" in text or "t(" in text:
+        return False
+    if text.startswith(("$t(", "t(")):
+        return False
+    if is_technical_token(text):
+        return False
+    if allowlist.contains(text):
+        return False
+    return True
+
+
+def add_violations_from_matches(
+    *,
+    path: str,
+    line: int,
+    kind: str,
+    matches: Iterable[re.Match[str]],
+    candidate_group: int,
+    allowlist: Allowlist,
+    sink: list[Violation],
+) -> None:
+    for match in matches:
+        candidate = match.group(candidate_group)
+        if should_flag(candidate, allowlist):
+            sink.append(Violation(path=path, line=line, kind=kind, snippet=normalize_text(candidate)))
+
+
+def scan_vue(path: str, content: str, allowlist: Allowlist) -> list[Violation]:
+    violations: list[Violation] = []
+
+    for tpl_match in TEMPLATE_BLOCK_RE.finditer(content):
+        tpl = tpl_match.group(1)
+        start_line = content.count("\n", 0, tpl_match.start(1)) + 1
+        for idx, raw_line in enumerate(tpl.splitlines(), start=start_line):
+            line = COMMENT_RE.sub("", raw_line)
+            if not line.strip():
+                continue
+            add_violations_from_matches(
+                path=path,
+                line=idx,
+                kind="template-attr",
+                matches=ATTR_RE.finditer(line),
+                candidate_group=3,
+                allowlist=allowlist,
+                sink=violations,
+            )
+            add_violations_from_matches(
+                path=path,
+                line=idx,
+                kind="template-text",
+                matches=TEXT_NODE_RE.finditer(line),
+                candidate_group=1,
+                allowlist=allowlist,
+                sink=violations,
+            )
+
+    stripped = TEMPLATE_BLOCK_RE.sub("\n", content)
+    for line_no, raw_line in enumerate(stripped.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("//"):
+            continue
+        add_violations_from_matches(
+            path=path,
+            line=line_no,
+            kind="script-ui-call",
+            matches=UI_CALL_RE.finditer(line),
+            candidate_group=2,
+            allowlist=allowlist,
+            sink=violations,
+        )
+        add_violations_from_matches(
+            path=path,
+            line=line_no,
+            kind="script-error",
+            matches=ERROR_RE.finditer(line),
+            candidate_group=2,
+            allowlist=allowlist,
+            sink=violations,
+        )
+        add_violations_from_matches(
+            path=path,
+            line=line_no,
+            kind="script-assign",
+            matches=ASSIGN_RE.finditer(line),
+            candidate_group=2,
+            allowlist=allowlist,
+            sink=violations,
+        )
+
+    return violations
+
+
+def scan_script(path: str, content: str, allowlist: Allowlist) -> list[Violation]:
+    violations: list[Violation] = []
+    for line_no, raw_line in enumerate(content.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("//"):
+            continue
+        add_violations_from_matches(
+            path=path,
+            line=line_no,
+            kind="script-ui-call",
+            matches=UI_CALL_RE.finditer(line),
+            candidate_group=2,
+            allowlist=allowlist,
+            sink=violations,
+        )
+        add_violations_from_matches(
+            path=path,
+            line=line_no,
+            kind="script-error",
+            matches=ERROR_RE.finditer(line),
+            candidate_group=2,
+            allowlist=allowlist,
+            sink=violations,
+        )
+        add_violations_from_matches(
+            path=path,
+            line=line_no,
+            kind="script-assign",
+            matches=ASSIGN_RE.finditer(line),
+            candidate_group=2,
+            allowlist=allowlist,
+            sink=violations,
+        )
+    return violations
+
+
+def scan_hardcoded_strings(repo_root: Path, files: list[str], allowlist: Allowlist) -> list[Violation]:
+    violations: list[Violation] = []
+    for rel_path in files:
+        path = repo_root / rel_path
+        if not path.exists() or not path.is_file():
+            continue
+        content = path.read_text(encoding="utf-8")
+        if rel_path.endswith(".vue"):
+            violations.extend(scan_vue(rel_path, content, allowlist))
+        else:
+            violations.extend(scan_script(rel_path, content, allowlist))
+    return sorted(violations, key=lambda v: (v.path, v.line, v.kind, v.snippet))
+
+
+def check_locale_pair(repo_root: Path, app: str) -> list[str]:
+    locale_root = repo_root / app / "src" / "locales"
+    de_path = locale_root / "de.json"
+    en_path = locale_root / "en.json"
+    try:
+        de = json.loads(de_path.read_text(encoding="utf-8"))
+        en = json.loads(en_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{app}: invalid JSON in locale files ({exc})"]
+
+    if not isinstance(de, dict) or not isinstance(en, dict):
+        return [f"{app}: locale root must be a JSON object in both de.json and en.json"]
+
+    de_keys = flatten_keys(de)
+    en_keys = flatten_keys(en)
+    errors: list[str] = []
+
+    for key in sorted(de_keys - en_keys):
+        errors.append(f"{app}/src/locales/en.json is missing key: {key}")
+    for key in sorted(en_keys - de_keys):
+        errors.append(f"{app}/src/locales/de.json is missing key: {key}")
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Diff-scoped i18n hard gate")
+    parser.add_argument("--base", help="Base git ref for diff", default=None)
+    parser.add_argument("--head", help="Head git ref for diff", default=None)
+    parser.add_argument("--allowlist", default="scripts/i18n-allowlist.txt", help="Allowlist file path")
+    parser.add_argument("files", nargs="*", help="Explicit files to scan instead of deriving from git diff")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+
+    if args.files:
+        changed_files = sorted(set(args.files))
+    else:
+        changed_files = run_git_diff(repo_root, args.base, args.head)
+
+    if not changed_files:
+        print("i18n guard: no changed files in diff; nothing to do.")
+        return 0
+
+    scan_files = [p for p in changed_files if TARGET_FILE_RE.match(p)]
+    touched_apps = {m.group(1) for p in changed_files if (m := LOCALE_FILE_RE.match(p))}
+
+    if not scan_files and not touched_apps:
+        print("i18n guard: no relevant frontend/i18n files in diff; nothing to do.")
+        return 0
+
+    allowlist = Allowlist(repo_root / args.allowlist)
+    violations = scan_hardcoded_strings(repo_root, scan_files, allowlist)
+
+    locale_errors: list[str] = []
+    for app in sorted(touched_apps):
+        locale_errors.extend(check_locale_pair(repo_root, app))
+
+    if violations:
+        print("i18n guard: hardcoded user-facing strings detected in changed files:")
+        for v in violations:
+            print(f"  {v.path}:{v.line}: [{v.kind}] {v.snippet}")
+
+    if locale_errors:
+        print("i18n guard: locale consistency errors:")
+        for err in locale_errors:
+            print(f"  {err}")
+
+    if violations or locale_errors:
+        print("i18n guard: FAILED")
+        return 1
+
+    print(
+        "i18n guard: OK "
+        f"(scanned {len(scan_files)} changed frontend files; locale-app-checks: {', '.join(sorted(touched_apps)) or 'none'})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/i18n-allowlist.txt
+++ b/scripts/i18n-allowlist.txt
@@ -1,0 +1,24 @@
+# i18n hard-gate allowlist
+#
+# One entry per line.
+# - Exact literal match: copied as-is
+# - Regex match: prefix with `re:`
+#
+# Keep this list tight. Every entry should be reviewable and justified.
+
+MB
+kWh
+kW
+°C
+URL
+HTTP
+HTTPS
+API
+JSON
+CSV
+UUID
+MQTT
+KNX
+re:^0 — \$\{name\} \(Hierarchiename\)$
+re:^\$\{level\} — \$\{levelLabel\}$
+re:^\$\{level\} — \$\{levelLabel\} \$\{suffix\}$


### PR DESCRIPTION
## Summary
Implements #537 with a hard CI gate that only evaluates files changed in the PR/push diff.

### What is included
- New i18n guard workflow: `.github/workflows/i18n-guard.yml`
- New local/CI gate entrypoint: `scripts/check-i18n-hardcoded-strings.sh`
- Guard implementation: `scripts/check_i18n_guard.py`
- Reviewable allowlist: `scripts/i18n-allowlist.txt`
- Optional local push hook: `.githooks/pre-push`
- Documentation updates in `AGENTS.MD` (local gate usage + CI workflow + GitHub required-check setup)

## Gate behavior
1. Scans **changed files only** under `gui/src` and `frontend/src` (`.vue`, `.js`, `.ts`) for hardcoded user-facing strings outside `$t()` / `t()`.
2. If locale files changed, enforces key parity between `de.json` and `en.json` in:
   - `gui/src/locales/`
   - `frontend/src/locales/`

## GitHub CI setup instructions (required)
To make this a real merge gate in upstream:
1. Open `Settings` → `Branches` in `abeggled/openbridgeserver`.
2. Edit the branch protection rule for `main`.
3. Enable `Require status checks to pass before merging`.
4. Add `i18n-guard` as a required status check.

## Notes
- Legacy known exception patterns from `gui/src/utils/hierarchyDepthOptions.js` are explicitly constrained via regex allowlist entries.
- Guard is diff-scoped by design to avoid blocking PRs on unrelated historical debt.

Closes #537.
