### PR TITLE
[Codex] fix(security): harden formula evaluator against attribute/call sandbox escape

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,7 +22,7 @@
 * Adapter: "Zeitschaltuhr" support for multiple "Schaltpunkte" and own public holidays
 * Logicmodule: Functional Block: Sommer/Winter Umschaltung nach DIN Functional Block does now work as expected
 * Logicmodule: Functional Block: Read object / Write object: Renamed objects will be reflected in the Logicmodule now
-* Logicmodule Security (Upstream PR #PENDING): allow safe math constants (e.g. math.pi/math.e) in formula validation
+* Logicmodule Security (Upstream PR #573): allow safe math constants (e.g. math.pi/math.e) in formula validation
 * Visu Widget: Enhancment Roof Window Widget (new Velux-Type), and new "Zweitürer (L/R)"
 * Visu Widget "Verlauf" has now the possibility to display multiple graphs with two units (left/right)
 * Visu Widget "Zeitschaltuhr" supports multiple "Schaltpunkte" and oother new functions of the adapter

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,6 +22,7 @@
 * Adapter: "Zeitschaltuhr" support for multiple "Schaltpunkte" and own public holidays
 * Logicmodule: Functional Block: Sommer/Winter Umschaltung nach DIN Functional Block does now work as expected
 * Logicmodule: Functional Block: Read object / Write object: Renamed objects will be reflected in the Logicmodule now
+* Logicmodule Security (Upstream PR #PENDING): allow safe math constants (e.g. math.pi/math.e) in formula validation
 * Visu Widget: Enhancment Roof Window Widget (new Velux-Type), and new "Zweitürer (L/R)"
 * Visu Widget "Verlauf" has now the possibility to display multiple graphs with two units (left/right)
 * Visu Widget "Zeitschaltuhr" supports multiple "Schaltpunkte" and oother new functions of the adapter

--- a/obs/core/formula.py
+++ b/obs/core/formula.py
@@ -46,6 +46,7 @@ _ALLOWED_NODES = (
 
 
 _ALLOWED_FUNC_NAMES = {"abs", "round", "min", "max"}
+_ALLOWED_MATH_NAMES = {k for k in math.__dict__ if not k.startswith("_")}
 _ALLOWED_MATH_ATTRS = {k for k, v in math.__dict__.items() if not k.startswith("_") and callable(v)}
 
 
@@ -56,12 +57,7 @@ def _is_allowed_call(node: ast.Call) -> bool:
     if isinstance(func, ast.Name):
         return func.id in _ALLOWED_FUNC_NAMES or func.id in _ALLOWED_MATH_ATTRS
     if isinstance(func, ast.Attribute):
-        return (
-            isinstance(func.value, ast.Name)
-            and func.value.id == "math"
-            and func.attr in _ALLOWED_MATH_ATTRS
-            and not func.attr.startswith("_")
-        )
+        return isinstance(func.value, ast.Name) and func.value.id == "math" and func.attr in _ALLOWED_MATH_ATTRS and not func.attr.startswith("_")
     return False
 
 
@@ -70,15 +66,12 @@ def _validate_tree(tree: ast.AST) -> str | None:
         if not isinstance(node, _ALLOWED_NODES):
             return f"Nicht erlaubter Ausdruck: '{type(node).__name__}'"
 
-        if isinstance(node, ast.Name) and node.id not in {"x", "math", *_ALLOWED_FUNC_NAMES, *_ALLOWED_MATH_ATTRS}:
+        if isinstance(node, ast.Name) and node.id not in {"x", "math", *_ALLOWED_FUNC_NAMES, *_ALLOWED_MATH_NAMES}:
             return f"Nicht erlaubter Name: '{node.id}'"
 
         if isinstance(node, ast.Attribute):
             if not (
-                isinstance(node.value, ast.Name)
-                and node.value.id == "math"
-                and node.attr in _ALLOWED_MATH_ATTRS
-                and not node.attr.startswith("_")
+                isinstance(node.value, ast.Name) and node.value.id == "math" and node.attr in _ALLOWED_MATH_NAMES and not node.attr.startswith("_")
             ):
                 return "Nicht erlaubter Attributzugriff"
 
@@ -86,6 +79,7 @@ def _validate_tree(tree: ast.AST) -> str | None:
             return "Nicht erlaubter Funktionsaufruf"
 
     return None
+
 
 _SAFE_GLOBALS: dict[str, Any] = {
     "__builtins__": {},  # kein Zugriff auf builtins

--- a/obs/core/formula.py
+++ b/obs/core/formula.py
@@ -30,8 +30,8 @@ _ALLOWED_NODES = (
     ast.UnaryOp,
     ast.Constant,  # Python 3.8+
     ast.Name,  # für 'x' und math-Funktionen
-    ast.Attribute,  # für math.sqrt etc.
-    ast.Call,  # für abs(), round() etc.
+    ast.Attribute,  # nur math.<funktion>
+    ast.Call,  # nur erlaubte Funktionsaufrufe
     ast.Add,
     ast.Sub,
     ast.Mult,
@@ -43,6 +43,49 @@ _ALLOWED_NODES = (
     ast.USub,
     ast.Load,
 )
+
+
+_ALLOWED_FUNC_NAMES = {"abs", "round", "min", "max"}
+_ALLOWED_MATH_ATTRS = {k for k, v in math.__dict__.items() if not k.startswith("_") and callable(v)}
+
+
+def _is_allowed_call(node: ast.Call) -> bool:
+    if node.keywords:
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in _ALLOWED_FUNC_NAMES or func.id in _ALLOWED_MATH_ATTRS
+    if isinstance(func, ast.Attribute):
+        return (
+            isinstance(func.value, ast.Name)
+            and func.value.id == "math"
+            and func.attr in _ALLOWED_MATH_ATTRS
+            and not func.attr.startswith("_")
+        )
+    return False
+
+
+def _validate_tree(tree: ast.AST) -> str | None:
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            return f"Nicht erlaubter Ausdruck: '{type(node).__name__}'"
+
+        if isinstance(node, ast.Name) and node.id not in {"x", "math", *_ALLOWED_FUNC_NAMES, *_ALLOWED_MATH_ATTRS}:
+            return f"Nicht erlaubter Name: '{node.id}'"
+
+        if isinstance(node, ast.Attribute):
+            if not (
+                isinstance(node.value, ast.Name)
+                and node.value.id == "math"
+                and node.attr in _ALLOWED_MATH_ATTRS
+                and not node.attr.startswith("_")
+            ):
+                return "Nicht erlaubter Attributzugriff"
+
+        if isinstance(node, ast.Call) and not _is_allowed_call(node):
+            return "Nicht erlaubter Funktionsaufruf"
+
+    return None
 
 _SAFE_GLOBALS: dict[str, Any] = {
     "__builtins__": {},  # kein Zugriff auf builtins
@@ -77,10 +120,10 @@ def validate_formula(formula: str) -> str | None:
     except SyntaxError as exc:
         return f"Syntaxfehler: {exc.msg}"
 
-    # 2. Erlaubte Knoten prüfen
-    for node in ast.walk(tree):
-        if not isinstance(node, _ALLOWED_NODES):
-            return f"Nicht erlaubter Ausdruck: '{type(node).__name__}'"
+    # 2. Erlaubte Knoten/Funktionen prüfen
+    err = _validate_tree(tree)
+    if err:
+        return err
 
     # 3. Testlauf mit x=1 und x=0 (fängt offensichtliche Div-by-Zero)
     for test_val, label in ((1.0, "x=1"), (0.0, "x=0")):

--- a/obs/core/formula.py
+++ b/obs/core/formula.py
@@ -143,6 +143,10 @@ def apply_formula(formula: str, value: Any) -> Any:
     try:
         locals_: dict[str, Any] = {**_SAFE_GLOBALS, "x": x}
         tree = ast.parse(formula, mode="eval")
+        err = _validate_tree(tree)
+        if err:
+            logger.warning("Formula '%s' rejected by AST validation: %s", formula, err)
+            return value
         code = compile(tree, "<formula>", "eval")
         result = eval(code, {"__builtins__": {}}, locals_)  # noqa: S307
 

--- a/tests/unit/test_formula.py
+++ b/tests/unit/test_formula.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from obs.core.formula import apply_formula, validate_formula
+
+
+def test_validate_formula_allows_math_constants() -> None:
+    assert validate_formula("math.pi * x + math.e") is None
+
+
+def test_validate_formula_allows_direct_math_constants() -> None:
+    assert validate_formula("pi * x + e") is None
+
+
+def test_apply_formula_with_math_constants() -> None:
+    result = apply_formula("math.pi * x", 2)
+    assert result == pytest.approx(2 * 3.141592653589793)

--- a/tests/unit/test_formula.py
+++ b/tests/unit/test_formula.py
@@ -16,3 +16,8 @@ def test_validate_formula_allows_direct_math_constants() -> None:
 def test_apply_formula_with_math_constants() -> None:
     result = apply_formula("math.pi * x", 2)
     assert result == pytest.approx(2 * 3.141592653589793)
+
+
+def test_apply_formula_rejects_attribute_escape() -> None:
+    payload = "abs.__self__.__dict__.get('__import__')('math').pi + x"
+    assert apply_formula(payload, 2) == 2


### PR DESCRIPTION
## Upstream Tracking
- **Upstream PR:** https://github.com/abeggled/openbridgeserver/pull/573

### Motivation
- Prevent an AST/eval sandbox escape in the formula evaluator that allowed attribute traversal and callable objects (e.g. `abs.__self__.__dict__...`) to reach `__import__` and execute OS commands while validating or applying user-provided formulas.
- Re-enable safe formula validation/evaluation while preserving the supported functionality (`x`, arithmetic, `abs/round/min/max`, and `math.*`).

### Description
- Added `_ALLOWED_FUNC_NAMES` and `_ALLOWED_MATH_ATTRS` and implemented `_is_allowed_call` to only permit known-safe call targets and to reject keyword arguments.
- Implemented `_validate_tree` to perform semantic checks on the parsed AST, rejecting disallowed names, arbitrary `Attribute` access and unsafe `Call` nodes (only `math.<callable>` or whitelisted functions are allowed).
- Updated `validate_formula` to run `_validate_tree` before test evaluations.
- Updated `apply_formula` to enforce `_validate_tree` before compile/eval, so imported/stored formulas are gated even if they bypass explicit `validate_formula` calls.

### Additional Changes After Review
- Fixed review feedback about `math.pi`/`math.e`: validation now allows safe non-private math constants (attribute access like `math.pi` and direct names like `pi`) while call validation remains restricted to callable math members.
- Addressed P1 review feedback for imported bindings by validating AST in `apply_formula` before evaluation.
- Added regression unit tests in `tests/unit/test_formula.py` for:
  - constants (`math.pi`, `math.e`, `pi`, `e`)
  - direct `apply_formula` rejection of attribute-based escape payloads
- Added release note entry: `Logicmodule Security (Upstream PR #573): allow safe math constants (e.g. math.pi/math.e) in formula validation`.

### Verification
- `pytest -q tests/unit/test_formula.py` ✅ (4 passed)
- `ruff check obs/core/formula.py tests/unit/test_formula.py` ✅
- `ruff format obs/core/formula.py tests/unit/test_formula.py --check` ✅

### Testing
- Malicious attribute/call chain payloads are rejected by AST validation in both `validate_formula` and `apply_formula`.
- Valid formulas with `math.*` functions and constants continue to evaluate correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039ad047688329bc6c008fc6ced31b)
