### PR TITLE
test(mqtt): achieve 100% coverage for MQTT adapter

### DIFF
--- a/tests/adapters/test_mqtt_adapter.py
+++ b/tests/adapters/test_mqtt_adapter.py
@@ -346,6 +346,21 @@ class TestTlsConfig:
 
         assert adapter._tls_context is None
 
+    @pytest.mark.asyncio
+    async def test_connect_tls_insecure_disables_cert_verification(self, mock_bus):
+        import ssl
+
+        adapter = MqttAdapter(
+            event_bus=mock_bus,
+            config={"host": "self-signed.example.com", "port": 8883, "tls": True, "tls_insecure": True},
+        )
+        with mock.patch.object(asyncio, "create_task", side_effect=_mock_create_task):
+            await adapter.connect()
+
+        assert isinstance(adapter._tls_context, ssl.SSLContext)
+        assert adapter._tls_context.check_hostname is False
+        assert adapter._tls_context.verify_mode == ssl.CERT_NONE
+
 
 # ---------------------------------------------------------------------------
 # Connection status accuracy
@@ -362,3 +377,399 @@ class TestConnectionStatus:
             await adapter.connect()
 
         assert adapter.connected is False
+
+
+# ---------------------------------------------------------------------------
+# read()
+# ---------------------------------------------------------------------------
+
+
+class TestRead:
+    @pytest.mark.asyncio
+    async def test_read_returns_none(self, adapter):
+        binding = make_binding({"topic": "sensor/temp"})
+        result = await adapter.read(binding)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# disconnect()
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnect:
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_pub_and_sub_tasks(self, adapter, mock_bus):
+        async def sleeper():
+            await asyncio.sleep(100)
+
+        adapter._pub_task = asyncio.create_task(sleeper())
+        adapter._sub_task = asyncio.create_task(sleeper())
+        adapter._topic_map["t"] = [make_binding({"topic": "t"})]
+
+        await adapter.disconnect()
+
+        assert adapter._pub_task is None
+        assert adapter._sub_task is None
+        assert adapter._topic_map == {}
+        assert mock_bus.publish.called
+
+    @pytest.mark.asyncio
+    async def test_disconnect_without_tasks_does_not_raise(self, adapter):
+        await adapter.disconnect()
+        assert adapter._pub_task is None
+        assert adapter._sub_task is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_with_only_pub_task(self, adapter):
+        async def sleeper():
+            await asyncio.sleep(100)
+
+        adapter._pub_task = asyncio.create_task(sleeper())
+
+        await adapter.disconnect()
+
+        assert adapter._pub_task is None
+        assert adapter._sub_task is None
+
+
+# ---------------------------------------------------------------------------
+# _on_bindings_reloaded()
+# ---------------------------------------------------------------------------
+
+
+class TestOnBindingsReloaded:
+    @pytest.mark.asyncio
+    async def test_returns_early_when_cfg_is_none(self, adapter):
+        """_on_bindings_reloaded does nothing before connect() is called."""
+        adapter._bindings = [make_binding({"topic": "t"})]
+        await adapter._on_bindings_reloaded()
+        assert adapter._topic_map == {}
+
+    @pytest.mark.asyncio
+    async def test_builds_topic_map_for_source_and_both(self, adapter):
+        adapter._cfg = MqttAdapterConfig(host="localhost")
+        adapter._bindings = [
+            make_binding({"topic": "src"}, direction="SOURCE"),
+            make_binding({"topic": "both"}, direction="BOTH"),
+            make_binding({"topic": "dst"}, direction="DEST"),
+        ]
+
+        with mock.patch.object(asyncio, "create_task", side_effect=_mock_create_task):
+            await adapter._on_bindings_reloaded()
+
+        assert "src" in adapter._topic_map
+        assert "both" in adapter._topic_map
+        assert "dst" not in adapter._topic_map
+
+    @pytest.mark.asyncio
+    async def test_skips_invalid_binding_config(self, adapter):
+        adapter._cfg = MqttAdapterConfig(host="localhost")
+        bad = make_binding({})  # missing required 'topic' -> ValidationError
+        good = make_binding({"topic": "ok"}, direction="SOURCE")
+        adapter._bindings = [bad, good]
+
+        with mock.patch.object(asyncio, "create_task", side_effect=_mock_create_task):
+            await adapter._on_bindings_reloaded()
+
+        assert "ok" in adapter._topic_map
+        assert len(adapter._topic_map) == 1
+
+    @pytest.mark.asyncio
+    async def test_cancels_old_sub_task_on_reload(self, adapter):
+        adapter._cfg = MqttAdapterConfig(host="localhost")
+
+        async def sleeper():
+            await asyncio.sleep(100)
+
+        old_task = asyncio.create_task(sleeper())
+        adapter._sub_task = old_task
+        adapter._bindings = [make_binding({"topic": "t"}, direction="SOURCE")]
+
+        with mock.patch.object(asyncio, "create_task", side_effect=_mock_create_task):
+            await adapter._on_bindings_reloaded()
+
+        assert old_task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_no_sub_task_when_only_dest_bindings(self, adapter):
+        adapter._cfg = MqttAdapterConfig(host="localhost")
+        adapter._bindings = [make_binding({"topic": "t"}, direction="DEST")]
+
+        await adapter._on_bindings_reloaded()
+
+        assert adapter._sub_task is None
+        assert adapter._topic_map == {}
+
+    @pytest.mark.asyncio
+    async def test_multiple_bindings_same_topic_are_grouped(self, adapter):
+        adapter._cfg = MqttAdapterConfig(host="localhost")
+        b1 = make_binding({"topic": "t"}, direction="SOURCE")
+        b2 = make_binding({"topic": "t"}, direction="BOTH")
+        adapter._bindings = [b1, b2]
+
+        with mock.patch.object(asyncio, "create_task", side_effect=_mock_create_task):
+            await adapter._on_bindings_reloaded()
+
+        assert len(adapter._topic_map["t"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# _on_message -- formula application
+# ---------------------------------------------------------------------------
+
+
+class TestOnMessageFormula:
+    @pytest.mark.asyncio
+    async def test_formula_applied_to_numeric_value(self, adapter, mock_bus):
+        binding = make_binding(
+            {"topic": "t", "source_data_type": "float"},
+            value_formula="x * 2",
+        )
+        adapter._topic_map["t"] = [binding]
+        await adapter._on_message("t", b"5.0")
+
+        event = mock_bus.publish.call_args[0][0]
+        assert event.value == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_formula_skipped_when_value_is_none(self, adapter, mock_bus):
+        binding = make_binding({"topic": "t"}, value_formula="x * 2")
+        adapter._topic_map["t"] = [binding]
+
+        with mock.patch("obs.adapters.mqtt.adapter.apply_source_type", return_value=None):
+            await adapter._on_message("t", b"5.0")
+
+        event = mock_bus.publish.call_args[0][0]
+        assert event.value is None
+
+
+# ---------------------------------------------------------------------------
+# _on_message -- exception handling in binding processing
+# ---------------------------------------------------------------------------
+
+
+class TestOnMessageExceptionHandling:
+    @pytest.mark.asyncio
+    async def test_exception_in_binding_processing_is_caught(self, adapter, mock_bus):
+        bad = mock.MagicMock()
+        bad.config = None  # MqttBindingConfig(**None) raises TypeError
+        bad.value_formula = None
+        bad.value_map = None
+        adapter._topic_map["t"] = [bad]
+
+        # Exception is caught; event is still published using the raw auto_value fallback.
+        await adapter._on_message("t", b"data")
+
+        assert mock_bus.publish.called
+        event = mock_bus.publish.call_args[0][0]
+        assert event.value == "data"  # json.loads("data") fails -> raw string
+
+
+# ---------------------------------------------------------------------------
+# write() -- exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestWriteExceptionHandling:
+    @pytest.mark.asyncio
+    async def test_write_exception_is_caught(self, adapter):
+        bad = make_binding({})  # missing topic -> Pydantic ValidationError
+
+        await adapter.write(bad, "value")
+
+        assert adapter._publish_queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# _subscriber_loop
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_aiomqtt_client(messages_gen):
+    """Build an async-context-manager mock for aiomqtt.Client."""
+    client = mock.AsyncMock()
+    client.__aenter__ = mock.AsyncMock(return_value=client)
+    client.__aexit__ = mock.AsyncMock(return_value=None)
+    client.subscribe = mock.AsyncMock()
+    client.messages = messages_gen
+    return client
+
+
+class TestSubscriberLoop:
+    @pytest.mark.asyncio
+    async def test_subscribes_and_dispatches_messages(self, adapter, mock_bus):
+        adapter._cfg = MqttAdapterConfig(host="broker.test")
+        adapter._sub_client_id = "obs-sub"
+        _add_binding(adapter, "t")
+
+        mock_msg = mock.MagicMock()
+        mock_msg.topic.__str__ = lambda self: "t"
+        mock_msg.payload = b"42"
+
+        dispatched = asyncio.Event()
+        original = adapter._on_message
+
+        async def tracking(topic, payload):
+            await original(topic, payload)
+            dispatched.set()
+
+        adapter._on_message = tracking
+
+        async def fake_messages():
+            yield mock_msg
+            await asyncio.Event().wait()  # block until task is cancelled
+
+        mock_client = _make_mock_aiomqtt_client(fake_messages())
+        mock_aiomqtt = mock.MagicMock()
+        mock_aiomqtt.Client.return_value = mock_client
+
+        with mock.patch.dict("sys.modules", {"aiomqtt": mock_aiomqtt}):
+            task = asyncio.create_task(adapter._subscriber_loop())
+            await asyncio.wait_for(dispatched.wait(), timeout=2.0)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert mock_bus.publish.called
+        mock_client.subscribe.assert_called_once_with("t")
+
+    @pytest.mark.asyncio
+    async def test_reconnects_on_connection_error(self, adapter):
+        adapter._cfg = MqttAdapterConfig(host="broker.test")
+        adapter._sub_client_id = "obs-sub"
+
+        attempt = 0
+
+        class FailingCM:
+            async def __aenter__(self_cm):
+                nonlocal attempt
+                attempt += 1
+                if attempt >= 3:
+                    raise asyncio.CancelledError()
+                raise ConnectionRefusedError("broker down")
+
+            async def __aexit__(self_cm, *args):
+                pass
+
+        mock_aiomqtt = mock.MagicMock()
+        mock_aiomqtt.Client.return_value = FailingCM()
+
+        with mock.patch.dict("sys.modules", {"aiomqtt": mock_aiomqtt}):
+            with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+                task = asyncio.create_task(adapter._subscriber_loop())
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        assert attempt >= 3
+
+
+# ---------------------------------------------------------------------------
+# _publisher_loop
+# ---------------------------------------------------------------------------
+
+
+class TestPublisherLoop:
+    @pytest.mark.asyncio
+    async def test_publishes_message_from_queue(self, adapter, mock_bus):
+        adapter._cfg = MqttAdapterConfig(host="broker.test")
+        adapter._pub_client_id = "obs-pub"
+        adapter._tls_context = None
+
+        published = asyncio.Event()
+
+        mock_client = mock.AsyncMock()
+        mock_client.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = mock.AsyncMock(return_value=None)
+
+        async def track_publish(topic, payload, retain=False):
+            published.set()
+
+        mock_client.publish.side_effect = track_publish
+
+        mock_aiomqtt = mock.MagicMock()
+        mock_aiomqtt.Client.return_value = mock_client
+
+        await adapter._publish_queue.put(("home/lamp", "on", False))
+
+        with mock.patch.dict("sys.modules", {"aiomqtt": mock_aiomqtt}):
+            task = asyncio.create_task(adapter._publisher_loop())
+            await asyncio.wait_for(published.wait(), timeout=2.0)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        mock_client.publish.assert_called_once_with("home/lamp", "on", retain=False)
+
+    @pytest.mark.asyncio
+    async def test_publisher_reports_connected_status(self, adapter, mock_bus):
+        adapter._cfg = MqttAdapterConfig(host="broker.test")
+        adapter._pub_client_id = "obs-pub"
+        adapter._tls_context = None
+
+        connected_event = asyncio.Event()
+        original_publish_status = adapter._publish_status
+
+        async def track_status(connected, detail="", severity="ok"):
+            if connected:
+                connected_event.set()
+            await original_publish_status(connected, detail, severity)
+
+        adapter._publish_status = track_status
+
+        mock_client = mock.AsyncMock()
+        mock_client.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = mock.AsyncMock(return_value=None)
+        mock_client.publish = mock.AsyncMock()
+
+        mock_aiomqtt = mock.MagicMock()
+        mock_aiomqtt.Client.return_value = mock_client
+
+        with mock.patch.dict("sys.modules", {"aiomqtt": mock_aiomqtt}):
+            task = asyncio.create_task(adapter._publisher_loop())
+            await asyncio.wait_for(connected_event.wait(), timeout=2.0)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert adapter.connected is True
+
+    @pytest.mark.asyncio
+    async def test_publisher_reconnects_on_connection_error(self, adapter, mock_bus):
+        adapter._cfg = MqttAdapterConfig(host="broker.test")
+        adapter._pub_client_id = "obs-pub"
+        adapter._tls_context = None
+
+        attempt = 0
+
+        class FailingCM:
+            async def __aenter__(self_cm):
+                nonlocal attempt
+                attempt += 1
+                if attempt >= 3:
+                    raise asyncio.CancelledError()
+                raise ConnectionRefusedError("publisher down")
+
+            async def __aexit__(self_cm, *args):
+                pass
+
+        mock_aiomqtt = mock.MagicMock()
+        mock_aiomqtt.Client.return_value = FailingCM()
+
+        with mock.patch.dict("sys.modules", {"aiomqtt": mock_aiomqtt}):
+            with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+                task = asyncio.create_task(adapter._publisher_loop())
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        assert attempt >= 3


### PR DESCRIPTION
Add 20 unit tests covering disconnect(), _on_bindings_reloaded(), _subscriber_loop(), _publisher_loop(), formula application, exception handling in _on_message/write(), and the tls_insecure branch.

Async loop tests mock sys.modules["aiomqtt"] to intercept the lazy import inside the loop methods. Reconnect paths use a FailingCM inner class that raises CancelledError on the third attempt to self-terminate the loop, with asyncio.sleep patched to an AsyncMock so the 5-second delay is skipped.