### PR TITLE
test(history): achieve 98% coverage across all history plugin modules

### DIFF
--- a/tests/unit/test_history_factory.py
+++ b/tests/unit/test_history_factory.py
@@ -1,0 +1,282 @@
+"""Unit tests for obs.history.factory.
+
+All external dependencies (asyncpg, xknxproject, DB) are mocked so no
+Docker / real database is required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+import obs.history.factory as factory_mod
+from obs.history.factory import (
+    _create_influxdb_plugin,
+    _create_timescaledb_plugin,
+    _load_history_settings,
+    get_history_plugin,
+    handle_value_event,
+    init_history_plugin,
+    reload_history_plugin,
+    reset_history_plugin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin():
+    """Always start each test with a clean plugin singleton."""
+    reset_history_plugin()
+    yield
+    reset_history_plugin()
+
+
+def _fake_db(rows=None):
+    """Return a mock DB whose fetchall() returns the given rows."""
+    db = mock.AsyncMock()
+    db.fetchall = mock.AsyncMock(return_value=rows or [])
+    return db
+
+
+def _row(key, value):
+    return {"key": key, "value": value}
+
+
+# ---------------------------------------------------------------------------
+# get_history_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestGetHistoryPlugin:
+    def test_raises_when_not_initialized(self):
+        with pytest.raises(RuntimeError, match="not initialized"):
+            get_history_plugin()
+
+
+# ---------------------------------------------------------------------------
+# reset_history_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestResetHistoryPlugin:
+    def test_reset_clears_singleton(self):
+        factory_mod._plugin = mock.MagicMock()
+        reset_history_plugin()
+        assert factory_mod._plugin is None
+
+
+# ---------------------------------------------------------------------------
+# _load_history_settings
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHistorySettings:
+    async def test_parses_rows(self):
+        db = _fake_db([_row("history.plugin", "influxdb"), _row("history.influx_url", "http://host:8086")])
+        cfg = await _load_history_settings(db)
+        assert cfg["plugin"] == "influxdb"
+        assert cfg["influx_url"] == "http://host:8086"
+
+    async def test_empty_db_returns_empty_dict(self):
+        cfg = await _load_history_settings(_fake_db())
+        assert cfg == {}
+
+    async def test_none_value_becomes_empty_string(self):
+        db = _fake_db([_row("history.plugin", None)])
+        cfg = await _load_history_settings(db)
+        assert cfg["plugin"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _create_influxdb_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestCreateInfluxdbPlugin:
+    def test_creates_plugin_with_defaults(self):
+        p = _create_influxdb_plugin({})
+        from obs.history.influxdb_plugin import InfluxDBHistoryPlugin
+
+        assert isinstance(p, InfluxDBHistoryPlugin)
+
+    def test_creates_plugin_with_custom_values(self):
+        cfg = {
+            "influx_url": "http://custom:9999",
+            "influx_version": "1",
+            "influx_token": "tok",
+            "influx_org": "org",
+            "influx_bucket": "bkt",
+            "influx_database": "mydb",
+            "influx_username": "user",
+            "influx_password": "pass",
+        }
+        p = _create_influxdb_plugin(cfg)
+        assert p._url == "http://custom:9999"
+        assert p._version == 1
+
+
+# ---------------------------------------------------------------------------
+# _create_timescaledb_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTimescaledbPlugin:
+    async def test_raises_when_dsn_missing(self):
+        with pytest.raises(ValueError, match="timescale_dsn"):
+            await _create_timescaledb_plugin({})
+
+    async def test_creates_and_connects(self):
+        fake_plugin = mock.AsyncMock()
+        fake_module = mock.MagicMock()
+        fake_module.TimescaleDBHistoryPlugin = mock.MagicMock(return_value=fake_plugin)
+        import sys
+
+        with mock.patch.dict(sys.modules, {"obs.history.timescaledb_plugin": fake_module}):
+            result = await _create_timescaledb_plugin({"timescale_dsn": "postgresql://x"})
+        fake_plugin.connect.assert_awaited_once()
+        assert result is fake_plugin
+
+
+# ---------------------------------------------------------------------------
+# init_history_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestInitHistoryPlugin:
+    async def test_defaults_to_sqlite(self):
+        db = _fake_db()
+        plugin = await init_history_plugin(db)
+        from obs.history.sqlite_plugin import SQLiteHistoryPlugin
+
+        assert isinstance(plugin, SQLiteHistoryPlugin)
+
+    async def test_sqlite_plugin_registered(self):
+        db = _fake_db()
+        await init_history_plugin(db)
+        assert get_history_plugin() is not None
+
+    async def test_influxdb_selected(self):
+        db = _fake_db([_row("history.plugin", "influxdb")])
+        plugin = await init_history_plugin(db)
+        from obs.history.influxdb_plugin import InfluxDBHistoryPlugin
+
+        assert isinstance(plugin, InfluxDBHistoryPlugin)
+
+    async def test_timescaledb_selected(self):
+        import sys
+
+        db = _fake_db([_row("history.plugin", "timescaledb"), _row("history.timescale_dsn", "postgresql://x")])
+        fake_plugin = mock.AsyncMock()
+        fake_module = mock.MagicMock()
+        fake_module.TimescaleDBHistoryPlugin = mock.MagicMock(return_value=fake_plugin)
+        with mock.patch.dict(sys.modules, {"obs.history.timescaledb_plugin": fake_module}):
+            plugin = await init_history_plugin(db)
+        assert plugin is fake_plugin
+
+
+# ---------------------------------------------------------------------------
+# reload_history_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestReloadHistoryPlugin:
+    async def test_disconnects_old_plugin(self):
+        old = mock.AsyncMock()
+        old.disconnect = mock.AsyncMock()
+        factory_mod._plugin = old
+        db = _fake_db()
+        await reload_history_plugin(db)
+        old.disconnect.assert_awaited_once()
+
+    async def test_old_plugin_without_disconnect(self):
+        old = mock.MagicMock(spec=[])  # no disconnect attribute
+        factory_mod._plugin = old
+        db = _fake_db()
+        # Should not raise
+        await reload_history_plugin(db)
+
+    async def test_disconnect_error_is_swallowed(self):
+        old = mock.AsyncMock()
+        old.disconnect = mock.AsyncMock(side_effect=Exception("boom"))
+        factory_mod._plugin = old
+        db = _fake_db()
+        # Should not raise
+        await reload_history_plugin(db)
+
+    async def test_returns_new_plugin(self):
+        factory_mod._plugin = mock.AsyncMock()
+        db = _fake_db()
+        new_plugin = await reload_history_plugin(db)
+        from obs.history.sqlite_plugin import SQLiteHistoryPlugin
+
+        assert isinstance(new_plugin, SQLiteHistoryPlugin)
+
+
+# ---------------------------------------------------------------------------
+# handle_value_event
+# ---------------------------------------------------------------------------
+
+
+class TestHandleValueEvent:
+    def _event(self, dp_id=None, value=1.0, quality="good", ts=None, source_adapter=None):
+        e = SimpleNamespace(
+            datapoint_id=dp_id or uuid.uuid4(),
+            value=value,
+            quality=quality,
+            ts=ts or datetime.now(UTC),
+            source_adapter=source_adapter,
+        )
+        return e
+
+    async def test_noop_when_no_plugin(self):
+        # _plugin is None — should silently return
+        await handle_value_event(self._event())
+
+    async def test_writes_to_plugin(self):
+        fake = mock.AsyncMock()
+        factory_mod._plugin = fake
+        ev = self._event(value=42.0, quality="ok")
+        # Mock registry to return a DP with record_history=True
+        dp = SimpleNamespace(record_history=True, unit="°C")
+        fake_registry = mock.MagicMock()
+        fake_registry.get.return_value = dp
+        with mock.patch("obs.core.registry.get_registry", return_value=fake_registry):
+            await handle_value_event(ev)
+        fake.write.assert_awaited_once()
+
+    async def test_skips_when_record_history_false(self):
+        fake = mock.AsyncMock()
+        factory_mod._plugin = fake
+        ev = self._event()
+        dp = SimpleNamespace(record_history=False, unit=None)
+        fake_registry = mock.MagicMock()
+        fake_registry.get.return_value = dp
+        with mock.patch("obs.core.registry.get_registry", return_value=fake_registry):
+            await handle_value_event(ev)
+        fake.write.assert_not_awaited()
+
+    async def test_write_error_does_not_propagate(self):
+        fake = mock.AsyncMock()
+        fake.write = mock.AsyncMock(side_effect=Exception("db down"))
+        factory_mod._plugin = fake
+        ev = self._event()
+        with mock.patch("obs.core.registry.get_registry", side_effect=RuntimeError("not init")):
+            # registry not available → unit=None, write still called and error swallowed
+            await handle_value_event(ev)
+
+    async def test_registry_runtime_error_still_writes(self):
+        """If registry is not initialized, write is still attempted (unit=None)."""
+        fake = mock.AsyncMock()
+        factory_mod._plugin = fake
+        ev = self._event()
+        with mock.patch("obs.core.registry.get_registry", side_effect=RuntimeError("not init")):
+            await handle_value_event(ev)
+        fake.write.assert_awaited_once()

--- a/tests/unit/test_influxdb_plugin.py
+++ b/tests/unit/test_influxdb_plugin.py
@@ -1,34 +1,388 @@
+"""Unit tests for obs.history.influxdb_plugin.
+
+All network calls are mocked with unittest.mock so no real
+InfluxDB instance is required.
+"""
+
 from __future__ import annotations
 
-from obs.history.influxdb_plugin import InfluxDBHistoryPlugin
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest import mock
+
+import pytest
+
+from obs.history.influxdb_plugin import InfluxDBHistoryPlugin, _to_rfc3339
 
 
-def _plugin(version: int) -> InfluxDBHistoryPlugin:
-    return InfluxDBHistoryPlugin(
-        url="http://localhost:8181",
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _plugin(version: int = 2, **kwargs) -> InfluxDBHistoryPlugin:
+    defaults = dict(
+        url="http://localhost:8086",
         version=version,
-        token="token",
-        org="org",
-        bucket="bucket",
-        database="obs",
+        token="mytoken",
+        org="myorg",
+        bucket="mybucket",
+        database="mydb",
         username="user",
         password="pass",
     )
+    defaults.update(kwargs)
+    return InfluxDBHistoryPlugin(**defaults)
 
 
-def test_write_url_params_v1_uses_db_param():
-    url, params = _plugin(1)._write_url_params()
-    assert url.endswith("/write")
-    assert params == {"db": "obs", "precision": "ns"}
+def _ts(offset: int = 0) -> datetime:
+    return datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC) + timedelta(hours=offset)
 
 
-def test_write_url_params_v2_uses_org_and_bucket():
-    url, params = _plugin(2)._write_url_params()
-    assert url.endswith("/api/v2/write")
-    assert params == {"org": "org", "bucket": "bucket", "precision": "ns"}
+def _make_httpx_mock(status=204, json_body=None):
+    """Return a (ctx, client) pair where ctx is usable as AsyncClient(...)."""
+    resp = mock.MagicMock()
+    resp.status_code = status
+    resp.raise_for_status = mock.MagicMock()
+    if json_body is not None:
+        resp.json = mock.MagicMock(return_value=json_body)
+
+    client = mock.AsyncMock()
+    client.post = mock.AsyncMock(return_value=resp)
+    client.get = mock.AsyncMock(return_value=resp)
+
+    ctx = mock.MagicMock()
+    ctx.__aenter__ = mock.AsyncMock(return_value=client)
+    ctx.__aexit__ = mock.AsyncMock(return_value=False)
+    return ctx, client
 
 
-def test_write_url_params_v3_uses_db_param():
-    url, params = _plugin(3)._write_url_params()
-    assert url.endswith("/api/v3/write_lp")
-    assert params == {"db": "obs", "precision": "nanosecond"}
+# ---------------------------------------------------------------------------
+# _to_rfc3339
+# ---------------------------------------------------------------------------
+
+
+class TestToRfc3339:
+    def test_aware_datetime(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0, 123000, tzinfo=UTC)
+        result = _to_rfc3339(dt)
+        assert result == "2024-01-15T10:30:00.123Z"
+
+    def test_naive_datetime_treated_as_utc(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        result = _to_rfc3339(dt)
+        assert result.endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# URL / params helpers
+# ---------------------------------------------------------------------------
+
+
+class TestWriteUrlParams:
+    def test_v1(self):
+        url, params = _plugin(1)._write_url_params()
+        assert url.endswith("/write")
+        assert params == {"db": "mydb", "precision": "ns"}
+
+    def test_v2(self):
+        url, params = _plugin(2)._write_url_params()
+        assert url.endswith("/api/v2/write")
+        assert params == {"org": "myorg", "bucket": "mybucket", "precision": "ns"}
+
+    def test_v3(self):
+        url, params = _plugin(3)._write_url_params()
+        assert url.endswith("/api/v3/write_lp")
+        assert params == {"db": "mydb", "precision": "nanosecond"}
+
+
+class TestQueryUrlParams:
+    def test_v1_uses_database(self):
+        _, params = _plugin(1)._query_url_params()
+        assert params["db"] == "mydb"
+
+    def test_v2_uses_bucket(self):
+        _, params = _plugin(2)._query_url_params()
+        assert params["db"] == "mybucket"
+
+    def test_v3_uses_database(self):
+        _, params = _plugin(3)._query_url_params()
+        assert params["db"] == "mydb"
+
+
+# ---------------------------------------------------------------------------
+# _headers
+# ---------------------------------------------------------------------------
+
+
+class TestHeaders:
+    def test_v1_no_username_no_auth(self):
+        p = _plugin(1, username="", password="")
+        h = p._headers()
+        assert "Authorization" not in h
+
+    def test_v1_with_username_basic_auth(self):
+        h = _plugin(1)._headers()
+        assert h["Authorization"].startswith("Basic ")
+
+    def test_v2_bearer_token(self):
+        h = _plugin(2)._headers()
+        assert h["Authorization"] == "Token mytoken"
+
+    def test_v3_bearer_token(self):
+        h = _plugin(3)._headers()
+        assert h["Authorization"] == "Bearer mytoken"
+
+    def test_no_content_type_when_empty(self):
+        h = _plugin(2)._headers(content_type="")
+        assert "Content-Type" not in h
+
+
+# ---------------------------------------------------------------------------
+# _escape helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeHelpers:
+    def test_escape_tag_comma(self):
+        assert _plugin()._escape_tag("a,b") == r"a\,b"
+
+    def test_escape_tag_space(self):
+        assert _plugin()._escape_tag("a b") == r"a\ b"
+
+    def test_escape_tag_equals(self):
+        assert _plugin()._escape_tag("a=b") == r"a\=b"
+
+    def test_escape_field_str_quote(self):
+        assert _plugin()._escape_field_str('say "hi"') == r"say \"hi\""
+
+    def test_escape_field_str_backslash(self):
+        assert _plugin()._escape_field_str("a\\b") == "a\\\\b"
+
+
+# ---------------------------------------------------------------------------
+# _build_line
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLine:
+    def test_float_value_adds_v_field(self):
+        line = _plugin()._build_line(uuid.uuid4(), 42.5, "°C", "good", _ts())
+        assert "v=42.5" in line
+
+    def test_string_value_no_v_field(self):
+        line = _plugin()._build_line(uuid.uuid4(), "ON", None, "ok", _ts())
+        assert "v=" not in line
+
+    def test_nan_no_v_field(self):
+        line = _plugin()._build_line(uuid.uuid4(), float("nan"), None, "ok", _ts())
+        assert "v=" not in line
+
+    def test_measurement_name(self):
+        line = _plugin()._build_line(uuid.uuid4(), 1.0, None, "ok", _ts())
+        assert line.startswith("obs,dp_id=")
+
+    def test_contains_raw_and_quality(self):
+        line = _plugin()._build_line(uuid.uuid4(), True, None, "good", _ts())
+        assert 'raw="' in line
+        assert 'quality="good"' in line
+
+
+# ---------------------------------------------------------------------------
+# _parse_influxql_series
+# ---------------------------------------------------------------------------
+
+
+class TestParseInfluxqlSeries:
+    def _make_response(self, columns, values):
+        return {"results": [{"series": [{"columns": columns, "values": values}]}]}
+
+    def test_raw_field_query(self):
+        # raw stores JSON-encoded values; "42.5" (with quotes) decodes to str "42.5"
+        # Store the number unquoted so json.loads returns float
+        data = self._make_response(
+            ["time", "raw", "quality", "unit"],
+            [["2024-01-01T00:00:00Z", "42.5", "good", "°C"]],
+        )
+        result = _plugin()._parse_influxql_series(data, raw_field=True)
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(42.5)
+        assert result[0]["q"] == "good"
+        assert result[0]["u"] == "°C"
+
+    def test_aggregate_field_query(self):
+        data = self._make_response(
+            ["time", "mean"],
+            [["2024-01-01T00:00:00Z", 15.0]],
+        )
+        result = _plugin()._parse_influxql_series(data, raw_field=False)
+        assert result[0]["bucket"] == "2024-01-01T00:00:00Z"
+        assert result[0]["v"] == pytest.approx(15.0)
+
+    def test_empty_results(self):
+        assert _plugin()._parse_influxql_series({}, raw_field=True) == []
+
+    def test_empty_series(self):
+        data = {"results": [{"series": []}]}
+        assert _plugin()._parse_influxql_series(data, raw_field=True) == []
+
+    def test_invalid_raw_json_returns_raw_string(self):
+        data = self._make_response(
+            ["time", "raw", "quality", "unit"],
+            [["2024-01-01T00:00:00Z", "not-json", "", None]],
+        )
+        result = _plugin()._parse_influxql_series(data, raw_field=True)
+        assert result[0]["v"] == "not-json"
+
+
+# ---------------------------------------------------------------------------
+# write
+# ---------------------------------------------------------------------------
+
+
+class TestInfluxDBWrite:
+    async def test_write_posts_to_endpoint(self):
+        ctx, client = _make_httpx_mock(status=204)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            await _plugin(2).write(uuid.uuid4(), 42.0, "°C", "good", ts=_ts())
+        client.post.assert_awaited_once()
+
+    async def test_write_raises_on_http_error(self):
+        resp = mock.MagicMock()
+        resp.raise_for_status = mock.MagicMock(side_effect=Exception("HTTP 500"))
+        ctx = mock.MagicMock()
+        ctx.__aenter__ = mock.AsyncMock(return_value=mock.MagicMock(post=mock.AsyncMock(return_value=resp)))
+        ctx.__aexit__ = mock.AsyncMock(return_value=False)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            with pytest.raises(Exception, match="HTTP 500"):
+                await _plugin().write(uuid.uuid4(), 1.0, None, "ok", ts=_ts())
+
+    async def test_write_without_ts_uses_now(self):
+        ctx, client = _make_httpx_mock(status=204)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            await _plugin().write(uuid.uuid4(), 1.0, None, "ok")
+        client.post.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# query
+# ---------------------------------------------------------------------------
+
+
+class TestInfluxDBQuery:
+    def _query_response(self):
+        return {
+            "results": [
+                {
+                    "series": [
+                        {
+                            "columns": ["time", "raw", "quality", "unit"],
+                            "values": [["2024-01-01T00:00:00Z", "7.5", "ok", "V"]],
+                        }
+                    ]
+                }
+            ]
+        }
+
+    async def test_query_returns_rows(self):
+        ctx, _ = _make_httpx_mock(status=200, json_body=self._query_response())
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            result = await _plugin().query(uuid.uuid4(), _ts(0), _ts(1))
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(7.5)
+
+    async def test_query_http_error_returns_empty(self):
+        resp = mock.MagicMock()
+        resp.raise_for_status = mock.MagicMock(side_effect=Exception("500"))
+        ctx = mock.MagicMock()
+        ctx.__aenter__ = mock.AsyncMock(return_value=mock.MagicMock(get=mock.AsyncMock(return_value=resp)))
+        ctx.__aexit__ = mock.AsyncMock(return_value=False)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            result = await _plugin().query(uuid.uuid4(), _ts(0), _ts(1))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestInfluxDBAggregate:
+    def _agg_response(self):
+        return {
+            "results": [
+                {
+                    "series": [
+                        {
+                            "columns": ["time", "mean"],
+                            "values": [["2024-01-01T00:00:00Z", 10.0]],
+                        }
+                    ]
+                }
+            ]
+        }
+
+    async def test_aggregate_avg(self):
+        ctx, _ = _make_httpx_mock(status=200, json_body=self._agg_response())
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            result = await _plugin().aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(1))
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(10.0)
+
+    async def test_aggregate_unknown_interval_falls_back_to_1h(self):
+        ctx, client = _make_httpx_mock(status=200, json_body=self._agg_response())
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            await _plugin().aggregate(uuid.uuid4(), "avg", "bad_interval", _ts(0), _ts(1))
+        q = client.get.call_args.kwargs.get("params", {}).get("q", "")
+        assert "GROUP BY time(1h)" in q
+
+    async def test_aggregate_http_error_returns_empty(self):
+        resp = mock.MagicMock()
+        resp.raise_for_status = mock.MagicMock(side_effect=Exception("500"))
+        ctx = mock.MagicMock()
+        ctx.__aenter__ = mock.AsyncMock(return_value=mock.MagicMock(get=mock.AsyncMock(return_value=resp)))
+        ctx.__aexit__ = mock.AsyncMock(return_value=False)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            result = await _plugin().aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(1))
+        assert result == []
+
+    async def test_aggregate_all_fns(self):
+        for fn in ("avg", "min", "max", "last"):
+            ctx, client = _make_httpx_mock(status=200, json_body=self._agg_response())
+            with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+                result = await _plugin().aggregate(uuid.uuid4(), fn, "1h", _ts(0), _ts(1))
+            assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+class TestInfluxDBPing:
+    async def test_ping_v1_success(self):
+        ctx, _ = _make_httpx_mock(status=204)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            assert await _plugin(1).ping() is True
+
+    async def test_ping_v1_failure(self):
+        ctx, _ = _make_httpx_mock(status=500)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            assert await _plugin(1).ping() is False
+
+    async def test_ping_v2_success(self):
+        ctx, _ = _make_httpx_mock(status=200)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            assert await _plugin(2).ping() is True
+
+    async def test_ping_v3_success(self):
+        ctx, _ = _make_httpx_mock(status=200, json_body={"results": []})
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            assert await _plugin(3).ping() is True
+
+    async def test_ping_exception_returns_false(self):
+        ctx = mock.MagicMock()
+        ctx.__aenter__ = mock.AsyncMock(side_effect=Exception("connection refused"))
+        ctx.__aexit__ = mock.AsyncMock(return_value=False)
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            assert await _plugin(1).ping() is False

--- a/tests/unit/test_sqlite_plugin.py
+++ b/tests/unit/test_sqlite_plugin.py
@@ -1,0 +1,376 @@
+"""Unit tests for obs.history.sqlite_plugin.
+
+All tests use an in-memory SQLite database via the real Database class so
+no mocking of SQL is required and every branch is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from obs.history.sqlite_plugin import (
+    SQLiteHistoryPlugin,
+    _aggregate_python,
+    _bucket_key,
+    _safe_loads,
+    _to_sqlite_ts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Minimal in-memory Database with the history_values table."""
+    from obs.db.database import Database
+
+    db_path = str(tmp_path / "test.db")
+    d = Database(db_path)
+    await d.connect()
+    # Create only what the plugin needs
+    await d.execute(
+        """CREATE TABLE IF NOT EXISTS history_values (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            datapoint_id   TEXT NOT NULL,
+            value          TEXT,
+            unit           TEXT,
+            quality        TEXT NOT NULL DEFAULT '',
+            ts             TEXT NOT NULL,
+            source_adapter TEXT
+        )"""
+    )
+    await d.commit()
+    yield d
+    await d.disconnect()
+
+
+@pytest.fixture
+async def plugin(db):
+    return SQLiteHistoryPlugin(db)
+
+
+def _ts(offset_minutes: int = 0) -> datetime:
+    return datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC) + timedelta(minutes=offset_minutes)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestToSqliteTs:
+    def test_format(self):
+        dt = datetime(2024, 6, 15, 10, 30, 45, 123456, tzinfo=UTC)
+        result = _to_sqlite_ts(dt)
+        assert result == "2024-06-15T10:30:45.123Z"
+
+    def test_millisecond_truncation(self):
+        dt = datetime(2024, 1, 1, 0, 0, 0, 999999, tzinfo=UTC)
+        result = _to_sqlite_ts(dt)
+        assert result.endswith("Z")
+        assert "." in result
+
+
+class TestSafeLoads:
+    def test_none_returns_none(self):
+        assert _safe_loads(None) is None
+
+    def test_valid_json_int(self):
+        assert _safe_loads("42") == 42
+
+    def test_valid_json_float(self):
+        assert _safe_loads("3.14") == pytest.approx(3.14)
+
+    def test_valid_json_string(self):
+        assert _safe_loads('"hello"') == "hello"
+
+    def test_invalid_json_returns_raw(self):
+        assert _safe_loads("not-json") == "not-json"
+
+
+class TestBucketKey:
+    def test_5m_bucket(self):
+        ts = "2024-01-01T12:07:30Z"
+        assert _bucket_key(ts, 5) == "2024-01-01T12:05:00"
+
+    def test_15m_bucket(self):
+        ts = "2024-01-01T12:22:00Z"
+        assert _bucket_key(ts, 15) == "2024-01-01T12:15:00"
+
+    def test_30m_bucket_upper_half(self):
+        ts = "2024-01-01T12:45:00Z"
+        assert _bucket_key(ts, 30) == "2024-01-01T12:30:00"
+
+    def test_invalid_ts_returns_truncated(self):
+        result = _bucket_key("bad-ts-string-xyz", 5)
+        # Falls back to ts[:16]
+        assert result == "bad-ts-string-xy"
+
+
+class TestAggregatePython:
+    def _rows(self, pairs):
+        return [{"ts": ts, "value": json.dumps(v)} for ts, v in pairs]
+
+    def test_avg(self):
+        rows = self._rows(
+            [
+                ("2024-01-01T12:00:00Z", 10.0),
+                ("2024-01-01T12:02:00Z", 20.0),
+            ]
+        )
+        result = _aggregate_python(rows, "avg", 5)
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(15.0)
+
+    def test_min(self):
+        rows = self._rows(
+            [
+                ("2024-01-01T12:00:00Z", 5.0),
+                ("2024-01-01T12:01:00Z", 3.0),
+            ]
+        )
+        result = _aggregate_python(rows, "min", 5)
+        assert result[0]["v"] == pytest.approx(3.0)
+
+    def test_max(self):
+        rows = self._rows(
+            [
+                ("2024-01-01T12:00:00Z", 5.0),
+                ("2024-01-01T12:01:00Z", 3.0),
+            ]
+        )
+        result = _aggregate_python(rows, "max", 5)
+        assert result[0]["v"] == pytest.approx(5.0)
+
+    def test_last(self):
+        rows = self._rows(
+            [
+                ("2024-01-01T12:00:00Z", 1.0),
+                ("2024-01-01T12:02:00Z", 9.0),
+            ]
+        )
+        result = _aggregate_python(rows, "last", 5)
+        assert result[0]["v"] == pytest.approx(9.0)
+
+    def test_non_numeric_value_skipped(self):
+        rows = self._rows([("2024-01-01T12:00:00Z", "text")])
+        result = _aggregate_python(rows, "avg", 5)
+        assert result == []
+
+    def test_unknown_fn_returns_empty(self):
+        rows = self._rows([("2024-01-01T12:00:00Z", 1.0)])
+        result = _aggregate_python(rows, "unknown", 5)
+        assert result == []
+
+    def test_two_buckets(self):
+        rows = self._rows(
+            [
+                ("2024-01-01T12:00:00Z", 1.0),
+                ("2024-01-01T12:10:00Z", 2.0),
+            ]
+        )
+        result = _aggregate_python(rows, "avg", 5)
+        assert len(result) == 2
+
+    def test_tuple_rows(self):
+        """Rows may be tuples (index-based) rather than dicts."""
+        rows = [("2024-01-01T12:00:00Z", "5.0")]
+        result = _aggregate_python(rows, "avg", 5)
+        assert result[0]["v"] == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# SQLiteHistoryPlugin — write / query
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteWrite:
+    async def test_write_stores_row(self, plugin, db):
+        dp_id = uuid.uuid4()
+        await plugin.write(dp_id, 42.0, "°C", "good", ts=_ts())
+        rows = await db.fetchall("SELECT * FROM history_values WHERE datapoint_id=?", (str(dp_id),))
+        assert len(rows) == 1
+        assert json.loads(rows[0]["value"]) == 42.0
+        assert rows[0]["unit"] == "°C"
+        assert rows[0]["quality"] == "good"
+
+    async def test_write_without_ts_uses_now(self, plugin, db):
+        dp_id = uuid.uuid4()
+        await plugin.write(dp_id, 1.0, None, "ok")
+        rows = await db.fetchall("SELECT ts FROM history_values WHERE datapoint_id=?", (str(dp_id),))
+        assert len(rows) == 1
+        assert rows[0]["ts"].endswith("Z")
+
+    async def test_write_string_value(self, plugin, db):
+        dp_id = uuid.uuid4()
+        await plugin.write(dp_id, "ON", None, "ok", ts=_ts())
+        rows = await db.fetchall("SELECT value FROM history_values WHERE datapoint_id=?", (str(dp_id),))
+        assert json.loads(rows[0]["value"]) == "ON"
+
+    async def test_write_bool_value(self, plugin, db):
+        dp_id = uuid.uuid4()
+        await plugin.write(dp_id, True, None, "ok", ts=_ts())
+        rows = await db.fetchall("SELECT value FROM history_values WHERE datapoint_id=?", (str(dp_id),))
+        assert json.loads(rows[0]["value"]) is True
+
+
+class TestSQLiteQuery:
+    async def _write_n(self, plugin, dp_id, n):
+        for i in range(n):
+            await plugin.write(dp_id, float(i), None, "ok", ts=_ts(i))
+
+    async def test_query_returns_rows_in_range(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_n(plugin, dp_id, 5)
+        result = await plugin.query(dp_id, _ts(0), _ts(4))
+        assert len(result) == 5
+
+    async def test_query_respects_limit(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_n(plugin, dp_id, 10)
+        result = await plugin.query(dp_id, _ts(0), _ts(9), limit=3)
+        assert len(result) == 3
+
+    async def test_query_order_desc(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_n(plugin, dp_id, 3)
+        result = await plugin.query(dp_id, _ts(0), _ts(2))
+        # newest first
+        assert result[0]["v"] >= result[-1]["v"]
+
+    async def test_query_empty_range(self, plugin):
+        dp_id = uuid.uuid4()
+        result = await plugin.query(dp_id, _ts(100), _ts(200))
+        assert result == []
+
+    async def test_query_result_shape(self, plugin):
+        dp_id = uuid.uuid4()
+        await plugin.write(dp_id, 7.5, "V", "good", ts=_ts())
+        result = await plugin.query(dp_id, _ts(-1), _ts(1))
+        assert len(result) == 1
+        row = result[0]
+        assert "ts" in row
+        assert "v" in row
+        assert "u" in row
+        assert "q" in row
+        assert row["v"] == pytest.approx(7.5)
+        assert row["u"] == "V"
+
+
+# ---------------------------------------------------------------------------
+# SQLiteHistoryPlugin — aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteAggregate:
+    async def _write_series(self, plugin, dp_id, values_with_offset):
+        for offset, val in values_with_offset:
+            await plugin.write(dp_id, float(val), None, "ok", ts=_ts(offset))
+
+    async def test_aggregate_avg_1h(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 10.0), (30, 20.0)])
+        result = await plugin.aggregate(dp_id, "avg", "1h", _ts(-1), _ts(60))
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(15.0)
+
+    async def test_aggregate_min_1h(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 3.0), (30, 9.0)])
+        result = await plugin.aggregate(dp_id, "min", "1h", _ts(-1), _ts(60))
+        assert result[0]["v"] == pytest.approx(3.0)
+
+    async def test_aggregate_max_1h(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 3.0), (30, 9.0)])
+        result = await plugin.aggregate(dp_id, "max", "1h", _ts(-1), _ts(60))
+        assert result[0]["v"] == pytest.approx(9.0)
+
+    async def test_aggregate_last_1h(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 1.0), (30, 99.0)])
+        result = await plugin.aggregate(dp_id, "last", "1h", _ts(-1), _ts(60))
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(99.0)
+
+    async def test_aggregate_sub_hourly_avg(self, plugin):
+        """5m interval triggers Python-side aggregation."""
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 10.0), (2, 20.0)])
+        result = await plugin.aggregate(dp_id, "avg", "5m", _ts(-1), _ts(10))
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(15.0)
+
+    async def test_aggregate_sub_hourly_last(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 5.0), (2, 8.0)])
+        result = await plugin.aggregate(dp_id, "last", "5m", _ts(-1), _ts(10))
+        assert result[0]["v"] == pytest.approx(8.0)
+
+    async def test_aggregate_unknown_interval_falls_back_to_1h(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 42.0)])
+        result = await plugin.aggregate(dp_id, "avg", "bad_interval", _ts(-1), _ts(60))
+        assert len(result) == 1
+
+    async def test_aggregate_empty_returns_empty(self, plugin):
+        dp_id = uuid.uuid4()
+        result = await plugin.aggregate(dp_id, "avg", "1h", _ts(100), _ts(200))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# SQLiteHistoryPlugin — delete_before
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteDeleteBefore:
+    async def test_delete_before_removes_old_rows(self, plugin, db):
+        dp_id = uuid.uuid4()
+        for i in range(5):
+            await plugin.write(dp_id, float(i), None, "ok", ts=_ts(i))
+        deleted = await plugin.delete_before(dp_id, _ts(3))
+        assert deleted == 3
+        rows = await db.fetchall("SELECT * FROM history_values WHERE datapoint_id=?", (str(dp_id),))
+        assert len(rows) == 2
+
+    async def test_delete_before_nothing_to_delete(self, plugin):
+        dp_id = uuid.uuid4()
+        await plugin.write(dp_id, 1.0, None, "ok", ts=_ts(10))
+        deleted = await plugin.delete_before(dp_id, _ts(0))
+        assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteModuleSingleton:
+    def test_get_raises_when_not_initialized(self):
+        import obs.history.sqlite_plugin as mod
+
+        mod._plugin = None
+        from obs.history.sqlite_plugin import get_history_plugin
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            get_history_plugin()
+
+    def test_init_sets_and_returns_plugin(self, db):
+        from obs.history.sqlite_plugin import get_history_plugin, init_history_plugin
+
+        p = init_history_plugin(db)
+        assert isinstance(p, SQLiteHistoryPlugin)
+        assert get_history_plugin() is p
+
+    def teardown_method(self, _):
+        import obs.history.sqlite_plugin as mod
+
+        mod._plugin = None

--- a/tests/unit/test_timescaledb_plugin.py
+++ b/tests/unit/test_timescaledb_plugin.py
@@ -1,0 +1,382 @@
+"""Unit tests for obs.history.timescaledb_plugin.
+
+asyncpg and all DB connections are fully mocked — no PostgreSQL instance required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest import mock
+
+import pytest
+
+from obs.history.timescaledb_plugin import TimescaleDBHistoryPlugin, _pg_bucket_expr
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _plugin(dsn="postgresql://test/test") -> TimescaleDBHistoryPlugin:
+    return TimescaleDBHistoryPlugin(dsn=dsn)
+
+
+def _ts(offset_h: int = 0) -> datetime:
+    return datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC) + timedelta(hours=offset_h)
+
+
+def _make_pool_mock(rows=None, execute_side_effect=None):
+    """Build a mock asyncpg pool with acquire() context manager."""
+    conn = mock.AsyncMock()
+    conn.fetchval = mock.AsyncMock(return_value=1)
+    conn.fetch = mock.AsyncMock(return_value=rows or [])
+
+    if execute_side_effect:
+        # execute raises on first call (hypertable), succeeds otherwise
+        conn.execute = mock.AsyncMock(side_effect=execute_side_effect)
+    else:
+        conn.execute = mock.AsyncMock(return_value=None)
+
+    acq_ctx = mock.MagicMock()
+    acq_ctx.__aenter__ = mock.AsyncMock(return_value=conn)
+    acq_ctx.__aexit__ = mock.AsyncMock(return_value=False)
+
+    pool = mock.AsyncMock()
+    pool.acquire = mock.MagicMock(return_value=acq_ctx)
+    pool.close = mock.AsyncMock()
+    return pool, conn
+
+
+def _make_asyncpg_mock(pool):
+    """Return a mock asyncpg module whose create_pool returns the given pool."""
+    asyncpg = mock.MagicMock()
+    asyncpg.create_pool = mock.AsyncMock(return_value=pool)
+    conn_mock = mock.AsyncMock()
+    conn_mock.fetchval = mock.AsyncMock(return_value=1)
+    conn_mock.close = mock.AsyncMock()
+    asyncpg.connect = mock.AsyncMock(return_value=conn_mock)
+    return asyncpg
+
+
+# ---------------------------------------------------------------------------
+# _pg_bucket_expr
+# ---------------------------------------------------------------------------
+
+
+class TestPgBucketExpr:
+    def test_1_hour(self):
+        assert _pg_bucket_expr("1 hour") == "date_trunc('hour', time)"
+
+    def test_1_day(self):
+        assert _pg_bucket_expr("1 day") == "date_trunc('day', time)"
+
+    def test_1_minute(self):
+        assert _pg_bucket_expr("1 minute") == "date_trunc('minute', time)"
+
+    def test_5_minutes(self):
+        expr = _pg_bucket_expr("5 minutes")
+        assert "300" in expr  # 5 * 60
+
+    def test_15_minutes(self):
+        expr = _pg_bucket_expr("15 minutes")
+        assert "900" in expr
+
+    def test_30_minutes(self):
+        expr = _pg_bucket_expr("30 minutes")
+        assert "1800" in expr
+
+    def test_6_hours(self):
+        expr = _pg_bucket_expr("6 hours")
+        assert "21600" in expr
+
+    def test_12_hours(self):
+        expr = _pg_bucket_expr("12 hours")
+        assert "43200" in expr
+
+    def test_unknown_falls_back_to_hour(self):
+        assert _pg_bucket_expr("99 years") == "date_trunc('hour', time)"
+
+
+# ---------------------------------------------------------------------------
+# connect / disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    async def test_connect_creates_pool_and_schema(self):
+        pool, conn = _make_pool_mock()
+        asyncpg = _make_asyncpg_mock(pool)
+        p = _plugin()
+        with mock.patch.dict(__import__("sys").modules, {"asyncpg": asyncpg}):
+            await p.connect()
+        asyncpg.create_pool.assert_awaited_once()
+        assert p._pool is pool
+
+    async def test_connect_detects_timescaledb(self):
+        pool, conn = _make_pool_mock()
+        asyncpg = _make_asyncpg_mock(pool)
+        p = _plugin()
+        with mock.patch.dict(__import__("sys").modules, {"asyncpg": asyncpg}):
+            await p.connect()
+        assert p._has_timescaledb is True
+
+    async def test_connect_without_timescaledb_extension(self):
+        """When the hypertable call raises, has_timescaledb=False."""
+        calls = [None, Exception("extension not found"), None]
+        pool, conn = _make_pool_mock(execute_side_effect=calls)
+        asyncpg = _make_asyncpg_mock(pool)
+        p = _plugin()
+        with mock.patch.dict(__import__("sys").modules, {"asyncpg": asyncpg}):
+            await p.connect()
+        assert p._has_timescaledb is False
+
+    async def test_connect_import_error(self):
+        import sys
+
+        with mock.patch.dict(sys.modules, {"asyncpg": None}):
+            with pytest.raises(RuntimeError, match="asyncpg"):
+                await _plugin().connect()
+
+    async def test_disconnect_closes_pool(self):
+        pool, _ = _make_pool_mock()
+        p = _plugin()
+        p._pool = pool
+        await p.disconnect()
+        pool.close.assert_awaited_once()
+        assert p._pool is None
+
+    async def test_disconnect_when_not_connected(self):
+        p = _plugin()
+        await p.disconnect()  # should not raise
+
+    def test_require_pool_raises_when_none(self):
+        p = _plugin()
+        with pytest.raises(RuntimeError, match="not connected"):
+            p._require_pool()
+
+
+# ---------------------------------------------------------------------------
+# write
+# ---------------------------------------------------------------------------
+
+
+class TestTimescaleWrite:
+    async def test_write_inserts_row(self):
+        pool, conn = _make_pool_mock()
+        p = _plugin()
+        p._pool = pool
+        await p.write(uuid.uuid4(), 42.0, "°C", "good", ts=_ts())
+        conn.execute.assert_awaited_once()
+        call_sql = conn.execute.call_args.args[0]
+        assert "INSERT INTO dp_history" in call_sql
+
+    async def test_write_nan_converts_to_none(self):
+        pool, conn = _make_pool_mock()
+        p = _plugin()
+        p._pool = pool
+        await p.write(uuid.uuid4(), float("nan"), None, "ok", ts=_ts())
+        args = conn.execute.call_args.args
+        # v_float should be None (index 3 = $3)
+        assert args[3] is None
+
+    async def test_write_non_numeric_converts_to_none(self):
+        pool, conn = _make_pool_mock()
+        p = _plugin()
+        p._pool = pool
+        await p.write(uuid.uuid4(), "ON", None, "ok", ts=_ts())
+        args = conn.execute.call_args.args
+        assert args[3] is None
+
+    async def test_write_without_ts_uses_now(self):
+        pool, conn = _make_pool_mock()
+        p = _plugin()
+        p._pool = pool
+        await p.write(uuid.uuid4(), 1.0, None, "ok")
+        conn.execute.assert_awaited_once()
+
+    async def test_write_requires_pool(self):
+        p = _plugin()
+        with pytest.raises(RuntimeError):
+            await p.write(uuid.uuid4(), 1.0, None, "ok")
+
+
+# ---------------------------------------------------------------------------
+# query
+# ---------------------------------------------------------------------------
+
+
+def _make_row(time_dt, raw_json, unit, quality):
+    row = mock.MagicMock()
+    row.__getitem__ = lambda self, k: {
+        "time": time_dt,
+        "raw": raw_json,
+        "unit": unit,
+        "quality": quality,
+    }[k]
+    return row
+
+
+class TestTimescaleQuery:
+    async def test_query_returns_formatted_rows(self):
+        # raw stores JSON; "42.5" (no quotes) → json.loads → float 42.5
+        row = _make_row(_ts(), "42.5", "°C", "good")
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        result = await p.query(uuid.uuid4(), _ts(-1), _ts(1))
+        assert len(result) == 1
+        assert result[0]["v"] == pytest.approx(42.5)
+        assert result[0]["u"] == "°C"
+        assert result[0]["q"] == "good"
+
+    async def test_query_invalid_json_raw_returns_string(self):
+        row = _make_row(_ts(), "not-json", None, "")
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        result = await p.query(uuid.uuid4(), _ts(-1), _ts(1))
+        assert result[0]["v"] == "not-json"
+
+    async def test_query_none_raw_returns_none(self):
+        row = _make_row(_ts(), None, None, "")
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        result = await p.query(uuid.uuid4(), _ts(-1), _ts(1))
+        assert result[0]["v"] is None
+
+    async def test_query_empty_returns_empty_list(self):
+        pool, conn = _make_pool_mock(rows=[])
+        p = _plugin()
+        p._pool = pool
+        result = await p.query(uuid.uuid4(), _ts(-1), _ts(1))
+        assert result == []
+
+    async def test_query_requires_pool(self):
+        p = _plugin()
+        with pytest.raises(RuntimeError):
+            await p.query(uuid.uuid4(), _ts(-1), _ts(1))
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+
+def _make_agg_row(bucket_dt, v):
+    row = mock.MagicMock()
+    row.__getitem__ = lambda self, k: {"bucket": bucket_dt, "v": v}[k]
+    row.get = lambda k, d=None: {"bucket": bucket_dt, "v": v}.get(k, d)
+    return row
+
+
+class TestTimescaleAggregate:
+    async def _run(self, p, fn="avg", interval="1h", rows=None):
+        pool, conn = _make_pool_mock(rows=rows or [])
+        p._pool = pool
+        p._has_timescaledb = True
+        result = await p.aggregate(uuid.uuid4(), fn, interval, _ts(0), _ts(2))
+        return result, conn
+
+    async def test_aggregate_avg_timescaledb(self):
+        row = _make_agg_row(_ts(), 10.0)
+        p = _plugin()
+        result, _ = await self._run(p, fn="avg", rows=[row])
+        assert result[0]["v"] == pytest.approx(10.0)
+
+    async def test_aggregate_unknown_interval_falls_back(self):
+        p = _plugin()
+        result, conn = await self._run(p, fn="avg", interval="bad_interval")
+        sql = conn.fetch.call_args.args[0]
+        # Should have fallen back to "1h" → bucket_str = "1 hour"
+        assert "1 hour" in sql
+
+    async def test_aggregate_without_timescaledb_uses_pg_expr(self):
+        row = _make_agg_row(_ts(), 5.0)
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        p._has_timescaledb = False
+        await p.aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(2))
+        sql = conn.fetch.call_args.args[0]
+        assert "date_trunc" in sql
+
+    async def test_aggregate_last_timescaledb(self):
+        row = _make_agg_row(_ts(), 99.0)
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        p._has_timescaledb = True
+        result = await p.aggregate(uuid.uuid4(), "last", "1h", _ts(0), _ts(2))
+        assert result[0]["v"] == pytest.approx(99.0)
+        sql = conn.fetch.call_args.args[0]
+        assert "last(" in sql.lower()
+
+    async def test_aggregate_last_without_timescaledb(self):
+        row = _make_agg_row(_ts(), 7.0)
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        p._has_timescaledb = False
+        result = await p.aggregate(uuid.uuid4(), "last", "1h", _ts(0), _ts(2))
+        assert result[0]["v"] == pytest.approx(7.0)
+        sql = conn.fetch.call_args.args[0]
+        assert "DISTINCT ON" in sql
+
+    async def test_aggregate_bucket_isoformat(self):
+        """Bucket with isoformat() method is serialised as ISO string."""
+        row = _make_agg_row(_ts(), 3.0)
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        p._has_timescaledb = True
+        result = await p.aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(2))
+        assert "T" in result[0]["bucket"]  # ISO format
+
+    async def test_aggregate_bucket_no_isoformat(self):
+        """Bucket without isoformat (plain str) falls back to str()."""
+        row = mock.MagicMock()
+        row.__getitem__ = lambda self, k: {"bucket": "2024-06-01", "v": 1.0}[k]
+        pool, conn = _make_pool_mock(rows=[row])
+        p = _plugin()
+        p._pool = pool
+        p._has_timescaledb = True
+        result = await p.aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(2))
+        assert result[0]["bucket"] == "2024-06-01"
+
+    async def test_aggregate_requires_pool(self):
+        p = _plugin()
+        with pytest.raises(RuntimeError):
+            await p.aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(1))
+
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+class TestTimescalePing:
+    async def test_ping_success(self):
+        asyncpg = _make_asyncpg_mock(mock.AsyncMock())
+        p = _plugin()
+        with mock.patch.dict(__import__("sys").modules, {"asyncpg": asyncpg}):
+            result = await p.ping()
+        assert result is True
+
+    async def test_ping_failure_returns_false(self):
+        import sys
+
+        asyncpg = mock.MagicMock()
+        asyncpg.connect = mock.AsyncMock(side_effect=Exception("connection refused"))
+        with mock.patch.dict(sys.modules, {"asyncpg": asyncpg}):
+            result = await _plugin().ping()
+        assert result is False
+
+    async def test_ping_import_error_raises(self):
+        import sys
+
+        with mock.patch.dict(sys.modules, {"asyncpg": None}):
+            with pytest.raises(RuntimeError, match="asyncpg"):
+                await _plugin().ping()


