### PR TITLE
feat(logic): allow api client secrets from files

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -45,6 +45,9 @@
 * Visu: Gauge mode for value display widget (arc/circle variants). https://github.com/abeggled/openbridgeserver/pull/421
 * Visu: Bar chart mode for history/chart widget. https://github.com/abeggled/openbridgeserver/pull/444
   
+### Improvements ✨
+* Logic: API client nodes can now load optional headers and bearer tokens from secret files. https://github.com/abeggled/openbridgeserver/pull/581
+
 ### Fixes 🐞
 * General #375: Proxmox LXC, confusing checksum field content within release notes. https://github.com/abeggled/openbridgeserver/issues/375
 * Security: Preserve legacy `OPENTWS_*`/`OPENTWS_CONFIG` compatibility with case-insensitive `OBS_CONFIG` precedence and keep `opentws.db` fallback active even with partial `database.*` overrides to avoid unintended default-admin re-bootstrap on upgrades. https://github.com/abeggled/openbridgeserver/pull/554
@@ -128,3 +131,4 @@
 ### Breaking changes:
 * none
   
+

--- a/obs/logic/manager.py
+++ b/obs/logic/manager.py
@@ -87,6 +87,19 @@ async def _resolve_safe_image_url(url: str) -> tuple[str, str, str] | None:
     return pinned_url, host_header, pinned_ip
 
 
