### PR TITLE
[Codex] Fix tag-name code injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,12 @@ jobs:
           TAG_NAME="${GITHUB_REF##*/}"
           REPO="${{ github.repository }}"
           PROJECT="${{ env.PROJECT_NAME }}"
-          python3 <<EOF
-          import re, os
-          tag = "${TAG_NAME}"
-          repo = "${REPO}"
-          project = "${PROJECT}"
+          export TAG_NAME REPO PROJECT
+          python3 <<'EOF'
+          import os, re
+          tag = os.environ['TAG_NAME']
+          repo = os.environ['REPO']
+          project = os.environ['PROJECT']
           # Remove -RC* suffix for release candidates
           base_version = re.sub(r'-RC\d*$', '', tag)
           with open('RELEASENOTES.md', 'r') as f:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,6 +16,7 @@
   
 ### Fixes:
 * General: Fix used tags at docker images
+* General Security (Upstream PR #PENDING): prevent tag-name code injection in release workflow
 * General: Implement contract tests for dependencies
 * Backend: History give only last 1000 entries now default 10'000 with amximum of 100'000
 * Adapter ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,7 +16,7 @@
   
 ### Fixes:
 * General: Fix used tags at docker images
-* General Security (Upstream PR #PENDING): prevent tag-name code injection in release workflow
+* General Security (Upstream PR #567): prevent tag-name code injection in release workflow
 * General: Implement contract tests for dependencies
 * Backend: History give only last 1000 entries now default 10'000 with amximum of 100'000
 * Adapter ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection

--- a/tests/unit/test_release_workflow_security.py
+++ b/tests/unit/test_release_workflow_security.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _python_heredoc_body(workflow_text: str) -> str:
+    start_marker = "python3 <<'EOF'"
+    start = workflow_text.find(start_marker)
+    assert start != -1, "release workflow must use single-quoted heredoc delimiter"
+    start = workflow_text.find("\n", start)
+    assert start != -1
+    end = workflow_text.find("\n          EOF", start)
+    assert end != -1, "release workflow Python block terminator missing"
+    return workflow_text[start:end]
+
+
+def test_release_workflow_uses_env_variables_for_python_block():
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    body = _python_heredoc_body(workflow)
+
+    assert "os.environ['TAG_NAME']" in body
+    assert "os.environ['REPO']" in body
+    assert "os.environ['PROJECT']" in body
+    assert "${TAG_NAME}" not in body
+    assert "${REPO}" not in body
+    assert "${PROJECT}" not in body


### PR DESCRIPTION
### Motivation
- The release job interpolated `TAG_NAME` directly into an embedded Python heredoc, which allowed crafted git tag names to break out of the Python string literal and execute arbitrary code in a job that has `contents: write` and `packages: write` permissions.

### Description
- Update `.github/workflows/release.yml` to `export TAG_NAME REPO PROJECT` and change the heredoc to a single-quoted delimiter `<<'EOF'` to disable shell interpolation inside the embedded Python block.
- Change the embedded Python to read values from environment variables via `os.environ` (e.g. `tag = os.environ['TAG_NAME']`) instead of directly embedding shell variables into the Python source.

### Additional Changes After Review
- Added security regression test: `tests/unit/test_release_workflow_security.py`.
  - Verifies the release workflow keeps a single-quoted Python heredoc.
  - Verifies the Python block consumes `TAG_NAME`, `REPO`, and `PROJECT` from `os.environ`.
  - Verifies shell interpolation markers (`${TAG_NAME}`, `${REPO}`, `${PROJECT}`) do not appear inside the Python block.
- Added release notes entry in `RELEASENOTES.md`:
  - `General Security (Upstream PR #567): prevent tag-name code injection in release workflow`

### Verification
- `pytest tests/unit/test_release_workflow_security.py -q` ✅
- `ruff check .` ✅
- `ruff format . --check` ✅
- i18n gate:
  - `scripts/check-i18n-hardcoded-strings.sh` is not present in this branch and also missing in `/Users/joh/Projekte/openbridge/openbridgeserver/scripts/`.
  - Fallback diff-gate executed against i18n-relevant frontend paths (`gui/src/**`, `gui/index.html`, `gui/public/**`) ✅
  - Result: no i18n-relevant frontend files changed in this PR diff.
