### PR TITLE
test(adapters): achieve 100% coverage for base, modbus_base, and regi…

### DIFF
--- a/tests/adapters/test_modbus_base.py
+++ b/tests/adapters/test_modbus_base.py
@@ -218,3 +218,22 @@ class TestEdgeCases:
 
     def test_unknown_format_falls_back_to_first_register(self):
         assert decode_registers([99], "mystery_format") == 99
+
+
+class TestEncodeInt32:
+    def test_negative_value(self):
+        regs = encode_value(-1, "int32")
+        assert len(regs) == 2
+        assert decode_registers(regs, "int32") == -1
+
+    def test_positive_value(self):
+        regs = encode_value(100_000, "int32")
+        assert decode_registers(regs, "int32") == 100_000
+
+
+class TestEncodeUnknownFormatFallback:
+    def test_unknown_format_returns_single_register(self):
+        assert encode_value(42, "bogus_format") == [42]
+
+    def test_unknown_format_with_large_value_masks_to_uint16(self):
+        assert encode_value(65538, "bogus_format") == [2]


### PR DESCRIPTION
…stry

Add tests for three files in obs/adapters/:

base.py (87% → 100%): new test_adapter_base.py covers get_bindings(), last_severity/last_detail properties, _publish_status() warning-severity behaviour, reload_bindings(), and abstract method bodies via a _SuperCallingAdapter helper that delegates each abstract method to super().

modbus_base.py (97% → 100%): two cases appended to test_modbus_base.py — encode_value with "int32" (the elif branch at line 107) and an unknown format string (the fallback return at line 118).

registry.py (22% → 100%): new test_registry.py with 46 tests covering register() error path, all lookup helpers, start_all / stop_all / restart_instance / stop_instance / reload_instance_bindings with success, skipped-unknown-type, exception-caught, value_getter injection, and _row_to_binding with null adapter_instance_id and value_map JSON. DB interaction is tested with a lightweight _make_db() fixture that uses an async side_effect function to route fetchall queries by table name. Registry globals (_adapters, _instances) are isolated per test via monkeypatch.setattr.