### PR TITLE
fix(i18n): complete remaining UI translations after #533

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -79,7 +79,12 @@
     "brokenDpRef": "Mindestens ein Datenpunkt-Verweis wurde nicht gefunden",
     "pageNamePlaceholder": "Seitenname …",
     "gridInfo": "Zelle: {w}×{h}px · Grid: {total}px breit",
-    "paletteHeading": "Widgets"
+    "paletteHeading": "Widgets",
+    "badge": "Editor",
+    "posX": "X",
+    "posY": "Y",
+    "widthShort": "B",
+    "heightShort": "H"
   },
   "viewer": {
     "noVisuSelected": "Keine Visu ausgewählt"
@@ -515,7 +520,9 @@
       "dpWStatus": "Weiss lesen (Status, optional)"
     },
     "link": {
-      "targetPage": "Ziel-Seite"
+      "targetPage": "Ziel-Seite",
+      "defaultLabel": "Link",
+      "noTarget": "Kein Ziel"
     },
     "qrcode": {
       "labelAbove": "Bezeichnung (erscheint oberhalb)",
@@ -561,7 +568,22 @@
       "dpSlatSend": "Lamellen schreiben",
       "dpSlatStatus": "Lamellen lesen (Status, optional)",
       "dpLock": "🔒 Sperre (Ausgang, schaltbar)",
-      "dpIndicatorRo": "Indikator {n} (Eingang, read-only)"
+      "dpIndicatorRo": "Indikator {n} (Eingang, read-only)",
+      "defaultStatus1": "Manuelle Sperre",
+      "defaultStatus2": "Status 2",
+      "defaultStatus3": "Status 3",
+      "defaultStatus4": "Status 4",
+      "tooltipUp": "Kurz: Stopp\nLang: Auffahren bis Endlage",
+      "tooltipDown": "Kurz: Stopp\nLang: Abfahren bis Endlage",
+      "tooltipStop": "Sofort stoppen",
+      "lockTitle": "Sperre",
+      "slatOpenTitle": "Lamellen öffnen (hell)",
+      "slatCloseTitle": "Lamellen schliessen (dunkel)",
+      "positionLabel": "Position",
+      "slatLabel": "Lamellen",
+      "openShort": "auf",
+      "openLabel": "offen",
+      "closedShort": "zu"
     },
     "rtr": {
       "accentColor": "Akzentfarbe",
@@ -623,7 +645,11 @@
       "stateOff": "AUS (false)",
       "modeSwitch": "Schalter",
       "modeIconOnly": "Nur Icon",
-      "modeIconText": "Icon + Text"
+      "modeIconText": "Icon + Text",
+      "labelPlaceholder": "z.B. Pumpe HK1",
+      "iconLabel": "Icon",
+      "colorTitle": "Farbe",
+      "textLabel": "Text"
     },
     "uhr": {
       "accentColor": "Akzentfarbe",
@@ -669,7 +695,21 @@
       "period": "Zeitraum (Stunden)",
       "duplicateTitle": "Duplizieren",
       "deleteTitle": "Löschen",
-      "defaultHistoryRange": "Standard-Verlaufszeitraum"
+      "defaultHistoryRange": "Standard-Verlaufszeitraum",
+      "labelPlaceholder": "z.B. Raumtemperatur",
+      "iconLabel": "Icon",
+      "colorTitle": "Farbe",
+      "prefixPlaceholder": "Präfix",
+      "postfixUnitPlaceholder": "Einheit / Postfix",
+      "displayTextPlaceholder": "Anzeigetext",
+      "postfixPlaceholder": "Postfix",
+      "valuePlaceholder": "Wert",
+      "secondaryLabelPlaceholder": "z.B. Soll",
+      "gaugeSettings": "Gauge Einstellungen",
+      "minimum": "Minimum",
+      "maximum": "Maximum",
+      "gaugeColors": "Farbe / Farbverlauf (1–4 Farben, niedrig → hoch)",
+      "colorIndex": "Farbe {n}"
     },
     "wetter": {
       "labelCity": "Bezeichnung (Ortname)",
@@ -693,7 +733,15 @@
       "showForecast": "Tagesvorhersage anzeigen",
       "forecastDays": "Anzahl Tage (1–7)",
       "precipitation": "Niederschlagswahrscheinlichkeit",
-      "showAlerts": "Wetterwarnungen anzeigen"
+      "showAlerts": "Wetterwarnungen anzeigen",
+      "configureApiUrl": "Wetter-API-URL konfigurieren",
+      "defaultLabel": "Wetter",
+      "previewLiveMode": "Vorschau im Live-Modus",
+      "noApiUrl": "Keine API-URL konfiguriert",
+      "loadingData": "Wetterdaten werden geladen …",
+      "reload": "Neu laden",
+      "refreshNow": "Jetzt aktualisieren",
+      "precipitationTitle": "Niederschlag: {pct}"
     },
     "widgetref": {
       "sourcePage": "Quell-Seite",
@@ -778,6 +826,10 @@
       "keyboardHint": "Enter = Polygon schliessen · Esc = verwerfen · Klick auf ersten Punkt = schliessen",
       "defaultAreaName": "Bereich {n}",
       "datapoint": "Datenpunkt"
+    },
+    "missing": {
+      "title": "Unbekannt",
+      "ariaLabel": "Unbekannter Widget-Typ"
     }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -79,7 +79,12 @@
     "brokenDpRef": "At least one datapoint reference was not found",
     "pageNamePlaceholder": "Page name …",
     "gridInfo": "Cell: {w}×{h}px · Grid: {total}px wide",
-    "paletteHeading": "Widgets"
+    "paletteHeading": "Widgets",
+    "badge": "Editor",
+    "posX": "X",
+    "posY": "Y",
+    "widthShort": "W",
+    "heightShort": "H"
   },
   "viewer": {
     "noVisuSelected": "No visu selected"
@@ -515,7 +520,9 @@
       "dpWStatus": "Read white (status, optional)"
     },
     "link": {
-      "targetPage": "Target page"
+      "targetPage": "Target page",
+      "defaultLabel": "Link",
+      "noTarget": "No target"
     },
     "qrcode": {
       "labelAbove": "Label (shown above)",
@@ -561,7 +568,22 @@
       "dpSlatSend": "Write slat angle",
       "dpSlatStatus": "Read slat angle (status, optional)",
       "dpLock": "🔒 Lock (output, switchable)",
-      "dpIndicatorRo": "Indicator {n} (input, read-only)"
+      "dpIndicatorRo": "Indicator {n} (input, read-only)",
+      "defaultStatus1": "Manual lock",
+      "defaultStatus2": "Status 2",
+      "defaultStatus3": "Status 3",
+      "defaultStatus4": "Status 4",
+      "tooltipUp": "Short: stop\nLong: move up to end position",
+      "tooltipDown": "Short: stop\nLong: move down to end position",
+      "tooltipStop": "Stop immediately",
+      "lockTitle": "Lock",
+      "slatOpenTitle": "Open slats (bright)",
+      "slatCloseTitle": "Close slats (dark)",
+      "positionLabel": "Position",
+      "slatLabel": "Slats",
+      "openShort": "open",
+      "openLabel": "open",
+      "closedShort": "closed"
     },
     "rtr": {
       "accentColor": "Accent colour",
@@ -623,7 +645,11 @@
       "stateOff": "OFF (false)",
       "modeSwitch": "Switch",
       "modeIconOnly": "Icon only",
-      "modeIconText": "Icon + Text"
+      "modeIconText": "Icon + Text",
+      "labelPlaceholder": "e.g. Pump HK1",
+      "iconLabel": "Icon",
+      "colorTitle": "Colour",
+      "textLabel": "Text"
     },
     "uhr": {
       "accentColor": "Accent colour",
@@ -669,7 +695,21 @@
       "period": "Period (hours)",
       "duplicateTitle": "Duplicate",
       "deleteTitle": "Delete",
-      "defaultHistoryRange": "Default history range"
+      "defaultHistoryRange": "Default history range",
+      "labelPlaceholder": "e.g. Room temperature",
+      "iconLabel": "Icon",
+      "colorTitle": "Colour",
+      "prefixPlaceholder": "Prefix",
+      "postfixUnitPlaceholder": "Unit / postfix",
+      "displayTextPlaceholder": "Display text",
+      "postfixPlaceholder": "Postfix",
+      "valuePlaceholder": "Value",
+      "secondaryLabelPlaceholder": "e.g. Setpoint",
+      "gaugeSettings": "Gauge settings",
+      "minimum": "Minimum",
+      "maximum": "Maximum",
+      "gaugeColors": "Colour / gradient (1–4 colours, low → high)",
+      "colorIndex": "Colour {n}"
     },
     "wetter": {
       "labelCity": "Label (location name)",
@@ -693,7 +733,15 @@
       "showForecast": "Show daily forecast",
       "forecastDays": "Number of days (1–7)",
       "precipitation": "Precipitation probability",
-      "showAlerts": "Show weather alerts"
+      "showAlerts": "Show weather alerts",
+      "configureApiUrl": "Configure weather API URL",
+      "defaultLabel": "Weather",
+      "previewLiveMode": "Preview in live mode",
+      "noApiUrl": "No API URL configured",
+      "loadingData": "Loading weather data …",
+      "reload": "Reload",
+      "refreshNow": "Refresh now",
+      "precipitationTitle": "Precipitation: {pct}"
     },
     "widgetref": {
       "sourcePage": "Source page",
@@ -778,6 +826,10 @@
       "keyboardHint": "Enter = close polygon · Esc = discard · Click first point = close",
       "defaultAreaName": "Area {n}",
       "datapoint": "Data point"
+    },
+    "missing": {
+      "title": "Unknown",
+      "ariaLabel": "Unknown widget type"
     }
   }
 }

--- a/frontend/src/views/VisuEditor.vue
+++ b/frontend/src/views/VisuEditor.vue
@@ -354,7 +354,7 @@ const showSettings = ref(false)
     <!-- ── Toolbar ──────────────────────────────────────────────────────────── -->
     <header class="border-b border-gray-200 dark:border-gray-800 px-4 py-2 flex items-center gap-3 flex-shrink-0 bg-gray-50 dark:bg-gray-900">
       <Breadcrumb />
-      <span class="text-xs font-medium text-blue-500 dark:text-blue-400 bg-blue-500/10 dark:bg-blue-400/10 px-2 py-0.5 rounded">Editor</span>
+      <span class="text-xs font-medium text-blue-500 dark:text-blue-400 bg-blue-500/10 dark:bg-blue-400/10 px-2 py-0.5 rounded">{{ $t('editor.badge') }}</span>
       <input
         v-if="isNew"
         v-model="newPageName"
@@ -565,23 +565,23 @@ const showSettings = ref(false)
               <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-2">{{ $t('editor.positionSize') }}</p>
               <div class="grid grid-cols-4 gap-1.5 text-xs">
                 <div>
-                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">X</label>
+                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">{{ $t('editor.posX') }}</label>
                   <input v-model.number="selectedWidget.x" type="number" min="0"
                     :max="COLS - selectedWidget.w"
                     class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-1 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500" />
                 </div>
                 <div>
-                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">Y</label>
+                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">{{ $t('editor.posY') }}</label>
                   <input v-model.number="selectedWidget.y" type="number" min="0"
                     class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-1 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500" />
                 </div>
                 <div>
-                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">B</label>
+                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">{{ $t('editor.widthShort') }}</label>
                   <input v-model.number="selectedWidget.w" type="number" :min="selectedDef.minW" :max="COLS"
                     class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-1 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500" />
                 </div>
                 <div>
-                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">H</label>
+                  <label class="block text-gray-400 dark:text-gray-500 mb-0.5">{{ $t('editor.heightShort') }}</label>
                   <input v-model.number="selectedWidget.h" type="number" :min="selectedDef.minH"
                     class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-1 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500" />
                 </div>

--- a/frontend/src/widgets/Link/Widget.vue
+++ b/frontend/src/widgets/Link/Widget.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import type { DataPointValue } from '@/types'
 import VisuIcon from '@/components/VisuIcon.vue'
 
@@ -13,7 +14,8 @@ const props = defineProps<{
 }>()
 
 const router   = useRouter()