+def _read_secret_file(path: str) -> str:
+    """Read a small root-managed secret file without logging its content."""
+    clean_path = (path or "").strip()
+    if not clean_path:
+        return ""
+    try:
+        with open(clean_path, encoding="utf-8") as handle:
+            return handle.read().strip()
+    except OSError as exc:
+        logger.warning("Could not read api_client secret file %s: %s", clean_path, exc)
+        return ""
+
+
 _THROTTLE_UNITS: dict[str, float] = {
     "ms": 1.0,
     "s": 1000.0,
@@ -537,6 +550,14 @@ class LogicManager:
                     extra_headers = _json.loads(hdr_str)
                 except Exception:
                     pass
+            hdr_secret_file = (node.data.get("headers_secret_file") or "").strip()
+            if hdr_secret_file:
+                try:
+                    secret_headers = _json.loads(_read_secret_file(hdr_secret_file))
+                    if isinstance(secret_headers, dict):
+                        extra_headers = {**extra_headers, **secret_headers}
+                except Exception:
+                    logger.warning("api_client headers_secret_file did not contain a JSON object")
             body = out.get("_body")
             # ── Authentication ──────────────────────────────────────────
             auth_type = (node.data.get("auth_type") or "none").lower()
@@ -548,6 +569,9 @@ class LogicManager:
                     auth = httpx.BasicAuth(username, password) if auth_type == "basic" else httpx.DigestAuth(username, password)
             elif auth_type == "bearer":
                 token = (node.data.get("auth_token") or "").strip()
+                token_file = (node.data.get("auth_token_file") or "").strip()
+                if not token and token_file:
+                    token = _read_secret_file(token_file)
                 if token:
                     extra_headers = {
                         **extra_headers,

--- a/obs/logic/node_types.py
+++ b/obs/logic/node_types.py
@@ -835,6 +835,11 @@ BUILTIN_NODE_TYPES: list[NodeTypeDef] = [
                 "default": "",
                 "label": "Header (JSON-Objekt, optional)",
             },
+            "headers_secret_file": {
+                "type": "string",
+                "default": "",
+                "label": "Header aus Secret-Datei (JSON-Objekt, optional)",
+            },
             "timeout_s": {"type": "number", "default": 10, "label": "Timeout (s)"},
             "auth_type": {
                 "type": "string",
@@ -858,6 +863,11 @@ BUILTIN_NODE_TYPES: list[NodeTypeDef] = [
                 "default": "",
                 "label": "Bearer Token",
                 "subtype": "password",
+            },
+            "auth_token_file": {
+                "type": "string",
+                "default": "",
+                "label": "Bearer Token aus Secret-Datei",
             },
         },
         color="#0e7490",

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from obs.logic.manager import LogicManager
+from obs.logic.manager import LogicManager, _read_secret_file
 from obs.logic.models import FlowData
 from tests.unit.conftest import edge, make_executor, node
 
@@ -47,6 +47,25 @@ def _mock_response(status_code: int, json_data: object | None = None, text: str 
     else:
         resp.json.side_effect = ValueError("no JSON")
     return resp
+
+
+class TestApiClientSecretFiles:
+    """Tests for api_client secret-file helpers."""
+
+    def test_read_secret_file_returns_stripped_content(self, tmp_path):
+        secret_file = tmp_path / "api-secret"
+        secret_file.write_text("  secret-value\n", encoding="utf-8")
+
+        assert _read_secret_file(str(secret_file)) == "secret-value"
+
+    def test_read_secret_file_empty_path_returns_empty_string(self):
+        assert _read_secret_file("") == ""
+
+    def test_read_secret_file_missing_path_returns_empty_string(self, tmp_path, caplog):
+        missing = tmp_path / "missing-secret"
+
+        assert _read_secret_file(str(missing)) == ""
+        assert "Could not read api_client secret file" in caplog.text
 
 
 # ===========================================================================
@@ -350,6 +369,138 @@ class TestApiClientAuthentication:
             asyncio.run(manager._execute_graph(graph_id, "t", flow, {"ac": {"trigger": True}}))
 
         assert "Authorization" not in captured_headers[0]
+
+    @patch("obs.logic.manager.httpx.AsyncClient")
+    def test_headers_secret_file_merges_headers(self, mock_client_cls):
+        captured_headers: list[dict] = []
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        async def _capture(method, url, **kwargs):
+            captured_headers.append(kwargs.get("headers", {}))
+            return _mock_response(200, {})
+
+        mock_client.request = _capture
+
+        manager = _make_manager()
+        data = {
+            "url": "http://example.com/",
+            "method": "GET",
+            "headers": '{"X-Static": "static"}',
+            "headers_secret_file": "/run/secrets/api-headers.json",
+        }
+        n = node("ac", "api_client", data)
+        flow = _flow([n])
+        graph_id = "g-headers-secret"
+        manager._graphs[graph_id] = ("t", True, flow)
+        manager._node_state[graph_id] = {}
+
+        with patch("obs.logic.manager._read_secret_file", return_value='{"hue-application-key": "secret"}'):
+            with patch("obs.api.v1.websocket.get_ws_manager", side_effect=RuntimeError("no ws")):
+                asyncio.run(manager._execute_graph(graph_id, "t", flow, {"ac": {"trigger": True}}))
+
+        assert captured_headers[0]["X-Static"] == "static"
+        assert captured_headers[0]["hue-application-key"] == "secret"
+
+    @patch("obs.logic.manager.httpx.AsyncClient")
+    def test_headers_secret_file_overrides_inline_header(self, mock_client_cls):
+        captured_headers: list[dict] = []
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        async def _capture(method, url, **kwargs):
+            captured_headers.append(kwargs.get("headers", {}))
+            return _mock_response(200, {})
+
+        mock_client.request = _capture
+
+        manager = _make_manager()
+        data = {
+            "url": "http://example.com/",
+            "method": "GET",
+            "headers": '{"X-Token": "inline"}',
+            "headers_secret_file": "/run/secrets/api-headers.json",
+        }
+        n = node("ac", "api_client", data)
+        flow = _flow([n])
+        graph_id = "g-headers-secret-override"
+        manager._graphs[graph_id] = ("t", True, flow)
+        manager._node_state[graph_id] = {}
+
+        with patch("obs.logic.manager._read_secret_file", return_value='{"X-Token": "from-file"}'):
+            with patch("obs.api.v1.websocket.get_ws_manager", side_effect=RuntimeError("no ws")):
+                asyncio.run(manager._execute_graph(graph_id, "t", flow, {"ac": {"trigger": True}}))
+
+        assert captured_headers[0]["X-Token"] == "from-file"
+
+    @patch("obs.logic.manager.httpx.AsyncClient")
+    def test_bearer_auth_token_file_sets_authorization_header(self, mock_client_cls):
+        captured_headers: list[dict] = []
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        async def _capture(method, url, **kwargs):
+            captured_headers.append(kwargs.get("headers", {}))
+            return _mock_response(200, {})
+
+        mock_client.request = _capture
+
+        manager = _make_manager()
+        data = {
+            "url": "http://example.com/",
+            "method": "GET",
+            "auth_type": "bearer",
+            "auth_token": "",
+            "auth_token_file": "/run/secrets/api-token",
+        }
+        n = node("ac", "api_client", data)
+        flow = _flow([n])
+        graph_id = "g-bearer-token-file"
+        manager._graphs[graph_id] = ("t", True, flow)
+        manager._node_state[graph_id] = {}
+
+        with patch("obs.logic.manager._read_secret_file", return_value="file-token-xyz"):
+            with patch("obs.api.v1.websocket.get_ws_manager", side_effect=RuntimeError("no ws")):
+                asyncio.run(manager._execute_graph(graph_id, "t", flow, {"ac": {"trigger": True}}))
+
+        assert captured_headers[0]["Authorization"] == "Bearer file-token-xyz"
+
+    @patch("obs.logic.manager.httpx.AsyncClient")
+    def test_inline_bearer_token_takes_precedence_over_token_file(self, mock_client_cls):
+        captured_headers: list[dict] = []
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        async def _capture(method, url, **kwargs):
+            captured_headers.append(kwargs.get("headers", {}))
+            return _mock_response(200, {})
+
+        mock_client.request = _capture
+
+        manager = _make_manager()
+        data = {
+            "url": "http://example.com/",
+            "method": "GET",
+            "auth_type": "bearer",
+            "auth_token": "inline-token",
+            "auth_token_file": "/run/secrets/api-token",
+        }
+        n = node("ac", "api_client", data)
+        flow = _flow([n])
+        graph_id = "g-bearer-token-file-precedence"
+        manager._graphs[graph_id] = ("t", True, flow)
+        manager._node_state[graph_id] = {}
+
+        with patch("obs.logic.manager._read_secret_file") as read_secret:
+            with patch("obs.api.v1.websocket.get_ws_manager", side_effect=RuntimeError("no ws")):
+                asyncio.run(manager._execute_graph(graph_id, "t", flow, {"ac": {"trigger": True}}))
+
+        read_secret.assert_not_called()
+        assert captured_headers[0]["Authorization"] == "Bearer inline-token"
 
     @patch("obs.logic.manager.httpx.AsyncClient")
     def test_none_auth_no_auth_object(self, mock_client_cls):


### PR DESCRIPTION
## Summary
- add api_client support for loading headers from a root-managed JSON secret file
- add bearer token loading from a secret file when no inline token is configured
- expose both fields in the api_client node schema

## Tests
- /tmp/obs-pr-test-venv/bin/python -m pytest tests/unit/test_api_client.py -q
- /tmp/obs-pr-test-venv/bin/ruff check --cache-dir /tmp/obs-ruff-cache obs/logic/manager.py obs/logic/node_types.py tests/unit/test_api_client.py