### PR TITLE
[Codex] Harden LXC updater with bundle checksum verification

### DIFF
--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -191,19 +191,22 @@ jobs:
               exit 1
           fi
 
+          BUNDLE_FILENAME=$(basename "$BUNDLE_URL")
+          CHECKSUM_FILENAME=$(basename "$CHECKSUM_URL")
+
           TMP=$(mktemp -d)
           trap "rm -rf $TMP" EXIT
 
           echo "Downloading $BUNDLE_URL ..."
-          curl -fL "$BUNDLE_URL" -o "$TMP/app-bundle.tar.gz"
+          curl -fL "$BUNDLE_URL" -o "$TMP/$BUNDLE_FILENAME"
           echo "Downloading $CHECKSUM_URL ..."
-          curl -fL "$CHECKSUM_URL" -o "$TMP/app-bundle.tar.gz.sha512"
+          curl -fL "$CHECKSUM_URL" -o "$TMP/$CHECKSUM_FILENAME"
 
-          (cd "$TMP" && sha512sum -c app-bundle.tar.gz.sha512)
+          (cd "$TMP" && sha512sum -c "$CHECKSUM_FILENAME")
 
           systemctl stop "$SERVICE"
 
-          tar -xzf "$TMP/app-bundle.tar.gz" -C "$INSTALL_DIR"
+          tar -xzf "$TMP/$BUNDLE_FILENAME" -C "$INSTALL_DIR"
           "$INSTALL_DIR/venv/bin/pip" install --no-cache-dir -q -r "$INSTALL_DIR/requirements.txt"
 
           # Self-update: replace this script with the version from the bundle

--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -170,19 +170,24 @@ jobs:
 
           echo "Installing $TARGET ..."
 
