### PR TITLE
[Codex] fix(homeassistant): remove startup REST initial-read SSRF primitive

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,7 +19,7 @@
 * General: Implement contract tests for dependencies
 * Backend: History give only last 1000 entries now default 10'000 with amximum of 100'000
 * Adapter ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection
-* Adapter Home Assistant Security (Upstream PR #PENDING): remove startup initial-read REST fetch to prevent SSRF via binding-controlled entity IDs
+* Adapter Home Assistant Security (Upstream PR #560): remove startup initial-read REST fetch to prevent SSRF via binding-controlled entity IDs
 * Adapter: "Zeitschaltuhr" support for multiple "Schaltpunkte" and own public holidays
 * Logicmodule: Functional Block: Sommer/Winter Umschaltung nach DIN Functional Block does now work as expected
 * Logicmodule: Functional Block: Read object / Write object: Renamed objects will be reflected in the Logicmodule now

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,6 +19,7 @@
 * General: Implement contract tests for dependencies
 * Backend: History give only last 1000 entries now default 10'000 with amximum of 100'000
 * Adapter ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection
+* Adapter Home Assistant Security (Upstream PR #PENDING): remove startup initial-read REST fetch to prevent SSRF via binding-controlled entity IDs
 * Adapter: "Zeitschaltuhr" support for multiple "Schaltpunkte" and own public holidays
 * Logicmodule: Functional Block: Sommer/Winter Umschaltung nach DIN Functional Block does now work as expected
 * Logicmodule: Functional Block: Read object / Write object: Renamed objects will be reflected in the Logicmodule now

--- a/obs/adapters/homeassistant/adapter.py
+++ b/obs/adapters/homeassistant/adapter.py
@@ -217,55 +217,7 @@ class HomeAssistantAdapter(AdapterBase):
             self._ws_task = None
 
         if self._entity_map:
-            # Initial read: publish current state for all SOURCE/BOTH bindings immediately
-            asyncio.create_task(self._initial_read_all(), name="ha-adapter-init-read")
             self._ws_task = asyncio.create_task(self._ws_loop(), name="ha-adapter-ws")
-
-    async def _initial_read_all(self) -> None:
-        """Read and publish current state for all SOURCE/BOTH bindings via REST on startup."""
-        if self._http_client is None:
-            return
-        for bindings in self._entity_map.values():
-            for binding in bindings:
-                try:
-                    bc = HaBindingConfig(**binding.config)
-                    resp = await self._http_client.get(f"/api/states/{bc.entity_id}")
-                    resp.raise_for_status()
-                    state_obj: dict = resp.json()
-
-                    if bc.attribute:
-                        attrs = state_obj.get("attributes") or {}
-                        raw_val = attrs.get(bc.attribute)
-                    else:
-                        raw_str = state_obj.get("state", "unavailable")
-                        raw_val = _coerce_state(raw_str) if raw_str not in ("unavailable", "unknown") else None
-
-                    # formula first (numeric scale), then value_map (text substitution)
-                    pub_value = raw_val
-                    if binding.value_formula and pub_value is not None:
-                        from obs.core.formula import apply_formula
-
-                        pub_value = apply_formula(binding.value_formula, pub_value)
-                    pub_value = apply_value_map(pub_value, binding.value_map)
-
-                    logger.info(
-                        "HA adapter initial read: entity=%s attr=%s → dp=%s value=%r",
-                        bc.entity_id,
-                        bc.attribute or "state",
-                        binding.datapoint_id,
-                        pub_value,
-                    )
-                    await self._bus.publish(
-                        DataValueEvent(
-                            datapoint_id=binding.datapoint_id,
-                            value=pub_value,
-                            quality="good",
-                            source_adapter=self.adapter_type,
-                            binding_id=binding.id,
-                        ),
-                    )
-                except Exception:
-                    logger.exception("HA adapter initial read failed for binding %s", binding.id)
 
     # ------------------------------------------------------------------
     # WebSocket loop

--- a/tests/adapters/test_homeassistant.py
+++ b/tests/adapters/test_homeassistant.py
@@ -296,6 +296,32 @@ class TestOnStateChangedValueMap:
 
 
 # ---------------------------------------------------------------------------
+# _on_bindings_reloaded — security regression
+# ---------------------------------------------------------------------------
+
+
+class TestBindingsReloaded:
+    @pytest.mark.asyncio
+    async def test_reloaded_starts_ws_without_initial_rest_read(self, adapter):
+        adapter._bindings = [make_binding({"entity_id": "sensor.temperature"}, direction="SOURCE")]
+        adapter._http_client.get = AsyncMock()
+
+        task_names: list[str | None] = []
+        fake_task = MagicMock()
+
+        def _fake_create_task(coro, *, name=None):
+            task_names.append(name)
+            coro.close()
+            return fake_task
+
+        with patch("obs.adapters.homeassistant.adapter.asyncio.create_task", side_effect=_fake_create_task):
+            await adapter._on_bindings_reloaded()
+
+        assert task_names == ["ha-adapter-ws"]
+        adapter._http_client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # write() — service call logic
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Motivation
- Remove a server-side startup REST read that allowed attacker-controlled `entity_id` and adapter host to trigger outbound HTTP requests and publish their JSON into datapoints, creating an authenticated SSRF/data-exfiltration primitive.

### Description
- Stop scheduling the automatic `_initial_read_all` task in the Home Assistant adapter when bindings are reloaded, so no REST GETs are performed on binding-controlled values during startup/reload.
- Delete the `_initial_read_all` implementation that performed `GET /api/states/{entity_id}`, parsed the JSON result, applied formulas/value-maps and published `DataValueEvent`s.
- Preserve existing WebSocket-based `state_changed` subscription and the `_ws_loop` behavior for SOURCE/BOTH bindings.
- No changes were made to adapter/binding config schemas or API auth checks in this patch; this is a minimal remediation to remove the SSRF path.

### Additional Changes After Review
- Added a regression test that verifies `_on_bindings_reloaded()` only schedules `ha-adapter-ws` and does not trigger any startup REST initial-read path.
- Added and finalized `RELEASENOTES.md` entry for this fix with `Upstream PR #560`.
- Re-ran mandatory checks using shared tooling from the main worktree (`./openbridgeserver/.venv` and `./openbridgeserver/scripts/check-i18n-hardcoded-strings.sh`).

### Verification
- `/Volumes/Daten/Projekte/openbridge/openbridgeserver/.venv/bin/pytest -q tests/adapters/test_homeassistant.py` ✅ (41 passed)
- `/Volumes/Daten/Projekte/openbridge/openbridgeserver/.venv/bin/ruff check .` ✅
- `/Volumes/Daten/Projekte/openbridge/openbridgeserver/.venv/bin/ruff format . --check` ✅
- `I18N_DIFF_BASE=origin/main I18N_DIFF_HEAD=fork/codex/propose-fix-for-home-assistant-ssrf /Volumes/Daten/Projekte/openbridge/openbridgeserver/scripts/check-i18n-hardcoded-strings.sh` ✅ (`no relevant frontend/i18n files in diff`)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037cf6bb9c83299dc96699e47387d4)
