### PR TITLE
[Codex] fix(visu): SVG-Uploads im Background-Katalog deaktivieren

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -38,6 +38,7 @@
 * Backend: The adapter page automatically reloaded every few seconds, making configuration difficult. https://github.com/abeggled/openbridgeserver/issues/394
 * Backend: Fix view permissions of Demo User https://github.com/abeggled/openbridgeserver/issues/471
 * Logic engine: The object selector now uses the entire available window space. https://github.com/abeggled/openbridgeserver/issues/345
+* Visu Security (Upstream PR #572): prevent stored XSS by rejecting SVG uploads in the background catalog.
 * Visu: History widget now updates automatically when new values arrive via WebSocket. https://github.com/abeggled/openbridgeserver/issues/408
 * Visu: RTR Widget now use correct values for room controller (heating) DPT 20.102 https://github.com/abeggled/openbridgeserver/issues/461
 * Visu #440: Widget positioning broken if floorplan is rotated

--- a/frontend/src/views/VisuEditor.vue
+++ b/frontend/src/views/VisuEditor.vue
@@ -563,7 +563,7 @@ const showSettings = ref(false)
         <input
           ref="backgroundFileInput"
           type="file"
-          accept="image/png,image/jpeg,image/webp,image/svg+xml,.png,.jpg,.jpeg,.webp,.svg"
+          accept="image/png,image/jpeg,image/webp,.png,.jpg,.jpeg,.webp"
           class="hidden"
           @change="onBackgroundFiles"
         />

--- a/obs/api/v1/visu_backgrounds.py
+++ b/obs/api/v1/visu_backgrounds.py
@@ -21,7 +21,7 @@ from obs.config import get_settings
 
 router = APIRouter(tags=["visu", "backgrounds"])
 
-_ALLOWED_EXTENSIONS = ("png", "jpg", "jpeg", "webp", "svg")
+_ALLOWED_EXTENSIONS = ("png", "jpg", "jpeg", "webp")
 
 
 class BackgroundOut(BaseModel):
@@ -85,8 +85,6 @@ def _detect_image_type(content: bytes) -> tuple[str, str] | None:
         return "jpg", "image/jpeg"
     if len(head) >= 12 and head[0:4] == b"RIFF" and head[8:12] == b"WEBP":
         return "webp", "image/webp"
-    if re.search(rb"<svg[\s>]", head, flags=re.IGNORECASE):
-        return "svg", "image/svg+xml"
     return None
 
 
@@ -98,8 +96,6 @@ def _guess_mime_type(path: Path) -> str:
         return "image/jpeg"
     if ext == "webp":
         return "image/webp"
-    if ext == "svg":
-        return "image/svg+xml"
     return "application/octet-stream"
 
 
@@ -160,7 +156,7 @@ async def import_backgrounds(
         if detected is None:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_CONTENT,
-                f"'{filename}' enthält kein gültiges Bildformat (erlaubt: PNG, JPG, WEBP, SVG)",
+                f"'{filename}' enthält kein gültiges Bildformat (erlaubt: PNG, JPG, WEBP)",
             )
 
         name = _safe_stem(filename)

--- a/tests/integration/test_visu_backgrounds.py
+++ b/tests/integration/test_visu_backgrounds.py
@@ -60,17 +60,13 @@ async def test_import_background_png(client, auth_headers, backgrounds_tmp):
 
 
 @pytest.mark.asyncio
-async def test_import_background_svg(client, auth_headers, backgrounds_tmp):
+async def test_import_background_rejects_svg(client, auth_headers, backgrounds_tmp):
     resp = await client.post(
         "/api/v1/visu/backgrounds/import",
         headers=auth_headers,
         files=[("files", ("blueprint.svg", _MINIMAL_SVG, "image/svg+xml"))],
     )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["imported"] == 1
-    assert body["names"] == ["blueprint"]
-    assert (backgrounds_tmp / "blueprint.svg").exists()
+    assert resp.status_code == 422
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- SVG-Dateien ermöglichen aktive First‑party-Auslieferung von XML/JS und wurden versehentlich als Background-Format zugelassen, was eine same-origin XSS-Angriffsfläche schafft.
- Ziel ist ein minimaler sicherer Fix, der die Exploit‑Vektoren schließt, ohne bestehende PNG/JPEG/WEBP-Funktionalität zu verändern.

### Description
- Entfernt `svg` aus der Allowlist durch Änderung von `_ALLOWED_EXTENSIONS` in `obs/api/v1/visu_backgrounds.py` (nur `png`, `jpg`, `jpeg`, `webp` bleiben erlaubt). 
- Entfernt die einfache SVG-Erkennung in `_detect_image_type` und das SVG‑MIME-Mapping in `_guess_mime_type`, sodass SVG-Inhalte beim Import nicht mehr als Bild erkannt werden.
- Passt die Import-Fehlermeldung an (ohne Erwähnung von SVG) in `obs/api/v1/visu_backgrounds.py` und speichert weiterhin erlaubte Bilder unverändert auf Disk, wodurch das bestehende Verhalten für erlaubte Formate erhalten bleibt.
- Entfernt `.svg` / `image/svg+xml` aus dem `accept`-Attribut im Visu-Frontend in `frontend/src/views/VisuEditor.vue`, damit der Client den riskanten Typ nicht mehr vorschlägt.
- Aktualisiert den Integrationstest in `tests/integration/test_visu_backgrounds.py`, sodass ein SVG-Upload jetzt `422` erwartet (`test_import_background_rejects_svg`).

### Testing
- Lint: `./tools/lint.sh --check` wurde ausgeführt und alle Checks sind erfolgreich durchgelaufen.
- Integrationstest: `pytest tests/integration/test_visu_backgrounds.py` wurde versucht, lief hier jedoch wegen fehlender Testabhängigkeit (`ModuleNotFoundError: No module named 'pytest_asyncio'`) nicht durch und konnte deshalb nicht vollständig ausgeführt; der Test wurde entsprechend im Repository geändert, um das neue Verhalten zu prüfen.
- Verhalten: Manuelle Verifikation der geänderten Codepfade bestätigt, dass SVG-Dateien jetzt beim Import abgelehnt werden und nur PNG/JPEG/WEBP als Backgrounds gelistet und ausgeliefert werden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148da98be88329941e54e18cc50d52)