### PR DESCRIPTION
Add 138 new unit tests across 4 new/extended test files covering the entire obs/history/ package. All tests run without Docker or any real database.

test_sqlite_plugin.py (41 tests) — sqlite_plugin.py 100%:
- _to_sqlite_ts, _safe_loads, _bucket_key, _aggregate_python (all fns + edge cases)
- SQLiteHistoryPlugin.write: float/string/bool values, ts=None fallback
- SQLiteHistoryPlugin.query: range, limit, DESC order, empty range, result shape
- SQLiteHistoryPlugin.aggregate: avg/min/max/last for hourly (SQL) and sub-hourly (Python-side) intervals; unknown interval fallback; empty result
- SQLiteHistoryPlugin.delete_before: removes correct rows, returns count
- Module-level singleton: get_history_plugin raises when unset, init sets it

test_influxdb_plugin.py (3 → 44 tests) — influxdb_plugin.py 100%:
- _to_rfc3339: aware and naive datetime
- _write_url_params / _query_url_params: all three InfluxDB versions
- _headers: v1 Basic auth, v2 Token, v3 Bearer, no-username, no content-type
- _escape_tag / _escape_field_str: comma, space, equals, quote, backslash
- _build_line: float v field, NaN/string → no v, measurement prefix, raw+quality
- _parse_influxql_series: raw and aggregate shapes, empty results, invalid JSON
- write: HTTP POST called, raises on error, ts=None fallback
- query: rows returned, HTTP error → empty list
- aggregate: avg, unknown interval fallback, HTTP error → empty, all fn variants
- ping: v1/v2/v3 success + failure, exception → False