-          BUNDLE_URL=$(echo "$ALL_RELEASES" | python3 -c "
+          ASSET_INFO=$(echo "$ALL_RELEASES" | python3 -c "
           import sys, json
           target = '${TARGET}'
           releases = json.load(sys.stdin)
           r = next((r for r in releases if r['tag_name'] == target), None)
           if r:
-              a = next((a for a in r['assets'] if 'app-bundle' in a['name'] and a['name'].endswith('.tar.gz')), None)
-              if a:
-                  print(a['browser_download_url'])
+              bundle = next((a for a in r['assets'] if 'app-bundle' in a['name'] and a['name'].endswith('.tar.gz')), None)
+              checksum = next((a for a in r['assets'] if 'app-bundle' in a['name'] and a['name'].endswith('.tar.gz.sha512')), None)
+              if bundle and checksum:
+                  print(bundle['browser_download_url'])
+                  print(checksum['browser_download_url'])
           ")
 
-          if [[ -z "$BUNDLE_URL" ]]; then
-              echo "Error: no app-bundle asset found for $TARGET" >&2
+          BUNDLE_URL=$(echo "$ASSET_INFO" | sed -n '1p')
+          CHECKSUM_URL=$(echo "$ASSET_INFO" | sed -n '2p')
+
+          if [[ -z "$BUNDLE_URL" ]] || [[ -z "$CHECKSUM_URL" ]]; then
+              echo "Error: missing app-bundle or checksum asset for $TARGET" >&2
               exit 1
           fi
 
@@ -191,6 +196,10 @@ jobs:
 
           echo "Downloading $BUNDLE_URL ..."
           curl -fL "$BUNDLE_URL" -o "$TMP/app-bundle.tar.gz"
+          echo "Downloading $CHECKSUM_URL ..."
+          curl -fL "$CHECKSUM_URL" -o "$TMP/app-bundle.tar.gz.sha512"
+
+          (cd "$TMP" && sha512sum -c app-bundle.tar.gz.sha512)
 
           systemctl stop "$SERVICE"
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,6 +17,7 @@
 ### Fixes:
 * General: Fix used tags at docker images
 * General: Implement contract tests for dependencies
+* General Security (Upstream PR #PENDING): harden LXC updater by verifying app bundle checksums against the original release artifact filename
 * Backend: History give only last 1000 entries now default 10'000 with amximum of 100'000
 * Adapter ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection
 * Adapter: "Zeitschaltuhr" support for multiple "Schaltpunkte" and own public holidays

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,7 +17,7 @@
 ### Fixes:
 * General: Fix used tags at docker images
 * General: Implement contract tests for dependencies
-* General Security (Upstream PR #PENDING): harden LXC updater by verifying app bundle checksums against the original release artifact filename
+* General Security (Upstream PR #574): harden LXC updater by verifying app bundle checksums against the original release artifact filename
 * Backend: History give only last 1000 entries now default 10'000 with amximum of 100'000
 * Adapter ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection
 * Adapter: "Zeitschaltuhr" support for multiple "Schaltpunkte" and own public holidays

--- a/tests/unit/test_lxc_template_updater.py
+++ b/tests/unit/test_lxc_template_updater.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def _workflow_text() -> str:
+    root = Path(__file__).resolve().parents[2]
+    return (root / ".github" / "workflows" / "lxc-template.yml").read_text(encoding="utf-8")
+
+
+def test_updater_uses_release_bundle_filename_for_download_and_extract():
+    workflow = _workflow_text()
+
+    assert 'BUNDLE_FILENAME=$(basename "$BUNDLE_URL")' in workflow
+    assert 'curl -fL "$BUNDLE_URL" -o "$TMP/$BUNDLE_FILENAME"' in workflow
+    assert 'tar -xzf "$TMP/$BUNDLE_FILENAME" -C "$INSTALL_DIR"' in workflow
+    assert '"$TMP/app-bundle.tar.gz"' not in workflow
+
+
+def test_updater_verifies_checksum_against_downloaded_filenames():
+    workflow = _workflow_text()
+
+    assert 'CHECKSUM_FILENAME=$(basename "$CHECKSUM_URL")' in workflow
+    assert 'curl -fL "$CHECKSUM_URL" -o "$TMP/$CHECKSUM_FILENAME"' in workflow
+    assert 'sha512sum -c "$CHECKSUM_FILENAME"' in workflow
+    assert "sha512sum -c app-bundle.tar.gz.sha512" not in workflow


### PR DESCRIPTION
### Motivation
- Close a supply-chain integrity gap where the generated `obs-update` script downloaded and extracted app bundles as root without validating their integrity.
- The workflow already emits a `.sha512` checksum for the app bundle, but the updater previously did not consume or verify it, enabling tampered bundles to be installed.
- Introduce a minimal, fail-closed verification step so updates only proceed when the published checksum matches the downloaded asset.

### Description
- Updated the updater-generation block in `.github/workflows/lxc-template.yml` so the generated `obs-update` script fetches both the `app-bundle*.tar.gz` asset and its corresponding `.sha512` asset from the selected release.
- The updater now downloads both files into a temporary directory and runs checksum verification before stopping the service, extracting the bundle, or running `pip` installs.
- Added explicit error handling to abort the update when either the bundle or the checksum asset is missing, preserving existing extraction, `pip` install, and self-update behavior only after successful verification.

### Additional Changes After Review
- Fixed the filename-coupling bug raised in review: the updater now derives `BUNDLE_FILENAME` and `CHECKSUM_FILENAME` from the release asset URLs via `basename`.
- `sha512sum -c` now validates against the downloaded checksum filename, and bundle extraction uses the real downloaded bundle filename.
- Added regression tests in `tests/unit/test_lxc_template_updater.py` to ensure the updater keeps release filenames (no hardcoded `app-bundle.tar.gz`) and verifies checksums using the downloaded checksum filename.
- Added release note entry: `General Security (Upstream PR #574): harden LXC updater by verifying app bundle checksums against the original release artifact filename`.

### Verification
- `python -m pytest tests/unit/test_lxc_template_updater.py` (via main worktree `.venv`): **passed** (2 tests)
- `ruff check .`: **passed**
- `ruff format . --check`: **passed**
- `check-i18n-hardcoded-strings.sh`: script not present in PR worktree and main worktree, so a fallback i18n gate over PR diff was executed; no i18n-relevant paths changed, gate **passed**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0368ecb3d08329894c6aabb6a00a7c)
