### PR TITLE
[Codex] fix(security): block SMIL vectors and reject SVG doctype

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -55,7 +55,7 @@
 * Security: Prevent logic formula sandbox escape via custom round helper. https://github.com/abeggled/openbridgeserver/pull/504
 * Security: Validate imported binding formulas to prevent untrusted formula execution. https://github.com/abeggled/openbridgeserver/pull/505
 * Security: Bound write-router value cache to mitigate MQTT payload-retention DoS risk. https://github.com/abeggled/openbridgeserver/pull/524
-* Security: Harden SVG icon import sanitization (obfuscated javascript href, deep nesting guard, stable `<svg>` serialization), make ZIP imports atomic on sanitize errors, preserve API-key flows across username changes, and allow imports for authenticated users. https://github.com/abeggled/openbridgeserver/pull/555
+* Security: Harden SVG icon import sanitization (obfuscated javascript href, deep nesting guard, stable `<svg>` serialization, blocked SMIL animation tags, and DOCTYPE rejection), make ZIP imports atomic on sanitize errors, preserve API-key flows across username changes, and allow imports for authenticated users. https://github.com/abeggled/openbridgeserver/pull/555
 * Security: Harden LXC first-boot and release handling (per-container JWT secret, stricter env/tag handling). https://github.com/abeggled/openbridgeserver/pull/455 https://github.com/abeggled/openbridgeserver/pull/506 https://github.com/abeggled/openbridgeserver/pull/512
 * Backend: Complete remaining UI translation fixes after i18n rollout. https://github.com/abeggled/openbridgeserver/pull/542
 * Backend: Validate `DataValueEvent` payloads before bridge propagation. https://github.com/abeggled/openbridgeserver/pull/519

--- a/obs/api/v1/icons.py
+++ b/obs/api/v1/icons.py
@@ -29,6 +29,7 @@ router = APIRouter(tags=["icons"])
 
 _SVG_RE = re.compile(rb"<svg[\s>]", re.IGNORECASE)
 _SVG_MAX_DEPTH = 256
+_SVG_DOCTYPE_RE = re.compile(r"<!DOCTYPE", re.IGNORECASE)
 
 
 def _secure_filename(filename: str) -> str:
@@ -113,6 +114,11 @@ def _sanitize_svg(content: bytes) -> bytes:
     """Remove executable/dangerous SVG constructs and return sanitized UTF-8 bytes."""
     try:
         decoded = content.decode("utf-8")
+        if _SVG_DOCTYPE_RE.search(decoded):
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                "Ungültiges SVG (DOCTYPE ist nicht erlaubt)",
+            )
         root = ET.fromstring(decoded)
     except (UnicodeDecodeError, ET.ParseError):
         raise HTTPException(
@@ -123,7 +129,17 @@ def _sanitize_svg(content: bytes) -> bytes:
     def local_name(tag: str) -> str:
         return tag.split("}", 1)[-1].lower()
 
-    blocked_tags = {"script", "foreignobject", "iframe", "object", "embed"}
+    blocked_tags = {
+        "script",
+        "foreignobject",
+        "iframe",
+        "object",
+        "embed",
+        "animate",
+        "animatemotion",
+        "animatetransform",
+        "set",
+    }
     stack: list[tuple[ET.Element | None, ET.Element, int]] = [(None, root, 0)]
 
     while stack:

--- a/tests/unit/test_icons.py
+++ b/tests/unit/test_icons.py
@@ -136,12 +136,27 @@ class TestSanitizeSvg:
         assert "<foreignObject" not in out
         assert "path" in out
 
+    def test_removes_smil_animation_elements(self):
+        payload = b'<svg xmlns="http://www.w3.org/2000/svg"><a><set attributeName="href" to="javascript:alert(1)" /></a><path d="M1 1"/></svg>'
+        out = _sanitize_svg(payload).decode("utf-8")
+        assert "<set" not in out
+        assert "path" in out
+
     def test_rejects_invalid_xml(self):
         import pytest
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException):
             _sanitize_svg(b"<svg><path></svg")
+
+    def test_rejects_doctype(self):
+        import pytest
+        from fastapi import HTTPException
+
+        payload = b'<!DOCTYPE svg [<!ENTITY x "abc">]><svg xmlns="http://www.w3.org/2000/svg"><text>&x;</text></svg>'
+        with pytest.raises(HTTPException) as exc_info:
+            _sanitize_svg(payload)
+        assert exc_info.value.status_code == 422
 
     def test_strips_obfuscated_javascript_href(self):
         payload = b'<svg xmlns="http://www.w3.org/2000/svg"><a href="java&#10;script:alert(1)"><path d="M1 1"/></a></svg>'


### PR DESCRIPTION
### Motivation
Close remaining SVG import vectors in the icon sanitizer while keeping authenticated-user imports enabled by product decision.

### Description
- Reject SVG payloads that contain `<!DOCTYPE ...>` before XML parsing.
- Remove SMIL animation elements (`animate`, `animateMotion`, `animateTransform`, `set`) to prevent post-sanitize reintroduction of executable links.
- Keep existing hardenings (event-handler stripping, obfuscated `javascript:` href stripping, depth guard, atomic ZIP writes, namespace-stable `<svg>` serialization).
- Add unit tests for DOCTYPE rejection and SMIL tag removal.

### Testing
- `ruff check`
- `i18n guard`
- `pytest` (pre-push CI parity)