test_history_factory.py (22 tests) — factory.py 100%:
- get_history_plugin: raises when uninitialized
- reset_history_plugin: clears singleton
- _load_history_settings: parses rows, empty DB, None value → ""
- _create_influxdb_plugin: defaults and custom config
- _create_timescaledb_plugin: raises on missing DSN, creates and connects
- init_history_plugin: sqlite default, influxdb, timescaledb selection
- reload_history_plugin: disconnects old plugin, swallows disconnect errors, handles plugins without disconnect, returns new plugin
- handle_value_event: noop with no plugin, writes with record_history=True, skips with record_history=False, swallows write errors, tolerates uninitialized registry

test_timescaledb_plugin.py (34 tests) — timescaledb_plugin.py 100%:
- _pg_bucket_expr: all 8 mapped intervals + unknown fallback
- connect: creates pool, detects TimescaleDB, falls back gracefully when extension absent, raises on missing asyncpg import
- disconnect: closes pool, noop when not connected
- _require_pool: raises RuntimeError when pool is None
- write: INSERT called, NaN/non-numeric → v=None, ts=None fallback, pool guard
- query: formatted rows, invalid JSON raw, None raw, empty result, pool guard
- aggregate: avg with TimescaleDB (time_bucket), without (date_trunc), unknown interval fallback; last with and without TimescaleDB; bucket isoformat and plain-string serialisation; pool guard
- ping: success, connection failure → False, missing asyncpg → RuntimeError

Final coverage: factory.py 100%, sqlite_plugin.py 100%, influxdb_plugin.py 100%, timescaledb_plugin.py 100%, base.py 80% (abstract method bodies uncoverable)

<img width="2116" height="712" alt="CleanShot 2026-05-29 at 17 57 58@2x" src="https://github.com/user-attachments/assets/61048e64-ee81-43e9-b042-cca5fd71aab2" />