-const label    = computed(() => (props.config.label         as string | undefined) ?? 'Link')
+const { t } = useI18n()
+const label    = computed(() => (props.config.label         as string | undefined) ?? t('widgets.link.defaultLabel'))
 const icon     = computed(() => (props.config.icon          as string | undefined) ?? '🔗')
 const targetId = computed(() => (props.config.target_node_id as string | undefined) ?? '')
 
@@ -34,6 +36,6 @@ function navigate() {
     <span class="text-4xl leading-none" data-testid="link-icon"><VisuIcon :icon="icon" /></span>
     <span class="text-sm font-medium text-gray-800 dark:text-gray-200 text-center leading-tight">{{ label }}</span>
     <span v-if="!editorMode && targetId" class="text-xs text-gray-400 dark:text-gray-500">→</span>
-    <span v-else-if="!targetId" class="text-xs text-gray-400 dark:text-gray-600">Kein Ziel</span>
+    <span v-else-if="!targetId" class="text-xs text-gray-400 dark:text-gray-600">{{ $t('widgets.link.noTarget') }}</span>
   </div>
 </template>

--- a/frontend/src/widgets/MissingWidget.vue
+++ b/frontend/src/widgets/MissingWidget.vue
@@ -1,14 +1,18 @@
 <template>
   <div class="missing-widget">
-    <span class="missing-widget__badge" aria-label="Unbekannter Widget-Typ">!</span>
+    <span class="missing-widget__badge" :aria-label="$t('widgets.missing.ariaLabel')">!</span>
     <div class="missing-widget__text">
-      <div class="missing-widget__title">Unbekannt</div>
+      <div class="missing-widget__title">{{ $t('widgets.missing.title') }}</div>
       <div class="missing-widget__type">{{ widgetType }}</div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+useI18n()
+
 defineProps<{ widgetType: string }>()
 </script>
 

--- a/frontend/src/widgets/Rolladen/Widget.vue
+++ b/frontend/src/widgets/Rolladen/Widget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { datapoints } from '@/api/client'
 import { useDatapointsStore } from '@/stores/datapoints'
 import type { DataPointValue } from '@/types'
@@ -21,6 +22,7 @@ const props = defineProps<{
   editorMode: boolean
   readonly?: boolean
 }>()
+const { t } = useI18n()
 
 const dpStore = useDatapointsStore()
 
@@ -46,10 +48,10 @@ const dpStatus2 = computed(() => (props.config.dp_status_2 as string) || null)
 const dpStatus3 = computed(() => (props.config.dp_status_3 as string) || null)
 const dpStatus4 = computed(() => (props.config.dp_status_4 as string) || null)
 
-const labelStatus1 = computed(() => (props.config.label_status_1 as string) || 'Manuelle Sperre')
-const labelStatus2 = computed(() => (props.config.label_status_2 as string) || 'Status 2')
-const labelStatus3 = computed(() => (props.config.label_status_3 as string) || 'Status 3')
-const labelStatus4 = computed(() => (props.config.label_status_4 as string) || 'Status 4')
+const labelStatus1 = computed(() => (props.config.label_status_1 as string) || t('widgets.rolladen.defaultStatus1'))
+const labelStatus2 = computed(() => (props.config.label_status_2 as string) || t('widgets.rolladen.defaultStatus2'))
+const labelStatus3 = computed(() => (props.config.label_status_3 as string) || t('widgets.rolladen.defaultStatus3'))
+const labelStatus4 = computed(() => (props.config.label_status_4 as string) || t('widgets.rolladen.defaultStatus4'))
 
 // ── Werte aus dem Store lesen ────────────────────────────────────────────────
 function toNumber(id: string | null): number | null {
@@ -284,10 +286,9 @@ const slatLines = computed(() => {
 })
 
 // ── Tooltip-Texte ────────────────────────────────────────────────────────────
-const tooltipUp   = 'Kurz: Stopp\nLang: Auffahren bis Endlage'
-const tooltipDown = 'Kurz: Stopp\nLang: Abfahren bis Endlage'
-
-const tooltipStop = 'Sofort stoppen'
+const tooltipUp = computed(() => t('widgets.rolladen.tooltipUp'))
+const tooltipDown = computed(() => t('widgets.rolladen.tooltipDown'))
+const tooltipStop = computed(() => t('widgets.rolladen.tooltipStop'))
 
 // ── Sicherheits-Cleanup ──────────────────────────────────────────────────────
 function onWindowPointerUp() {
@@ -395,7 +396,7 @@ onUnmounted(() => {
           <!-- Positionsregler -->
           <div>
             <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-0.5">
-              <span>Position</span>
+              <span>{{ $t('widgets.rolladen.positionLabel') }}</span>
               <span class="tabular-nums font-medium text-gray-700 dark:text-gray-300">
                 {{ displayPosition !== null ? Math.round(shownPosition) + ' %' : '—' }}
               </span>
@@ -409,14 +410,14 @@ onUnmounted(() => {
               @change="onPositionChange"
             />
             <div class="flex justify-between text-xs text-gray-400 dark:text-gray-600 mt-0.5">
-              <span>auf</span><span>zu</span>
+              <span>{{ $t('widgets.rolladen.openShort') }}</span><span>{{ $t('widgets.rolladen.closedShort') }}</span>
             </div>
           </div>
 
           <!-- Lamellenregler (nur Jalousie) -->
           <div v-if="mode === 'jalousie'">
             <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-0.5">
-              <span>Lamellen</span>
+              <span>{{ $t('widgets.rolladen.slatLabel') }}</span>
               <span class="tabular-nums font-medium text-gray-700 dark:text-gray-300">
                 {{ rawSlat !== null ? Math.round(shownSlat) + ' %' : '—' }}
               </span>
@@ -430,7 +431,7 @@ onUnmounted(() => {
               @change="onSlatChange"
             />
             <div class="flex justify-between text-xs text-gray-400 dark:text-gray-600 mt-0.5">
-              <span>offen</span><span>zu</span>
+              <span>{{ $t('widgets.rolladen.openLabel') }}</span><span>{{ $t('widgets.rolladen.closedShort') }}</span>
             </div>
           </div>
 
@@ -446,7 +447,7 @@ onUnmounted(() => {
                    bg-gray-200 dark:bg-gray-700
                    hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-40"
             :disabled="editorMode || readonly"
-            title="Sperre"
+            :title="$t('widgets.rolladen.lockTitle')"
             @click="toggleLock"
           >
             <span
@@ -526,7 +527,7 @@ onUnmounted(() => {
                  bg-gray-200 dark:bg-gray-700 text-yellow-500
                  hover:bg-amber-100 dark:hover:bg-amber-900 disabled:opacity-40"
           :disabled="editorMode || readonly || isLocked"
-          title="Lamellen öffnen (hell)"
+          :title="$t('widgets.rolladen.slatOpenTitle')"
           @click="slatStep('open')"
         >☀</button>
 
@@ -563,7 +564,7 @@ onUnmounted(() => {
                  bg-gray-200 dark:bg-gray-700 text-blue-400
                  hover:bg-blue-100 dark:hover:bg-blue-900 disabled:opacity-40"
           :disabled="editorMode || readonly || isLocked"
-          title="Lamellen schliessen (dunkel)"
+          :title="$t('widgets.rolladen.slatCloseTitle')"
           @click="slatStep('close')"
         >🌙</button>
       </div>

--- a/frontend/src/widgets/Toggle/Config.vue
+++ b/frontend/src/widgets/Toggle/Config.vue
@@ -43,8 +43,8 @@ function parseRule(raw: unknown, defaults: StateRule): StateRule {
 const cfg = reactive<Cfg>({
   label: (props.modelValue.label as string) ?? '',
   mode:  (props.modelValue.mode  as DisplayMode) ?? 'switch',
-  on:  parseRule(props.modelValue.on,  { icon: '', color: '#3b82f6', text: 'EIN' }),
-  off: parseRule(props.modelValue.off, { icon: '', color: '#6b7280', text: 'AUS' }),
+  on:  parseRule(props.modelValue.on,  { icon: '', color: '#3b82f6', text: t('common.on') }),
+  off: parseRule(props.modelValue.off, { icon: '', color: '#6b7280', text: t('common.off') }),
 })
 
 watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
@@ -59,7 +59,7 @@ watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
       <input
         v-model="cfg.label"
         type="text"
-        placeholder="z.B. Pumpe HK1"
+        :placeholder="$t('widgets.toggle.labelPlaceholder')"
         class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
       />
     </div>
@@ -93,23 +93,23 @@ watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
 
         <!-- Icon + Farbe -->
         <div class="flex gap-2 items-center">
-          <span class="text-xs text-gray-500 w-8 shrink-0">Icon</span>
+          <span class="text-xs text-gray-500 w-8 shrink-0">{{ $t('widgets.toggle.iconLabel') }}</span>
           <IconPicker v-model="cfg.on.icon" :dark="true" />
           <input
             v-model="cfg.on.color"
             type="color"
             class="w-7 h-7 rounded cursor-pointer border border-gray-700 bg-transparent p-0.5 shrink-0"
-            title="Farbe"
+            :title="$t('widgets.toggle.colorTitle')"
           />
         </div>
 
         <!-- Text (nicht im Nur-Icon-Modus) -->
         <div v-if="cfg.mode !== 'icon_only'" class="flex gap-2 items-center">
-          <span class="text-xs text-gray-500 w-8 shrink-0">Text</span>
+          <span class="text-xs text-gray-500 w-8 shrink-0">{{ $t('widgets.toggle.textLabel') }}</span>
           <input
             v-model="cfg.on.text"
             type="text"
-            placeholder="EIN"
+            :placeholder="$t('common.on')"
             class="flex-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
           />
         </div>
@@ -121,23 +121,23 @@ watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
 
         <!-- Icon + Farbe -->
         <div class="flex gap-2 items-center">
-          <span class="text-xs text-gray-500 w-8 shrink-0">Icon</span>
+          <span class="text-xs text-gray-500 w-8 shrink-0">{{ $t('widgets.toggle.iconLabel') }}</span>
           <IconPicker v-model="cfg.off.icon" :dark="true" />
           <input
             v-model="cfg.off.color"
             type="color"
             class="w-7 h-7 rounded cursor-pointer border border-gray-700 bg-transparent p-0.5 shrink-0"
-            title="Farbe"
+            :title="$t('widgets.toggle.colorTitle')"
           />
         </div>
 
         <!-- Text (nicht im Nur-Icon-Modus) -->
         <div v-if="cfg.mode !== 'icon_only'" class="flex gap-2 items-center">
-          <span class="text-xs text-gray-500 w-8 shrink-0">Text</span>
+          <span class="text-xs text-gray-500 w-8 shrink-0">{{ $t('widgets.toggle.textLabel') }}</span>
           <input
             v-model="cfg.off.text"
             type="text"
-            placeholder="AUS"
+            :placeholder="$t('common.off')"
             class="flex-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
           />
         </div>

--- a/frontend/src/widgets/ValueDisplay/Config.vue
+++ b/frontend/src/widgets/ValueDisplay/Config.vue
@@ -171,13 +171,13 @@ function dupRule(i: number) {
     <!-- Label -->
     <div>
       <label class="block text-xs text-gray-400 mb-1">{{ $t('widgets.common.label') }}</label>
-      <input
-        v-model="cfg.label"
-        type="text"
-        placeholder="z.B. Raumtemperatur"
-        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
-      />
-    </div>
+        <input
+          v-model="cfg.label"
+          type="text"
+          :placeholder="$t('widgets.valuedisplay.labelPlaceholder')"
+          class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+        />
+      </div>
 
     <!-- Mode -->
     <div>
@@ -219,13 +219,13 @@ function dupRule(i: number) {
 
               <!-- Icon + color row -->
               <div class="flex gap-2 items-center mb-2">
-                <span class="text-xs text-gray-500 w-8 shrink-0">Icon</span>
+                <span class="text-xs text-gray-500 w-8 shrink-0">{{ $t('widgets.valuedisplay.iconLabel') }}</span>
                 <IconPicker v-model="rule.icon" :dark="true" />
                 <input
                   v-model="rule.color"
                   type="color"
                   class="w-7 h-7 rounded cursor-pointer border border-gray-700 bg-transparent p-0.5 shrink-0"
-                  title="Farbe"
+                  :title="$t('widgets.valuedisplay.colorTitle')"
                 />
               </div>
 
@@ -250,7 +250,7 @@ function dupRule(i: number) {
                     <input
                       v-model="rule.prefix"
                       type="text"
-                      placeholder="Präfix"
+                      :placeholder="$t('widgets.valuedisplay.prefixPlaceholder')"
                       class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                     />
                     <select
@@ -262,7 +262,7 @@ function dupRule(i: number) {
                     <input
                       v-model="rule.postfix"
                       type="text"
-                      placeholder="Einheit / Postfix"
+                      :placeholder="$t('widgets.valuedisplay.postfixUnitPlaceholder')"
                       class="w-20 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                     />
                   </template>
@@ -271,19 +271,19 @@ function dupRule(i: number) {
                     <input
                       v-model="rule.prefix"
                       type="text"
-                      placeholder="Präfix"
+                      :placeholder="$t('widgets.valuedisplay.prefixPlaceholder')"
                       class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                     />
                     <input
                       v-model="rule.text"
                       type="text"
-                      placeholder="Anzeigetext"
+                      :placeholder="$t('widgets.valuedisplay.displayTextPlaceholder')"
                       class="flex-1 min-w-20 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                     />
                     <input
                       v-model="rule.postfix"
                       type="text"
-                      placeholder="Postfix"
+                      :placeholder="$t('widgets.valuedisplay.postfixPlaceholder')"
                       class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                     />
                   </template>
@@ -305,7 +305,7 @@ function dupRule(i: number) {
               <input
                 v-model="rule.threshold"
                 type="text"
-                placeholder="Wert"
+                :placeholder="$t('widgets.valuedisplay.valuePlaceholder')"
                 class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500 font-mono shrink-0"
               />
               <div class="flex-1" />
@@ -314,7 +314,7 @@ function dupRule(i: number) {
                 v-model="rule.color"
                 type="color"
                 class="w-7 h-7 rounded cursor-pointer border border-gray-700 bg-transparent p-0.5 shrink-0"
-                title="Farbe"
+                :title="$t('widgets.valuedisplay.colorTitle')"
               />
               <button
                 type="button"
@@ -337,8 +337,8 @@ function dupRule(i: number) {
                   v-model="rule.output_type"
                   class="bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-200 focus:outline-none focus:border-blue-500"
                 >
-                  <option value="value">Wert</option>
-                  <option value="text">Text</option>
+                  <option value="value">{{ $t('widgets.valuedisplay.outputValue') }}</option>
+                  <option value="text">{{ $t('widgets.valuedisplay.outputText') }}</option>
                 </select>
 
                 <template v-if="rule.output_type === 'value'">
@@ -351,7 +351,7 @@ function dupRule(i: number) {
                   <input
                     v-model="rule.prefix"
                     type="text"
-                    placeholder="Präfix"
+                    :placeholder="$t('widgets.valuedisplay.prefixPlaceholder')"
                     class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                   />
                   <select
@@ -363,7 +363,7 @@ function dupRule(i: number) {
                   <input
                     v-model="rule.postfix"
                     type="text"
-                    placeholder="Einheit / Postfix"
+                    :placeholder="$t('widgets.valuedisplay.postfixUnitPlaceholder')"
                     class="w-20 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                   />
                 </template>
@@ -372,19 +372,19 @@ function dupRule(i: number) {
                   <input
                     v-model="rule.prefix"
                     type="text"
-                    placeholder="Präfix"
+                    :placeholder="$t('widgets.valuedisplay.prefixPlaceholder')"
                     class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                   />
                   <input
                     v-model="rule.text"
                     type="text"
-                    placeholder="Anzeigetext"
+                    :placeholder="$t('widgets.valuedisplay.displayTextPlaceholder')"
                     class="flex-1 min-w-20 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                   />
                   <input
                     v-model="rule.postfix"
                     type="text"
-                    placeholder="Postfix"
+                    :placeholder="$t('widgets.valuedisplay.postfixPlaceholder')"
                     class="w-14 bg-gray-800 border border-gray-700 rounded px-1 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
                   />
                 </template>
@@ -413,18 +413,18 @@ function dupRule(i: number) {
         <div class="flex gap-2">
           <div class="flex-1">
             <label class="block text-xs text-gray-400 mb-1">{{ $t('widgets.valuedisplay.secondaryLabel') }}</label>
-            <input
-              v-model="cfg.secondary_label"
-              type="text"
-              placeholder="z.B. Soll"
-              class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
-            />
-          </div>
-          <div class="w-20">
-            <label class="block text-xs text-gray-400 mb-1">Dezimalst.</label>
-            <input
-              v-model.number="cfg.secondary_decimals"
-              type="number"
+              <input
+                v-model="cfg.secondary_label"
+                type="text"
+                :placeholder="$t('widgets.valuedisplay.secondaryLabelPlaceholder')"
+                class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
+              />
+            </div>
+            <div class="w-20">
+              <label class="block text-xs text-gray-400 mb-1">{{ $t('widgets.valuedisplay.decimalsShort') }}</label>
+              <input
+                v-model.number="cfg.secondary_decimals"
+                type="number"
               min="0"
               max="4"
               class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
@@ -447,12 +447,12 @@ function dupRule(i: number) {
 
     <!-- ── Gauge settings (gauge_arc / gauge_circle only) ─────────────────── -->
     <div v-if="isGaugeMode(cfg.mode)" class="border-t border-gray-700 pt-3 space-y-3">
-      <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Gauge Einstellungen</p>
+      <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider">{{ $t('widgets.valuedisplay.gaugeSettings') }}</p>
 
       <!-- Min / Max -->
       <div class="flex gap-2">
         <div class="flex-1">
-          <label class="block text-xs text-gray-400 mb-1">Minimum</label>
+          <label class="block text-xs text-gray-400 mb-1">{{ $t('widgets.valuedisplay.minimum') }}</label>
           <input
             v-model.number="cfg.gauge_min"
             type="number"
@@ -460,7 +460,7 @@ function dupRule(i: number) {
           />
         </div>
         <div class="flex-1">
-          <label class="block text-xs text-gray-400 mb-1">Maximum</label>
+          <label class="block text-xs text-gray-400 mb-1">{{ $t('widgets.valuedisplay.maximum') }}</label>
           <input
             v-model.number="cfg.gauge_max"
             type="number"
@@ -471,7 +471,7 @@ function dupRule(i: number) {
 
       <!-- Gradient colors -->
       <div>
-        <label class="block text-xs text-gray-400 mb-1">Farbe / Farbverlauf (1–4 Farben, niedrig → hoch)</label>
+        <label class="block text-xs text-gray-400 mb-1">{{ $t('widgets.valuedisplay.gaugeColors') }}</label>
         <div class="flex items-center gap-2 flex-wrap">
           <input
             v-for="(_, i) in cfg.gauge_colors"
@@ -479,7 +479,7 @@ function dupRule(i: number) {
             v-model="cfg.gauge_colors[i]"
             type="color"
             class="w-8 h-8 rounded cursor-pointer border border-gray-700 bg-transparent p-0.5 shrink-0"
-            :title="`Farbe ${i + 1}`"
+            :title="$t('widgets.valuedisplay.colorIndex', { n: i + 1 })"
           />
           <button
             v-if="cfg.gauge_colors.length < 4"

--- a/frontend/src/widgets/Wetter/Widget.vue
+++ b/frontend/src/widgets/Wetter/Widget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { DataPointValue } from '@/types'
 import { getJwt } from '@/api/client'
 
@@ -70,6 +71,7 @@ const props = defineProps<{
   statusValue: DataPointValue | null
   editorMode: boolean
 }>()
+const { locale } = useI18n()
 
 // ── Config ─────────────────────────────────────────────────────────────────────
 
@@ -134,11 +136,11 @@ function windDir(deg: number): string {
 }
 
 function fmtTime(unixTs: number): string {
-  return new Date(unixTs * 1000).toLocaleTimeString('de', { hour: '2-digit', minute: '2-digit' })
+  return new Date(unixTs * 1000).toLocaleTimeString(locale.value || 'de', { hour: '2-digit', minute: '2-digit' })
 }
 
 function fmtDay(unixTs: number): string {
-  return new Date(unixTs * 1000).toLocaleDateString('de', { weekday: 'short' })
+  return new Date(unixTs * 1000).toLocaleDateString(locale.value || 'de', { weekday: 'short' })
 }
 
 function fmtPercent(v: number): string {
@@ -236,7 +238,7 @@ const activeAlerts = computed(() => {
       class="flex-1 flex flex-col items-center justify-center text-gray-400 dark:text-gray-500 gap-2"
     >
       <span class="text-4xl">🌤️</span>
-      <span class="text-xs">Wetter-API-URL konfigurieren</span>
+      <span class="text-xs">{{ $t('widgets.wetter.configureApiUrl') }}</span>
     </div>
 
     <!-- ── Editor-Modus mit URL (kein Live-Fetch) ──────────────────────────── -->
@@ -245,8 +247,8 @@ const activeAlerts = computed(() => {
       class="flex-1 flex flex-col items-center justify-center text-gray-400 dark:text-gray-500 gap-1"
     >
       <span class="text-3xl">🌤️</span>
-      <span class="text-xs text-gray-500 dark:text-gray-400">{{ label || 'Wetter' }}</span>
-      <span class="text-xs text-gray-400 dark:text-gray-600">Vorschau im Live-Modus</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{{ label || $t('widgets.wetter.defaultLabel') }}</span>
+      <span class="text-xs text-gray-400 dark:text-gray-600">{{ $t('widgets.wetter.previewLiveMode') }}</span>
     </div>
 
     <!-- ── Kein URL im Live-Modus ───────────────────────────────────────────── -->
@@ -254,7 +256,7 @@ const activeAlerts = computed(() => {
       v-else-if="!url"
       class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-600 text-xs"
     >
-      Keine API-URL konfiguriert
+      {{ $t('widgets.wetter.noApiUrl') }}
     </div>
 
     <!-- ── Laden ────────────────────────────────────────────────────────────── -->
@@ -263,7 +265,7 @@ const activeAlerts = computed(() => {
       class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500 text-xs gap-2"
     >
       <span class="animate-spin">⏳</span>
-      <span>Wetterdaten werden geladen …</span>
+      <span>{{ $t('widgets.wetter.loadingData') }}</span>
     </div>
 
     <!-- ── Fehler ────────────────────────────────────────────────────────────── -->
@@ -277,7 +279,7 @@ const activeAlerts = computed(() => {
         class="mt-1 px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-xs text-gray-700 dark:text-gray-200 transition-colors"
         @click="fetchWeather"
       >
-        Neu laden
+        {{ $t('widgets.wetter.reload') }}
       </button>
     </div>
 
@@ -294,7 +296,7 @@ const activeAlerts = computed(() => {
         </span>
         <button
           class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors text-xs ml-2 shrink-0"
-          title="Jetzt aktualisieren"
+          :title="$t('widgets.wetter.refreshNow')"
           @click="fetchWeather"
         >
           ↺
@@ -368,7 +370,7 @@ const activeAlerts = computed(() => {
           <span
             v-if="showForecastPrecipitation && day.pop > 0"
             class="text-xs text-blue-600 dark:text-blue-400"
-            :title="`Niederschlag: ${fmtPercent(day.pop)}`"
+            :title="$t('widgets.wetter.precipitationTitle', { pct: fmtPercent(day.pop) })"
           >
             {{ fmtPercent(day.pop) }}
           </span>

--- a/gui/src/components/datapoints/BindingForm.vue
+++ b/gui/src/components/datapoints/BindingForm.vue
@@ -20,46 +20,46 @@
 
       <div class="grid gap-4" :class="selectedAdapterType === 'ANWESENHEITSSIMULATION' ? 'grid-cols-1' : 'grid-cols-2'">
         <div class="form-group">
-          <label class="label">Adapter-Instanz *</label>
+          <label class="label">{{ $t('adapters.bindingForm.adapterInstanceLabel') }}</label>
           <div v-if="props.initial" class="input bg-slate-100 dark:bg-slate-800/50 text-slate-400 cursor-not-allowed">
             {{ currentInstanceName }}
           </div>
           <select v-else v-model="form.adapter_instance_id" class="input" required data-testid="select-adapter-instance">
-            <option value="">Instanz wählen …</option>
+            <option value="">{{ $t('adapters.bindingForm.selectInstance') }}</option>
             <optgroup v-for="group in groupedInstances" :key="group.type" :label="group.type">
               <option v-for="inst in group.items" :key="inst.id" :value="inst.id">{{ inst.name }}</option>
             </optgroup>
           </select>
         </div>
         <div v-if="selectedAdapterType !== 'ANWESENHEITSSIMULATION'" class="form-group">
-          <label class="label">Richtung *</label>
+          <label class="label">{{ $t('adapters.bindingForm.directionLabel') }}</label>
           <select
             v-model="form.direction"
             class="input"
             :disabled="selectedAdapterType === 'ZEITSCHALTUHR'"
             data-testid="select-direction"
           >
-            <option value="SOURCE">Lesen (von Adapter)</option>
-            <option v-if="selectedAdapterType !== 'ZEITSCHALTUHR'" value="DEST">Schreiben (auf Adapter)</option>
-            <option v-if="selectedAdapterType !== 'ZEITSCHALTUHR'" value="BOTH">Lesen/Schreiben (von/auf Adapter)</option>
+            <option value="SOURCE">{{ $t('adapters.bindingForm.directionRead') }}</option>
+            <option v-if="selectedAdapterType !== 'ZEITSCHALTUHR'" value="DEST">{{ $t('adapters.bindingForm.directionWrite') }}</option>
+            <option v-if="selectedAdapterType !== 'ZEITSCHALTUHR'" value="BOTH">{{ $t('adapters.bindingForm.directionReadWrite') }}</option>
           </select>
           <p v-if="selectedAdapterType === 'ZEITSCHALTUHR'" class="hint">
-            Die Zeitschaltuhr ist eine reine Quelle — nur Lesen möglich.
+            {{ $t('adapters.bindingForm.timerReadOnlyHint') }}
           </p>
         </div>
       </div>
 
       <!-- KNX -->
       <template v-if="selectedAdapterType === 'KNX'">
-        <div class="section-header">KNX Binding</div>
+        <div class="section-header">{{ $t('adapters.bindingForm.knxSection') }}</div>
         <div class="form-group">
-          <label class="label">Gruppenadresse *</label>
-          <GaCombobox v-model="cfg.group_address" placeholder="z.B. 1/2/3 oder Name suchen …" @select="onGaSelect" />
+          <label class="label">{{ $t('adapters.bindingForm.groupAddressLabel') }}</label>
+          <GaCombobox v-model="cfg.group_address" :placeholder="$t('adapters.bindingForm.groupAddressPlaceholder')" @select="onGaSelect" />
         </div>
         <div class="form-group">
-          <label class="label">DPT *</label>
+          <label class="label">{{ $t('adapters.bindingForm.dptLabel') }}</label>
           <select v-model="cfg.dpt_id" class="input" required>
-            <option value="">DPT wählen …</option>
+            <option value="">{{ $t('adapters.bindingForm.selectDpt') }}</option>
             <optgroup v-for="group in groupedDpts" :key="group.family" :label="group.label">
               <option v-for="dpt in group.dpts" :key="dpt.dpt_id" :value="dpt.dpt_id">
                 {{ dpt.dpt_id }} — {{ dpt.name }}<template v-if="dpt.unit"> [{{ dpt.unit }}]</template>
@@ -80,10 +80,10 @@
               for="respond_to_read"
               class="text-sm"
               :class="props.dpPersistValue ? 'text-slate-600 dark:text-slate-300' : 'text-slate-400 dark:text-slate-500 cursor-not-allowed'"
-            >Antworte auf Leseanfragen</label>
+            >{{ $t('adapters.bindingForm.respondToReadLabel') }}</label>
             <p class="hint">
-              Sendet den aktuellen Wert als GroupValueResponse wenn eine Leseanfrage eingeht.
-              <template v-if="!props.dpPersistValue"> Erfordert aktiviertes „Letzten Wert speichern" am Objekt.</template>
+              {{ $t('adapters.bindingForm.respondToReadHint') }}
+              <template v-if="!props.dpPersistValue"> {{ $t('adapters.bindingForm.respondToReadPersistHint') }}</template>
             </p>
           </div>
         </div>
@@ -91,14 +91,14 @@
 
       <!-- Modbus -->
       <template v-if="selectedAdapterType === 'MODBUS_TCP' || selectedAdapterType === 'MODBUS_RTU'">
-        <div class="section-header">Modbus Binding</div>
+        <div class="section-header">{{ $t('adapters.bindingForm.modbusSection') }}</div>
         <div class="grid grid-cols-3 gap-4">
           <div class="form-group">
-            <label class="label">Adresse *</label>
+            <label class="label">{{ $t('adapters.bindingForm.addressLabel') }}</label>
             <input v-model.number="cfg.address" type="number" min="0" max="65535" class="input" required />
           </div>
           <div class="form-group">
-            <label class="label">Registertyp *</label>
+            <label class="label">{{ $t('adapters.bindingForm.registerTypeLabel') }}</label>
             <select v-model="cfg.register_type" class="input">
               <option value="holding">Holding Register</option>
               <option value="input">Input Register</option>
@@ -107,7 +107,7 @@
             </select>
           </div>
           <div class="form-group">
-            <label class="label">Datenformat *</label>
+            <label class="label">{{ $t('adapters.bindingForm.dataFormatLabel') }}</label>
             <select v-model="cfg.data_format" class="input">
               <optgroup label="16-Bit">
                 <option value="uint16">UINT16</option>
@@ -128,36 +128,36 @@
         <div class="optional-divider">{{ $t('adapters.binding.optionalSettings') }}</div>
         <div class="grid grid-cols-4 gap-4">
           <div class="form-group">
-            <label class="label">Unit ID</label>
+            <label class="label">{{ $t('adapters.bindingForm.unitIdLabel') }}</label>
             <input v-model.number="cfg.unit_id" type="number" min="0" max="255" class="input" />
-            <p class="hint">Standard: 1</p>
+            <p class="hint">{{ $t('adapters.bindingForm.defaultN', { n: '1' }) }}</p>
           </div>
           <div class="form-group">
-            <label class="label">Anz. Register</label>
+            <label class="label">{{ $t('adapters.bindingForm.registerCountLabel') }}</label>
             <input v-model.number="cfg.count" type="number" min="1" max="125" class="input" />
-            <p class="hint">Standard: 1</p>
+            <p class="hint">{{ $t('adapters.bindingForm.defaultN', { n: '1' }) }}</p>
           </div>
           <div class="form-group">
-            <label class="label">Skalierung</label>
+            <label class="label">{{ $t('adapters.bindingForm.scaleLabel') }}</label>
             <input v-model.number="cfg.scale_factor" type="number" step="any" class="input" />
-            <p class="hint">Standard: 1.0</p>
+            <p class="hint">{{ $t('adapters.bindingForm.defaultN', { n: '1.0' }) }}</p>
           </div>
           <div class="form-group">
-            <label class="label">Intervall (s)</label>
+            <label class="label">{{ $t('adapters.bindingForm.intervalSecondsLabel') }}</label>
             <input v-model.number="cfg.poll_interval" type="number" step="0.1" min="0.1" class="input" />
-            <p class="hint">Standard: 1.0</p>
+            <p class="hint">{{ $t('adapters.bindingForm.defaultN', { n: '1.0' }) }}</p>
           </div>
         </div>
         <div class="grid grid-cols-2 gap-4">
           <div class="form-group">
-            <label class="label">Byte-Reihenfolge</label>
+            <label class="label">{{ $t('adapters.bindingForm.byteOrderLabel') }}</label>
             <select v-model="cfg.byte_order" class="input">
               <option value="big">Big Endian</option>
               <option value="little">Little Endian</option>
             </select>
           </div>
           <div class="form-group">
-            <label class="label">Word-Reihenfolge</label>
+            <label class="label">{{ $t('adapters.bindingForm.wordOrderLabel') }}</label>
             <select v-model="cfg.word_order" class="input">
               <option value="big">Big Endian</option>
               <option value="little">Little Endian</option>
@@ -168,13 +168,13 @@
 
       <!-- MQTT -->
       <template v-if="selectedAdapterType === 'MQTT'">
-        <div class="section-header">MQTT Binding</div>
+        <div class="section-header">{{ $t('adapters.bindingForm.mqttSection') }}</div>
 
         <!-- Topic with browser -->
         <div class="form-group">
-          <label class="label">Topic *</label>
+          <label class="label">{{ $t('adapters.bindingForm.topicLabel') }}</label>
           <div class="flex gap-2">
-            <input v-model="cfg.topic" class="input flex-1" placeholder="z.B. haus/wohnzimmer/temperatur" required data-testid="input-mqtt-topic" />
+            <input v-model="cfg.topic" class="input flex-1" :placeholder="$t('adapters.bindingForm.topicPlaceholder')" required data-testid="input-mqtt-topic" />
             <button
               type="button"
               class="btn-secondary px-3 text-sm whitespace-nowrap"
@@ -182,10 +182,10 @@
               @click="mqttBrowse"
             >
               <span v-if="mqttBrowseLoading" class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin mr-1"></span>
-              {{ mqttBrowseLoading ? 'Scannen …' : 'Browse' }}
+              {{ mqttBrowseLoading ? $t('adapters.bindingForm.scanning') : $t('adapters.bindingForm.browse') }}
             </button>
           </div>
-          <p class="hint">Lesen/Lesen+Schreiben: abonniertes Topic; Schreiben: Publish-Topic</p>
+          <p class="hint">{{ $t('adapters.bindingForm.topicHint') }}</p>
 
           <!-- Browse results -->
           <div
@@ -207,34 +207,34 @@
         <div class="grid grid-cols-2 gap-4">
           <!-- Publish-Topic: nur bei Lesen/Schreiben (BOTH) sichtbar -->
           <div v-if="form.direction === 'BOTH'" class="form-group">
-            <label class="label">Publish-Topic <span class="optional">(optional)</span></label>
-            <input v-model="cfg.publish_topic" class="input" placeholder="z.B. …/set" />
-            <p class="hint">Topic für Schreiben — leer = Topic wird verwendet</p>
+            <label class="label">{{ $t('adapters.bindingForm.publishTopicLabel') }} <span class="optional">{{ $t('logic.nodeConfig.common.optional') }}</span></label>
+            <input v-model="cfg.publish_topic" class="input" :placeholder="$t('adapters.bindingForm.publishTopicPlaceholder')" />
+            <p class="hint">{{ $t('adapters.bindingForm.publishTopicHint') }}</p>
           </div>
           <!-- Retain: nur bei Schreiben (DEST) oder Lesen/Schreiben (BOTH) -->
           <div v-if="form.direction === 'DEST' || form.direction === 'BOTH'" class="form-group flex flex-col justify-end">
             <div class="flex items-center gap-2 mt-6">
               <input type="checkbox" id="mqtt_retain" v-model="cfg.retain" class="w-4 h-4 rounded" />
-              <label for="mqtt_retain" class="text-sm text-slate-600 dark:text-slate-300">Retain</label>
+              <label for="mqtt_retain" class="text-sm text-slate-600 dark:text-slate-300">{{ $t('adapters.bindingForm.retainLabel') }}</label>
             </div>
-            <p class="hint">Broker speichert letzten Wert</p>
+            <p class="hint">{{ $t('adapters.bindingForm.retainHint') }}</p>
           </div>
         </div>
 
         <!-- Payload Template — only for DEST / BOTH -->
         <div v-if="form.direction === 'DEST' || form.direction === 'BOTH'" class="form-group">
-          <label class="label">Payload-Template <span class="optional">(optional)</span></label>
+          <label class="label">{{ $t('adapters.bindingForm.payloadTemplateLabel') }} <span class="optional">{{ $t('logic.nodeConfig.common.optional') }}</span></label>
           <input
             v-model="cfg.payload_template"
             class="input font-mono text-sm"
-            placeholder='z.B. {"value": "###DP###", "unit": "°C"}'
+            :placeholder="$t('adapters.bindingForm.payloadTemplatePlaceholder')"
           />
-          <p class="hint"><code class="text-blue-400">###DP###</code> wird durch den Datenpunktwert ersetzt. Leer = Wert direkt als Payload.</p>
+          <p class="hint">{{ $t('adapters.bindingForm.payloadTemplateHint') }}</p>
         </div>
 
         <!-- Source Data Type — SOURCE / BOTH only -->
         <div v-if="form.direction === 'SOURCE' || form.direction === 'BOTH'" class="form-group">
-          <label class="label">Quell-Datentyp <span class="optional">(optional)</span></label>
+          <label class="label">{{ $t('adapters.bindingForm.sourceDataTypeLabel') }} <span class="optional">{{ $t('logic.nodeConfig.common.optional') }}</span></label>
           <div class="flex gap-2 items-start">
             <select v-model="cfg.source_data_type" class="input flex-1" data-testid="select-source-data-type">
               <option v-for="t in MQTT_SOURCE_TYPES" :key="t.value" :value="t.value">{{ t.label }}</option>
@@ -244,8 +244,8 @@
             </span>
           </div>
           <p class="hint">
-            Wie der eingehende Payload interpretiert wird.
-            Objekt-Typ: <code class="text-blue-400">{{ props.dpDataType }}</code>
+            {{ $t('adapters.bindingForm.sourceDataTypeHint') }}
+            {{ $t('adapters.bindingForm.objectTypeLabel') }}: <code class="text-blue-400">{{ props.dpDataType }}</code>
           </p>
 
           <!-- JSON key extraction panel -->
@@ -1080,10 +1080,10 @@
     <div v-if="error" class="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">{{ error }}</div>
 
     <div class="flex justify-end gap-3">
-      <button type="button" @click="$emit('cancel')" class="btn-secondary">Abbrechen</button>
+      <button type="button" @click="$emit('cancel')" class="btn-secondary">{{ $t('common.cancel') }}</button>
       <button type="submit" class="btn-primary" :disabled="saving">
         <Spinner v-if="saving" size="sm" color="white" />
-        Speichern
+        {{ $t('common.save') }}
       </button>
     </div>
 
@@ -1092,6 +1092,7 @@
 
 <script setup>
 import { ref, reactive, watch, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { dpApi, adapterApi } from '@/api/client'
 import Spinner    from '@/components/ui/Spinner.vue'
 import GaCombobox from '@/components/ui/GaCombobox.vue'
@@ -1103,6 +1104,7 @@ const props = defineProps({
   dpDataType:     { type: String,  default: 'UNKNOWN' },  // DataPoint.data_type for compat check
 })
 const emit = defineEmits(['save', 'cancel'])
+const { t } = useI18n()
 
 const saving       = ref(false)
 const error        = ref(null)
@@ -1135,13 +1137,13 @@ const form = reactive({
 })
 
 const VALUE_MAP_PRESETS = [
-  { key: '',            label: '— keine Wertzuordnung —',            map: null },
-  { key: 'num_invert',  label: '0 ↔ 1 (numerisch invertieren)',       map: { '0': '1', '1': '0' } },
-  { key: 'bool_onoff',  label: 'true/false → on/off',                 map: { 'true': 'on', 'false': 'off' } },
-  { key: 'onoff_bool',  label: 'on/off → true/false',                 map: { 'on': 'true', 'off': 'false' } },
-  { key: 'num_onoff',   label: '0/1 → off/on',                        map: { '0': 'off', '1': 'on' } },
-  { key: 'onoff_num',   label: 'off/on → 0/1',                        map: { 'off': '0', 'on': '1' } },
-  { key: 'custom',      label: 'Benutzerdefiniert (JSON) …',           map: null },
+  { key: '',            label: t('adapters.bindingForm.noValueMapping'),            map: null },
+  { key: 'num_invert',  label: t('adapters.bindingForm.valueMapNumInvert'),         map: { '0': '1', '1': '0' } },
+  { key: 'bool_onoff',  label: t('adapters.bindingForm.valueMapBoolOnOff'),         map: { 'true': 'on', 'false': 'off' } },
+  { key: 'onoff_bool',  label: t('adapters.bindingForm.valueMapOnOffBool'),         map: { 'on': 'true', 'off': 'false' } },
+  { key: 'num_onoff',   label: t('adapters.bindingForm.valueMapNumOnOff'),          map: { '0': 'off', '1': 'on' } },
+  { key: 'onoff_num',   label: t('adapters.bindingForm.valueMapOnOffNum'),          map: { 'off': '0', 'on': '1' } },
+  { key: 'custom',      label: t('adapters.bindingForm.customValueMapping'),         map: null },
 ]
 
 const cfg = reactive({
@@ -1183,13 +1185,13 @@ const cfg = reactive({
 
 // MQTT source data type constants + compatibility map
 const MQTT_SOURCE_TYPES = [
-  { value: '',       label: '— kein Typ erzwingen (Standard) —' },
+  { value: '',       label: t('adapters.bindingForm.noForcedType') },
   { value: 'string', label: 'string' },
   { value: 'int',    label: 'int' },
   { value: 'float',  label: 'float' },
   { value: 'bool',   label: 'bool' },
-  { value: 'json',   label: 'JSON — Schlüssel extrahieren' },
-  { value: 'xml',    label: 'XML — Element-Pfad extrahieren' },
+  { value: 'json',   label: t('adapters.bindingForm.jsonExtractKey') },
+  { value: 'xml',    label: t('adapters.bindingForm.xmlExtractPath') },
 ]
 
 // DataPoint type → which MQTT source types are ok / warn / bad
@@ -1241,10 +1243,10 @@ const ztHolidaysError = ref(null)
 
 // Date window UI state
 const WIN_MONTHS = [
-  { v: 1, l: 'Januar' }, { v: 2, l: 'Februar' }, { v: 3, l: 'März' },
-  { v: 4, l: 'April' }, { v: 5, l: 'Mai' }, { v: 6, l: 'Juni' },
-  { v: 7, l: 'Juli' }, { v: 8, l: 'August' }, { v: 9, l: 'September' },
-  { v: 10, l: 'Oktober' }, { v: 11, l: 'November' }, { v: 12, l: 'Dezember' },
+  { v: 1, l: t('common.months.january') }, { v: 2, l: t('common.months.february') }, { v: 3, l: t('common.months.march') },
+  { v: 4, l: t('common.months.april') }, { v: 5, l: t('common.months.may') }, { v: 6, l: t('common.months.june') },
+  { v: 7, l: t('common.months.july') }, { v: 8, l: t('common.months.august') }, { v: 9, l: t('common.months.september') },
+  { v: 10, l: t('common.months.october') }, { v: 11, l: t('common.months.november') }, { v: 12, l: t('common.months.december') },
 ]
 const winFrom = reactive({ type: 'fixed', month: 1,  day: 1,  sign: '+', offset: 0, name: '' })
 const winTo   = reactive({ type: 'fixed', month: 12, day: 31, sign: '+', offset: 0, name: '' })
@@ -1268,17 +1270,17 @@ const currentInstanceName = computed(() => {
 const selectedInstanceId = computed(() => props.initial?.adapter_instance_id || form.adapter_instance_id)
 
 const visibleTabs = computed(() => {
-  const tabs = [{ id: 'conn', label: 'Verbindung', badge: false }]
+  const tabs = [{ id: 'conn', label: t('logic.nodeConfig.tabs.connection'), badge: false }]
   if (selectedAdapterType.value && selectedAdapterType.value !== 'ZEITSCHALTUHR' && selectedAdapterType.value !== 'ANWESENHEITSSIMULATION') {
     if (selectedAdapterType.value === 'IOBROKER' && !showAdvancedTabs.value) return tabs
     const hasFormula = !!form.value_formula?.trim() || !!form.value_map_preset
-    tabs.push({ id: 'transform', label: 'Transformation', badge: hasFormula })
+    tabs.push({ id: 'transform', label: t('logic.nodeConfig.tabs.transform'), badge: hasFormula })
     const canUseFilter = selectedAdapterType.value === 'IOBROKER'
       || form.direction === 'DEST' || form.direction === 'BOTH'
     if (canUseFilter) {
       const hasFilter = form.throttle_value > 0 || form.send_on_change
         || (form.send_min_delta ?? 0) > 0 || (form.send_min_delta_pct ?? 0) > 0
-      tabs.push({ id: 'filter', label: 'Filter', badge: hasFilter })
+      tabs.push({ id: 'filter', label: t('logic.nodeConfig.tabs.filter'), badge: hasFilter })
     }
   }
   return tabs
@@ -1327,10 +1329,10 @@ const mqttTypeCompat = computed(() => {
   const compat = MQTT_TYPE_COMPAT[dpType]
   if (!compat) return null                             // UNKNOWN → no badge
   if (compat.ok.includes(sdt))
-    return { cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400', label: 'kompatibel' }
+    return { cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400', label: t('adapters.bindingForm.compatible') }
   if (compat.warn.includes(sdt))
-    return { cls: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400', label: 'Konvertierung nötig' }
-  return { cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400', label: 'inkompatibel' }
+    return { cls: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400', label: t('adapters.bindingForm.conversionRequired') }
+  return { cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400', label: t('adapters.bindingForm.incompatible') }
 })
 
 // ---------------------------------------------------------------------------
@@ -1447,7 +1449,7 @@ async function loadZsuHolidays() {
     const { data } = await adapterApi.getZsuHolidays(instanceId)
     ztHolidays.value = data
   } catch (e) {
-    ztHolidaysError.value = e.response?.data?.detail ?? 'Feiertage konnten nicht geladen werden'
+    ztHolidaysError.value = e.response?.data?.detail ?? t('adapters.bindingForm.errors.holidaysLoadFailed')
   } finally {
     ztHolidaysLoading.value = false
   }
@@ -1470,9 +1472,9 @@ async function mqttBrowse() {
   try {
     const res = await adapterApi.mqttBrowseTopics(form.adapter_instance_id)
     mqttBrowseTopics.value = res.data
-    if (res.data.length === 0) mqttBrowseError.value = 'Keine Topics empfangen – Broker erreichbar?'
+    if (res.data.length === 0) mqttBrowseError.value = t('adapters.bindingForm.errors.noTopicsReceived')
   } catch (e) {
-    mqttBrowseError.value = e.response?.data?.detail ?? 'Fehler beim Abrufen der Topics'
+    mqttBrowseError.value = e.response?.data?.detail ?? t('adapters.bindingForm.errors.topicsFetchFailed')
   } finally {
     mqttBrowseLoading.value = false
   }
@@ -1498,7 +1500,7 @@ function onIoBrokerStateInput() {
 async function browseIoBrokerStates() {
   const instanceId = selectedInstanceId.value
   if (!instanceId) {
-    iobrokerBrowseError.value = 'Bitte zuerst eine ioBroker-Instanz wählen'
+    iobrokerBrowseError.value = t('adapters.bindingForm.errors.selectIoBrokerInstanceFirst')
     return
   }
   iobrokerBrowseLoading.value = true
@@ -1506,9 +1508,9 @@ async function browseIoBrokerStates() {
   try {
     const { data } = await adapterApi.iobrokerBrowseStates(instanceId, cfg.state_id?.trim() ?? '', 50)
     iobrokerStates.value = data
-    if (data.length === 0) iobrokerBrowseError.value = 'Keine States gefunden'
+    if (data.length === 0) iobrokerBrowseError.value = t('adapters.bindingForm.errors.noStatesFound')
   } catch (e) {
-    iobrokerBrowseError.value = e.response?.data?.detail ?? 'ioBroker-States konnten nicht geladen werden'
+    iobrokerBrowseError.value = e.response?.data?.detail ?? t('adapters.bindingForm.errors.ioBrokerStatesLoadFailed')
   } finally {
     iobrokerBrowseLoading.value = false
   }
@@ -1546,10 +1548,10 @@ async function snmpWalk(append = false) {
     } else {
       snmpWalkResults.value = data
     }
-    if (snmpWalkResults.value.length === 0) snmpWalkError.value = 'Keine OIDs gefunden'
+    if (snmpWalkResults.value.length === 0) snmpWalkError.value = t('adapters.bindingForm.errors.noOidsFound')
     snmpWalkHasMore.value = data.length === 50
   } catch (e) {
-    snmpWalkError.value = e.response?.data?.detail ?? 'SNMP Walk fehlgeschlagen'
+    snmpWalkError.value = e.response?.data?.detail ?? t('adapters.bindingForm.errors.snmpWalkFailed')
   } finally {
     snmpWalkLoading.value = false
   }
@@ -1568,7 +1570,7 @@ function onValueMapCustomInput() {
   try {
     JSON.parse(form.value_map_custom)
   } catch (e) {
-    form.value_map_custom_error = `Ungültiges JSON: ${e.message}`
+    form.value_map_custom_error = t('adapters.bindingForm.errors.invalidJson', { msg: e.message })
   }
 }
 
@@ -1590,7 +1592,7 @@ async function loadMqttSample() {
       onMqttXmlSampleInput()
     }
   } catch (e) {
-    const msg = e.response?.data?.detail ?? 'Kein Payload empfangen'
+    const msg = e.response?.data?.detail ?? t('adapters.bindingForm.errors.noPayloadReceived')
     if (cfg.source_data_type === 'json') mqttJsonParseError.value = msg
     if (cfg.source_data_type === 'xml')  mqttXmlParseError.value  = msg
   } finally {
@@ -1778,12 +1780,12 @@ function onMqttXmlSampleInput() {
   const doc = parser.parseFromString(s, 'application/xml')
   const parseErr = doc.querySelector('parsererror')
   if (parseErr) {
-    mqttXmlParseError.value = `Kein gültiges XML: ${parseErr.textContent.split('\n')[0].trim()}`
+    mqttXmlParseError.value = t('adapters.bindingForm.errors.invalidXml', { msg: parseErr.textContent.split('\n')[0].trim() })
     return
   }
   mqttXmlElements.value = collectXmlLeafPaths(doc.documentElement, '')
   if (mqttXmlElements.value.length === 0)
-    mqttXmlParseError.value = 'Keine Kind-Elemente gefunden'
+    mqttXmlParseError.value = t('adapters.bindingForm.errors.noChildElementsFound')
 }
 
 // Flatten all leaf paths from a JSON object/array to dot-notation (max depth 6)
@@ -1820,10 +1822,10 @@ function onMqttJsonSampleInput() {
     if (obj !== null && typeof obj === 'object') {
       mqttJsonKeys.value = _flattenJsonLeaves(obj)
     } else {
-      mqttJsonParseError.value = 'Sample muss ein JSON-Objekt oder Array sein'
+      mqttJsonParseError.value = t('adapters.bindingForm.errors.sampleMustBeJsonObjectOrArray')
     }
   } catch (e) {
-    mqttJsonParseError.value = `Kein gültiges JSON: ${e.message}`
+    mqttJsonParseError.value = t('adapters.bindingForm.errors.invalidJson', { msg: e.message })
   }
 }
 
@@ -1983,7 +1985,7 @@ async function submit() {
       })
     } else {
       if (!form.adapter_instance_id) {
-        error.value = 'Bitte eine Adapter-Instanz wählen'; saving.value = false; return
+        error.value = t('adapters.bindingForm.errors.selectAdapterInstance'); saving.value = false; return
       }
       await dpApi.createBinding(props.dpId, {
         adapter_instance_id: form.adapter_instance_id,
@@ -1992,7 +1994,7 @@ async function submit() {
     }
     emit('save')
   } catch (e) {
-    error.value = e.response?.data?.detail ?? 'Fehler beim Speichern'
+    error.value = e.response?.data?.detail ?? t('common.saveError')
   } finally {
     saving.value = false
   }

--- a/gui/src/components/logic/NodeConfigPanel.vue
+++ b/gui/src/components/logic/NodeConfigPanel.vue
@@ -77,7 +77,7 @@
 
           <div class="section-label mt-1">{{ $t('logic.nodeConfig.transform.mapSection') }}</div>
           <div class="form-group">
-            <label class="label">{{ $t('logic.nodeConfig.transform.mapSection') }} <span class="text-slate-500 font-normal text-xs">(optional)</span></label>
+            <label class="label">{{ $t('logic.nodeConfig.transform.mapSection') }} <span class="text-slate-500 font-normal text-xs">{{ $t('logic.nodeConfig.common.optional') }}</span></label>
             <select v-model="valueMapPreset" @change="onValueMapPresetChange" class="input text-xs"
               data-testid="value-map-preset">
               <option v-for="p in VALUE_MAP_PRESETS" :key="p.key" :value="p.key">{{ p.label }}</option>
@@ -289,7 +289,7 @@
 
         <!-- Standard request fields -->
         <div class="form-group">
-          <label class="label">URL</label>
+          <label class="label">{{ $t('logic.nodeConfig.apiClient.urlLabel') }}</label>
           <input v-model="localData.url" type="text" class="input text-sm" @change="emitUpdate"
             data-testid="api-client-url" />
         </div>
@@ -301,7 +301,7 @@
           </select>
         </div>
         <div class="form-group">
-          <label class="label">Request Content-Type</label>
+          <label class="label">{{ $t('logic.nodeConfig.apiClient.requestContentType') }}</label>
           <select v-model="localData.content_type" class="input text-sm" @change="emitUpdate">
             <option v-for="ct in ['application/json','text/plain','application/x-www-form-urlencoded']" :key="ct" :value="ct">{{ ct }}</option>
           </select>
@@ -335,9 +335,9 @@
           <select v-model="localData.auth_type" class="input text-sm" @change="emitUpdate"
             data-testid="api-client-auth-type">
             <option value="none">{{ $t('logic.nodeConfig.apiClient.authNone') }}</option>
-            <option value="basic">Basic Auth</option>
-            <option value="digest">Digest Auth</option>
-            <option value="bearer">Bearer Token</option>
+            <option value="basic">{{ $t('logic.nodeConfig.apiClient.authBasic') }}</option>
+            <option value="digest">{{ $t('logic.nodeConfig.apiClient.authDigest') }}</option>
+            <option value="bearer">{{ $t('logic.nodeConfig.apiClient.authBearer') }}</option>
           </select>
         </div>
         <template v-if="localData.auth_type === 'basic' || localData.auth_type === 'digest'">
@@ -354,7 +354,7 @@
         </template>
         <template v-if="localData.auth_type === 'bearer'">
           <div class="form-group" data-testid="api-client-auth-bearer">
-            <label class="label">Bearer Token</label>
+            <label class="label">{{ $t('logic.nodeConfig.apiClient.authBearer') }}</label>
             <input v-model="localData.auth_token" type="password" class="input text-sm"
               autocomplete="new-password" @change="emitUpdate" />
           </div>
@@ -511,10 +511,10 @@
           <!-- Legacy single-path: show upgrade banner -->
           <template v-if="localData.xml_path && !xmlPaths.length">
             <div class="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300">
-              <p class="font-semibold mb-1">Legacy-Konfiguration</p>
-              <p class="text-amber-400/80 mb-2">Pfad: <code class="font-mono">{{ localData.xml_path }}</code></p>
+              <p class="font-semibold mb-1">{{ $t('logic.nodeConfig.extractor.legacyConfig') }}</p>
+              <p class="text-amber-400/80 mb-2">{{ $t('logic.nodeConfig.extractor.pathLabel') }}: <code class="font-mono">{{ localData.xml_path }}</code></p>
               <button @click="migrateXmlToMultiPath" class="btn btn-sm bg-amber-600 hover:bg-amber-500 text-white text-xs px-2 py-1 rounded">
-                Zu mehreren Ausgängen upgraden
+                {{ $t('logic.nodeConfig.extractor.upgradeToMultipleOutputs') }}
               </button>
             </div>
           </template>
@@ -522,10 +522,10 @@
           <!-- Multi-path path picker dropdown (one shared, fills active row) -->
           <div v-if="extractorPaths.length" class="form-group">
             <label class="label">
-              Pfad wählen<span v-if="activeExtractorRow !== null" class="text-teal-400"> → Ausgang {{ activeExtractorRow + 1 }}</span>
+              {{ $t('logic.nodeConfig.extractor.choosePath') }}<span v-if="activeExtractorRow !== null" class="text-teal-400"> → {{ $t('logic.nodeConfig.extractor.outputN', { n: activeExtractorRow + 1 }) }}</span>
             </label>
             <select @change="onExtractorPathSelect" class="input text-sm" data-testid="extractor-path-select">
-              <option value="">— Pfad wählen —</option>
+              <option value="">{{ $t('logic.nodeConfig.extractor.pathPlaceholder') }}</option>
               <option v-for="p in extractorPaths" :key="p" :value="p">{{ p }}</option>
             </select>
           </div>
@@ -533,11 +533,11 @@
           <!-- Output rows -->
           <div class="form-group">
             <div class="flex items-center justify-between mb-1">
-              <span class="section-label">Ausgänge ({{ xmlPaths.length }})</span>
+              <span class="section-label">{{ $t('logic.nodeConfig.extractor.outputsCount', { n: xmlPaths.length }) }}</span>
               <button
                 @click="addXmlPath"
                 class="w-6 h-6 flex items-center justify-center rounded text-teal-400 hover:bg-teal-400/10 font-bold text-lg leading-none"
-                title="Ausgang hinzufügen"
+                :title="$t('logic.nodeConfig.extractor.addOutput')"
               >+</button>
             </div>
 
@@ -552,12 +552,12 @@
                   :value="entry.label"
                   @input="updateXmlPath(i, 'label', $event.target.value)"
                   class="input text-xs flex-1"
-                  placeholder="Bezeichnung"
+                  :placeholder="$t('logic.nodeConfig.extractor.labelPlaceholder')"
                 />
                 <button
                   @click="removeXmlPath(i)"
                   class="extractor-output-remove w-5 h-5 flex items-center justify-center rounded hover:bg-red-400/10 text-base leading-none shrink-0"
-                  title="Ausgang entfernen"
+                  :title="$t('logic.nodeConfig.extractor.removeOutput')"
                 >−</button>
               </div>
               <input
@@ -567,7 +567,7 @@
                 @blur="activeExtractorRow = null"
                 class="input text-xs font-mono w-full"
                 :class="activeExtractorRow === i ? 'ring-1 ring-teal-500/60' : ''"
-                placeholder="z.B. .//temperature"
+                :placeholder="$t('logic.nodeConfig.extractor.xmlPathPlaceholder')"
                 data-testid="extractor-path-input"
               />
               <p v-if="xmlPathPreview(i) !== null" class="text-xs text-teal-400">
@@ -576,7 +576,7 @@
             </div>
 
             <p v-if="!xmlPaths.length && !localData.xml_path" class="text-xs text-slate-500 mt-2 text-center py-2">
-              Klicke <strong>+</strong> um Ausgänge hinzuzufügen.
+              {{ $t('logic.nodeConfig.extractor.clickPlusToAddOutputs') }}
             </p>
           </div>
         </template>
@@ -605,7 +605,7 @@
           <div class="form-group">
             <label class="label">{{ $t('logic.nodeConfig.substr.searchLabel') }}</label>
             <input v-model="localData.search" @change="emitUpdate" class="input text-sm font-mono"
-              placeholder="z.B. :" data-testid="substr-search" />
+              :placeholder="$t('logic.nodeConfig.substr.searchPlaceholder')" data-testid="substr-search" />
           </div>
           <div class="form-group">
             <label class="label">{{ $t('logic.nodeConfig.substr.occurrenceLabel') }}</label>
@@ -621,12 +621,12 @@
           <div class="form-group">
             <label class="label">{{ $t('logic.nodeConfig.substr.startMarker') }}</label>
             <input v-model="localData.start_marker" @change="emitUpdate" class="input text-sm font-mono"
-              placeholder="z.B. [" data-testid="substr-start-marker" />
+              :placeholder="$t('logic.nodeConfig.substr.startMarkerPlaceholder')" data-testid="substr-start-marker" />
           </div>
           <div class="form-group">
             <label class="label">{{ $t('logic.nodeConfig.substr.endMarker') }}</label>
             <input v-model="localData.end_marker" @change="emitUpdate" class="input text-sm font-mono"
-              placeholder="z.B. ]" data-testid="substr-end-marker" />
+              :placeholder="$t('logic.nodeConfig.substr.endMarkerPlaceholder')" data-testid="substr-end-marker" />
           </div>
         </template>
 
@@ -655,7 +655,7 @@
               </a>
             </label>
             <input v-model="localData.pattern" @change="emitUpdate" class="input text-sm font-mono"
-              placeholder="z.B. (\d+\.\d+)" data-testid="substr-pattern" />
+              :placeholder="$t('logic.nodeConfig.substr.regexPlaceholder')" data-testid="substr-pattern" />
           </div>
           <div class="form-group">
             <label class="label">{{ $t('logic.nodeConfig.substr.flags') }}</label>
@@ -739,7 +739,7 @@
 
           <!-- Name -->
           <div class="form-group">
-            <label class="label">Name</label>
+            <label class="label">{{ $t('logic.nodeConfig.ical.nameLabel') }}</label>
             <input :value="flt.name" @input="icalUpdateFilter(i, 'name', $event.target.value)"
               @change="emitUpdate" type="text" class="input text-sm"
               :placeholder="$t('logic.nodeConfig.ical.namePlaceholder')" :data-testid="`ical-filter-name-${i}`" />
@@ -766,9 +766,9 @@
 
           <!-- Per-field patterns -->
           <div v-for="field in [
-              { key: 'summary_pattern',     label: 'Summary',     placeholder: 'z.B. Restmüll' },
-              { key: 'location_pattern',    label: 'Location',    placeholder: 'z.B. Strasse' },
-              { key: 'description_pattern', label: 'Description', placeholder: 'z.B. Biotonne' },
+              { key: 'summary_pattern',     label: t('logic.nodeConfig.ical.summaryLabel'),     placeholder: t('logic.nodeConfig.ical.summaryPlaceholder') },
+              { key: 'location_pattern',    label: t('logic.nodeConfig.ical.locationLabel'),    placeholder: t('logic.nodeConfig.ical.locationPlaceholder') },
+              { key: 'description_pattern', label: t('logic.nodeConfig.ical.descriptionLabel'), placeholder: t('logic.nodeConfig.ical.descriptionPlaceholder') },
             ]" :key="field.key" class="form-group">
             <label class="label text-slate-400">{{ field.label }}</label>
             <input
@@ -862,11 +862,11 @@ const valueMapCustomError = ref('')
 // ── Value Map Presets ──────────────────────────────────────────────────────
 const VALUE_MAP_PRESETS = computed(() => [
   { key: '',            label: t('logic.nodeConfig.transform.noMapping'),            map: null },
-  { key: 'num_invert',  label: '0 ↔ 1 (numerisch invertieren)',                      map: { '0': '1', '1': '0' } },
-  { key: 'bool_onoff',  label: 'true/false → on/off',                                map: { 'true': 'on', 'false': 'off' } },
-  { key: 'onoff_bool',  label: 'on/off → true/false',                                map: { 'on': 'true', 'off': 'false' } },
-  { key: 'num_onoff',   label: '0/1 → off/on',                                       map: { '0': 'off', '1': 'on' } },
-  { key: 'onoff_num',   label: 'off/on → 0/1',                                       map: { 'off': '0', 'on': '1' } },
+  { key: 'num_invert',  label: t('logic.nodeConfig.transform.mapPresetNumInvert'),   map: { '0': '1', '1': '0' } },
+  { key: 'bool_onoff',  label: t('logic.nodeConfig.transform.mapPresetBoolOnOff'),   map: { 'true': 'on', 'false': 'off' } },
+  { key: 'onoff_bool',  label: t('logic.nodeConfig.transform.mapPresetOnOffBool'),   map: { 'on': 'true', 'off': 'false' } },
+  { key: 'num_onoff',   label: t('logic.nodeConfig.transform.mapPresetNumOnOff'),    map: { '0': 'off', '1': 'on' } },
+  { key: 'onoff_num',   label: t('logic.nodeConfig.transform.mapPresetOnOffNum'),    map: { 'off': '0', 'on': '1' } },
   { key: 'custom',      label: t('logic.nodeConfig.transform.customJson'),            map: null },
 ])
 
@@ -1275,7 +1275,7 @@ function _saveXmlPaths(paths) {
 
 function addXmlPath() {
   const paths = xmlPaths.value.slice()
-  paths.push({ label: `Wert ${paths.length + 1}`, path: '' })
+  paths.push({ label: t('logic.nodeConfig.extractor.valueN', { n: paths.length + 1 }), path: '' })
   _saveXmlPaths(paths)
   activeExtractorRow.value = paths.length - 1
 }
@@ -1309,7 +1309,7 @@ function xmlPathPreview(i) {
 function migrateXmlToMultiPath() {
   const legacyPath = (localData.value.xml_path || '').trim()
   if (!legacyPath) return
-  localData.value.xml_paths = JSON.stringify([{ label: 'Wert 1', path: legacyPath }])
+  localData.value.xml_paths = JSON.stringify([{ label: t('logic.nodeConfig.extractor.valueN', { n: 1 }), path: legacyPath }])
   localData.value.xml_path = ''
   emitUpdate()
 }
@@ -1486,7 +1486,6 @@ function onExtractorPathSelect(e) {
   const pathList = isJson ? jsonPaths.value : xmlPaths.value
   const updateFn = isJson ? updateJsonPath : updateXmlPath
   const saveFn   = isJson ? _saveJsonPaths : _saveXmlPaths
-  const labelKey = isJson ? 'json_path' : 'xml_path'
 
   // Fill the active row, or last row, or add a new row
   let target = activeExtractorRow.value
@@ -1498,7 +1497,7 @@ function onExtractorPathSelect(e) {
     activeExtractorRow.value = target
   } else {
     // No rows yet — add one
-    saveFn([{ label: 'Wert 1', path }])
+    saveFn([{ label: t('logic.nodeConfig.extractor.valueN', { n: 1 }), path }])
     activeExtractorRow.value = 0
   }
   e.target.value = ''

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -269,6 +269,80 @@
       "saveResult": "{created} erstellt, {removed} entfernt",
       "saveResultErrors": "{created} erstellt, {removed} entfernt ({errors} Fehler)",
       "saveFailed": "Speichern fehlgeschlagen"
+    },
+    "bindingForm": {
+      "adapterInstanceLabel": "Adapter-Instanz *",
+      "selectInstance": "Instanz wählen …",
+      "directionLabel": "Richtung *",
+      "directionRead": "Lesen (von Adapter)",
+      "directionWrite": "Schreiben (to adapter)",
+      "directionReadWrite": "Lesen/Schreiben (von/auf Adapter)",
+      "timerReadOnlyHint": "Die Zeitschaltuhr ist eine reine Quelle — nur Lesen möglich.",
+      "groupAddressLabel": "Gruppenadresse *",
+      "groupAddressPlaceholder": "z.B. 1/2/3 oder Name suchen …",
+      "selectDpt": "DPT wählen …",
+      "noValueMapping": "— keine Wertzuordnung —",
+      "valueMapNumInvert": "0 ↔ 1 (numerisch invertieren)",
+      "valueMapBoolOnOff": "true/false → on/off",
+      "valueMapOnOffBool": "on/off → true/false",
+      "valueMapNumOnOff": "0/1 → off/on",
+      "valueMapOnOffNum": "off/on → 0/1",
+      "customValueMapping": "Benutzerdefiniert (JSON) …",
+      "noForcedType": "— kein Typ erzwingen (Standard) —",
+      "jsonExtractKey": "JSON — Schlüssel extrahieren",
+      "xmlExtractPath": "XML — Element-Pfad extrahieren",
+      "compatible": "kompatibel",
+      "conversionRequired": "Konvertierung nötig",
+      "incompatible": "inkompatibel",
+      "errors": {
+        "holidaysLoadFailed": "Feiertage konnten nicht geladen werden",
+        "noTopicsReceived": "Keine Topics empfangen – Broker erreichbar?",
+        "topicsFetchFailed": "Fehler beim Abrufen der Topics",
+        "selectIoBrokerInstanceFirst": "Bitte zuerst eine ioBroker-Instanz wählen",
+        "noStatesFound": "Keine States gefunden",
+        "ioBrokerStatesLoadFailed": "ioBroker-States konnten nicht geladen werden",
+        "noOidsFound": "Keine OIDs gefunden",
+        "snmpWalkFailed": "SNMP Walk fehlgeschlagen",
+        "invalidJson": "Ungültiges JSON: {msg}",
+        "noPayloadReceived": "Kein Payload empfangen",
+        "invalidXml": "Kein gültiges XML: {msg}",
+        "noChildElementsFound": "Keine Kind-Elemente gefunden",
+        "sampleMustBeJsonObjectOrArray": "Sample muss ein JSON-Objekt oder Array sein",
+        "selectAdapterInstance": "Bitte eine Adapter-Instanz wählen"
+      },
+      "knxSection": "KNX Binding",
+      "dptLabel": "DPT *",
+      "respondToReadLabel": "Antworte auf Leseanfragen",
+      "respondToReadHint": "Sendet den aktuellen Wert als GroupValueResponse wenn eine Leseanfrage eingeht.",
+      "respondToReadPersistHint": "Erfordert aktiviertes „Letzten Wert speichern\" am Objekt.",
+      "modbusSection": "Modbus Binding",
+      "addressLabel": "Adresse *",
+      "registerTypeLabel": "Registertyp *",
+      "dataFormatLabel": "Datenformat *",
+      "unitIdLabel": "Unit ID",
+      "defaultN": "Standard: {n}",
+      "registerCountLabel": "Anz. Register",
+      "scaleLabel": "Skalierung",
+      "intervalSecondsLabel": "Intervall (s)",
+      "byteOrderLabel": "Byte-Reihenfolge",
+      "wordOrderLabel": "Word-Reihenfolge",
+      "mqttSection": "MQTT Binding",
+      "topicLabel": "Topic *",
+      "topicPlaceholder": "z.B. haus/wohnzimmer/temperatur",
+      "scanning": "Scannen …",
+      "browse": "Durchsuchen",
+      "topicHint": "Lesen/Lesen+Schreiben: abonniertes Topic; Schreiben: Publish-Topic",
+      "publishTopicLabel": "Publish-Topic",
+      "publishTopicPlaceholder": "z.B. …/set",
+      "publishTopicHint": "Topic für Schreiben — leer = Topic wird verwendet",
+      "retainLabel": "Retain",
+      "retainHint": "Broker speichert letzten Wert",
+      "payloadTemplateLabel": "Payload-Template",
+      "payloadTemplatePlaceholder": "z.B. {\"value\": \"###DP###\", \"unit\": \"°C\"}",
+      "payloadTemplateHint": "###DP### wird durch den Datenpunktwert ersetzt. Leer = Wert direkt als Payload.",
+      "sourceDataTypeLabel": "Quell-Datentyp",
+      "sourceDataTypeHint": "Wie der eingehende Payload interpretiert wird.",
+      "objectTypeLabel": "Objekt-Typ"
     }
   },
   "history": {
@@ -626,7 +700,12 @@
         "mapJsonHint": "JSON-Objekt — beliebig viele Einträge möglich.",
         "mapAfterFormula": "Wird nach der Formel angewendet.",
         "noMapping": "— keine Wertzuordnung —",
-        "customJson": "Benutzerdefiniert (JSON) …"
+        "customJson": "Benutzerdefiniert (JSON) …",
+        "mapPresetNumInvert": "0 ↔ 1 (numerisch invertieren)",
+        "mapPresetBoolOnOff": "true/false → on/off",
+        "mapPresetOnOffBool": "on/off → true/false",
+        "mapPresetNumOnOff": "0/1 → off/on",
+        "mapPresetOnOffNum": "off/on → 0/1"
       },
       "filter": {
         "timeSection": "Zeitlicher Filter",
@@ -738,7 +817,12 @@
         "authType": "Typ",
         "authNone": "Keine",
         "username": "Benutzername",
-        "password": "Passwort"
+        "password": "Passwort",
+        "urlLabel": "URL",
+        "requestContentType": "Request Content-Type",
+        "authBasic": "Basic Auth",
+        "authDigest": "Digest Auth",
+        "authBearer": "Bearer Token"
       },
       "stringConcat": {
         "inputCount": "Anzahl Eingänge",
@@ -754,7 +838,19 @@
         "selectPath": "Pfad aus Daten wählen",
         "pathPlaceholder": "— Pfad wählen —",
         "jsonPath": "JSON-Pfad",
-        "jsonPathPlaceholder": "z.B. data.temperature"
+        "jsonPathPlaceholder": "z.B. data.temperature",
+        "legacyConfig": "Legacy-Konfiguration",
+        "pathLabel": "Pfad",
+        "upgradeToMultipleOutputs": "Zu mehreren Ausgängen upgraden",
+        "choosePath": "Pfad wählen",
+        "outputN": "Ausgang {n}",
+        "addOutput": "Ausgang hinzufügen",
+        "removeOutput": "Ausgang entfernen",
+        "xmlPathPlaceholder": "z.B. .//temperature",
+        "clickPlusToAddOutputs": "Klicke + um Ausgänge hinzuzufügen.",
+        "valueN": "Wert {n}",
+        "outputsCount": "Ausgänge ({n})",
+        "labelPlaceholder": "Bezeichnung"
       },
       "substr": {
         "modeLabel": "Modus",
@@ -779,7 +875,11 @@
         "group": "Capture-Gruppe (0 = gesamter Treffer)",
         "testSection": "Test-Eingabe",
         "testPlaceholder": "Teststring eingeben oder Graph ausführen…",
-        "noMatch": "↳ kein Treffer"
+        "noMatch": "↳ kein Treffer",
+        "searchPlaceholder": "z.B. :",
+        "startMarkerPlaceholder": "z.B. [",
+        "endMarkerPlaceholder": "z.B. ]",
+        "regexPlaceholder": "z.B. (\\d+\\.\\d+)"
       },
       "ical": {
         "urlLabel": "iCal-URL",
@@ -798,9 +898,19 @@
         "ignoreEmpty": "(leer = ignorieren)",
         "reSyntax": "Python re-Syntax. Leer = Feld wird ignoriert.",
         "caseSensitive": "Gross-/Kleinschreibung beachten",
-        "outputs": "Ausgänge: f{i}_array · f{i}_next_date · f{i}_tomorrow · f{i}_today"
+        "outputs": "Ausgänge: f{i}_array · f{i}_next_date · f{i}_tomorrow · f{i}_today",
+        "nameLabel": "Name",
+        "summaryLabel": "Summary",
+        "locationLabel": "Location",
+        "descriptionLabel": "Description",
+        "summaryPlaceholder": "z.B. Restmüll",
+        "locationPlaceholder": "z.B. Strasse",
+        "descriptionPlaceholder": "z.B. Biotonne"
       },
-      "invalidJson": "Ungültiges JSON: {msg}"
+      "invalidJson": "Ungültiges JSON: {msg}",
+      "common": {
+        "optional": "(optional)"
+      }
     }
   },
   "settings": {
@@ -1128,7 +1238,21 @@
     "hierarchySearchPlaceholder": "Knoten suchen …",
     "searching": "Suche …",
     "iconPickerNoMatch": "Keine Treffer",
-    "iconPickerNoIcons": "Keine Icons importiert"
+    "iconPickerNoIcons": "Keine Icons importiert",
+    "months": {
+      "january": "Januar",
+      "february": "Februar",
+      "march": "März",
+      "april": "April",
+      "may": "Mai",
+      "june": "Juni",
+      "july": "Juli",
+      "august": "August",
+      "september": "September",
+      "october": "Oktober",
+      "november": "November",
+      "december": "Dezember"
+    }
   },
   "hierarchy": {
     "title": "Gerätestruktur",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -269,6 +269,80 @@
       "saveResult": "{created} created, {removed} removed",
       "saveResultErrors": "{created} created, {removed} removed ({errors} errors)",
       "saveFailed": "Save failed"
+    },
+    "bindingForm": {
+      "adapterInstanceLabel": "Adapter instance *",
+      "selectInstance": "Select instance …",
+      "directionLabel": "Direction *",
+      "directionRead": "Read (from adapter)",
+      "directionWrite": "Write (to adapter)",
+      "directionReadWrite": "Read/Write (from/to adapter)",
+      "timerReadOnlyHint": "The timer is a read-only source.",
+      "groupAddressLabel": "Group address *",
+      "groupAddressPlaceholder": "e.g. 1/2/3 or search name …",
+      "selectDpt": "Select DPT …",
+      "noValueMapping": "— no value mapping —",
+      "valueMapNumInvert": "0 ↔ 1 (invert numeric)",
+      "valueMapBoolOnOff": "true/false → on/off",
+      "valueMapOnOffBool": "on/off → true/false",
+      "valueMapNumOnOff": "0/1 → off/on",
+      "valueMapOnOffNum": "off/on → 0/1",
+      "customValueMapping": "Custom (JSON) …",
+      "noForcedType": "— do not force type (default) —",
+      "jsonExtractKey": "JSON — extract key",
+      "xmlExtractPath": "XML — extract element path",
+      "compatible": "compatible",
+      "conversionRequired": "conversion required",
+      "incompatible": "incompatible",
+      "errors": {
+        "holidaysLoadFailed": "Could not load holidays",
+        "noTopicsReceived": "No topics received – broker reachable?",
+        "topicsFetchFailed": "Failed to fetch topics",
+        "selectIoBrokerInstanceFirst": "Please select an ioBroker instance first",
+        "noStatesFound": "No states found",
+        "ioBrokerStatesLoadFailed": "Could not load ioBroker states",
+        "noOidsFound": "No OIDs found",
+        "snmpWalkFailed": "SNMP walk failed",
+        "invalidJson": "Invalid JSON: {msg}",
+        "noPayloadReceived": "No payload received",
+        "invalidXml": "Invalid XML: {msg}",
+        "noChildElementsFound": "No child elements found",
+        "sampleMustBeJsonObjectOrArray": "Sample must be a JSON object or array",
+        "selectAdapterInstance": "Please select an adapter instance"
+      },
+      "knxSection": "KNX binding",
+      "dptLabel": "DPT *",
+      "respondToReadLabel": "Respond to read requests",
+      "respondToReadHint": "Sends the current value as GroupValueResponse when a read request arrives.",
+      "respondToReadPersistHint": "Requires enabled “Persist last value” on the object.",
+      "modbusSection": "Modbus binding",
+      "addressLabel": "Address *",
+      "registerTypeLabel": "Register type *",
+      "dataFormatLabel": "Data format *",
+      "unitIdLabel": "Unit ID",
+      "defaultN": "Default: {n}",
+      "registerCountLabel": "Register count",
+      "scaleLabel": "Scale",
+      "intervalSecondsLabel": "Interval (s)",
+      "byteOrderLabel": "Byte order",
+      "wordOrderLabel": "Word order",
+      "mqttSection": "MQTT binding",
+      "topicLabel": "Topic *",
+      "topicPlaceholder": "e.g. house/livingroom/temperature",
+      "scanning": "Scanning …",
+      "browse": "Browse",
+      "topicHint": "Read/Read+Write: subscribed topic; Write: publish topic",
+      "publishTopicLabel": "Publish topic",
+      "publishTopicPlaceholder": "e.g. …/set",
+      "publishTopicHint": "Topic for writing — empty uses main topic",
+      "retainLabel": "Retain",
+      "retainHint": "Broker stores last value",
+      "payloadTemplateLabel": "Payload template",
+      "payloadTemplatePlaceholder": "e.g. {\"value\": \"###DP###\", \"unit\": \"°C\"}",
+      "payloadTemplateHint": "###DP### is replaced by datapoint value. Empty = direct payload value.",
+      "sourceDataTypeLabel": "Source data type",
+      "sourceDataTypeHint": "How incoming payload is interpreted.",
+      "objectTypeLabel": "Object type"
     }
   },
   "history": {
@@ -626,7 +700,12 @@
         "mapJsonHint": "JSON object — any number of entries.",
         "mapAfterFormula": "Applied after the formula.",
         "noMapping": "— no value mapping —",
-        "customJson": "Custom (JSON) …"
+        "customJson": "Custom (JSON) …",
+        "mapPresetNumInvert": "0 ↔ 1 (invert numeric)",
+        "mapPresetBoolOnOff": "true/false → on/off",
+        "mapPresetOnOffBool": "on/off → true/false",
+        "mapPresetNumOnOff": "0/1 → off/on",
+        "mapPresetOnOffNum": "off/on → 0/1"
       },
       "filter": {
         "timeSection": "Time Filter",
@@ -738,7 +817,12 @@
         "authType": "Type",
         "authNone": "None",
         "username": "Username",
-        "password": "Password"
+        "password": "Password",
+        "urlLabel": "URL",
+        "requestContentType": "Request Content-Type",
+        "authBasic": "Basic Auth",
+        "authDigest": "Digest Auth",
+        "authBearer": "Bearer token"
       },
       "stringConcat": {
         "inputCount": "Number of inputs",
@@ -754,7 +838,19 @@
         "selectPath": "Select path from data",
         "pathPlaceholder": "— Select path —",
         "jsonPath": "JSON path",
-        "jsonPathPlaceholder": "e.g. data.temperature"
+        "jsonPathPlaceholder": "e.g. data.temperature",
+        "legacyConfig": "Legacy configuration",
+        "pathLabel": "Path",
+        "upgradeToMultipleOutputs": "Upgrade to multiple outputs",
+        "choosePath": "Select path",
+        "outputN": "Output {n}",
+        "addOutput": "Add output",
+        "removeOutput": "Remove output",
+        "xmlPathPlaceholder": "e.g. .//temperature",
+        "clickPlusToAddOutputs": "Click + to add outputs.",
+        "valueN": "Value {n}",
+        "outputsCount": "Outputs ({n})",
+        "labelPlaceholder": "Label"
       },
       "substr": {
         "modeLabel": "Mode",
@@ -779,7 +875,11 @@
         "group": "Capture group (0 = full match)",
         "testSection": "Test input",
         "testPlaceholder": "Enter test string or run graph…",
-        "noMatch": "↳ no match"
+        "noMatch": "↳ no match",
+        "searchPlaceholder": "e.g. :",
+        "startMarkerPlaceholder": "e.g. [",
+        "endMarkerPlaceholder": "e.g. ]",
+        "regexPlaceholder": "e.g. (\\d+\\.\\d+)"
       },
       "ical": {
         "urlLabel": "iCal URL",
@@ -798,9 +898,19 @@
         "ignoreEmpty": "(empty = ignore)",
         "reSyntax": "Python re syntax. Empty = field is ignored.",
         "caseSensitive": "Case sensitive",
-        "outputs": "Outputs: f{i}_array · f{i}_next_date · f{i}_tomorrow · f{i}_today"
+        "outputs": "Outputs: f{i}_array · f{i}_next_date · f{i}_tomorrow · f{i}_today",
+        "nameLabel": "Name",
+        "summaryLabel": "Summary",
+        "locationLabel": "Location",
+        "descriptionLabel": "Description",
+        "summaryPlaceholder": "e.g. residual waste",
+        "locationPlaceholder": "e.g. street",
+        "descriptionPlaceholder": "e.g. organic bin"
       },
-      "invalidJson": "Invalid JSON: {msg}"
+      "invalidJson": "Invalid JSON: {msg}",
+      "common": {
+        "optional": "(optional)"
+      }
     }
   },
   "settings": {
@@ -1128,7 +1238,21 @@
     "hierarchySearchPlaceholder": "Search nodes …",
     "searching": "Searching …",
     "iconPickerNoMatch": "No results",
-    "iconPickerNoIcons": "No icons imported"
+    "iconPickerNoIcons": "No icons imported",
+    "months": {
+      "january": "January",
+      "february": "February",
+      "march": "March",
+      "april": "April",
+      "may": "May",
+      "june": "June",
+      "july": "July",
+      "august": "August",
+      "september": "September",
+      "october": "October",
+      "november": "November",
+      "december": "December"
+    }
   },
   "hierarchy": {
     "title": "Device structure",


### PR DESCRIPTION
## Summary
- migrate remaining hardcoded user-facing strings to i18n in gui/frontend follow-up scope
- add missing locale keys in `de.json` and `en.json` for touched UI areas
- keep behavior unchanged, only translation wiring and labels/messages

## Validation
- npm --prefix gui run build
- npm --prefix frontend run build

Closes #536