### PR TITLE
[Codex] fix(history): deny unknown page IDs in access check

### DIFF
--- a/obs/api/v1/history.py
+++ b/obs/api/v1/history.py
@@ -57,6 +57,20 @@ def _parse_ts(s: str | None, default: datetime) -> datetime:
         )
 
 
+async def _resolve_page_access(db: Database, node_id: str) -> str:
+    """Traversiert die parent_id-Kette und gibt das effektive Access-Level zurück."""
+    current_id: str | None = node_id
+    while current_id:
+        async with db.conn.execute("SELECT access, parent_id FROM visu_nodes WHERE id = ?", (current_id,)) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return "private"  # Unbekannter Knoten → sicher ablehnen
+        if row["access"] is not None:
+            return row["access"]
+        current_id = row["parent_id"]
+    return "public"
+
+
 async def _check_history_access(
     request: Request,
     user: str | None,
@@ -70,10 +84,7 @@ async def _check_history_access(
     if not page_id:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
 
-    async with db.conn.execute("SELECT access, parent_id FROM visu_nodes WHERE id = ?", (page_id,)) as cur:
-        row = await cur.fetchone()
-
-    access = row["access"] if row and row["access"] else "public"
+    access = await _resolve_page_access(db, page_id)
 
     if access in ("public", "readonly"):
         return  # Öffentliche Seite → History-Lesen erlaubt


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where a forged `X-Page-Id` or a node with inherited/NULL access was treated as `public`, allowing unauthenticated reads of history/aggregate endpoints.
- Ensure history endpoints use the same effective page ACL resolution as other API paths instead of defaulting missing rows to `public`.

### Description
- Added `async def _resolve_page_access(db: Database, node_id: str) -> str` which walks `visu_nodes.parent_id` to determine the effective access level and returns `"private"` for unknown nodes.
- Updated `_check_history_access(request, user, db)` to call `await _resolve_page_access(db, page_id)` and use the resolved ACL instead of defaulting missing/NULL access to `public`.
- Preserved existing behavior for `public`, `readonly`, and `protected` pages and kept session-token validation via `validate_session` unchanged.
- Changes made in `obs/api/v1/history.py` to deny unknown page IDs and fail closed for missing/inherited ACLs.

### Testing
- Attempted to run `pytest -q tests/integration/test_history.py -k limit_above_1000`, but the test run failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038e3405488329a7fcb93aabbe8372)