### PR TITLE
fix(visu): History widget Zeitraum-Dropdown zeigt übersetzte Labels (Issue #662)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -88,6 +88,7 @@
 * Logic engine: Sommer/Winter (DIN) block now fills T1/T2/T3 slots correctly when sensors report at intervals that do not hit hours 7, 12, or 22 exactly (e.g. every 2 or 4 hours). "First-crossing" semantics: each slot is captured on the first measurement at or after its target hour, so daily_avg is always computed and heating mode switches reliably. https://github.com/abeggled/openbridgeserver/issues/548
 * Backend/UI: History default window changed from 24h to 7d and is now configurable via `history.default_window_hours` (Settings → Historie DB). https://github.com/abeggled/openbridgeserver/pull/582
 * GUI: Fixed MQTT binding edit/create dialog becoming blank when switching to write direction; adapter-type resolution and i18n handling in BindingForm were hardened. https://github.com/abeggled/openbridgeserver/issues/656
+* Visu: History (Chart) widget time-range dropdown now shows translated labels instead of raw i18n key strings. https://github.com/abeggled/openbridgeserver/issues/662
 * Adapter: KNX IP Secure now works correctly in Docker bridge networks — credentials are extracted directly from the .knxkeys file and passed explicitly to xknx, bypassing the internal UDP DescriptionRequest that fails without host networking. Connection errors now include actionable hints (Docker network mode, gateway tunnel-slot exhaustion). https://github.com/abeggled/openbridgeserver/issues/393
 
 ### Known Issues 🔔

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -418,7 +418,10 @@
         "last_week": "Letzte Woche",
         "last_month": "Letzter Monat"
       },
-      "defaultTimeRange": "Standard-Zeitbereich"
+      "defaultTimeRange": "Standard-Zeitbereich",
+      "selectTimeRange": "Zeitbereich wählen",
+      "editorPlaceholder": "Verlaufs-Chart",
+      "seriesFallback": "Serie {n}"
     },
     "energiefluss": {
       "titleLabel": "Titel (optional)",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -418,7 +418,10 @@
         "last_week": "Last week",
         "last_month": "Last month"
       },
-      "defaultTimeRange": "Default time range"
+      "defaultTimeRange": "Default time range",
+      "selectTimeRange": "Select time range",
+      "editorPlaceholder": "History chart",
+      "seriesFallback": "Series {n}"
     },
     "energiefluss": {
       "titleLabel": "Title (optional)",

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   Chart,
   LineController, LineElement, PointElement,
@@ -26,6 +27,7 @@ const props = defineProps<{
   editorMode: boolean
 }>()
 
+const { t } = useI18n()
 const ws = useWebSocket()
 
 const label = computed(() => (props.config.label as string | undefined) ?? '—')
@@ -212,7 +214,7 @@ async function loadData() {
       })
       return {
         yAxisID:         s.axis,
-        label:           s.label || (hasMultiple ? `Serie ${i + 1}` : ''),
+        label:           s.label || (hasMultiple ? t('widgets.chart.seriesFallback', { n: i + 1 }) : ''),
         data,
         backgroundColor: s.color + 'cc',
         borderWidth:     0,
@@ -223,7 +225,7 @@ async function loadData() {
     chart.data.labels   = undefined
     chart.data.datasets = defs.map((s, i) => ({
       yAxisID:         s.axis,
-      label:           s.label || (hasMultiple ? `Serie ${i + 1}` : ''),
+      label:           s.label || (hasMultiple ? t('widgets.chart.seriesFallback', { n: i + 1 }) : ''),
       data:            results[i].map(d => ({ x: new Date(d.ts).getTime(), y: Number(d.v) })),
       borderColor:     s.color,
       backgroundColor: s.color + '1a',
@@ -307,15 +309,15 @@ onUnmounted(() => {
         v-if="!editorMode"
         v-model="selectedTimeRange"
         class="shrink-0 text-xs bg-gray-800 border border-gray-700 rounded px-1.5 py-0.5 text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
-        title="Zeitbereich wählen"
+        :title="$t('widgets.chart.selectTimeRange')"
       >
-        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+        <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ $t(p.label) }}</option>
       </select>
     </div>
     <div class="flex-1 min-h-0">
       <canvas v-if="!editorMode" ref="canvas" />
       <div v-else class="flex items-center justify-center h-full text-gray-600 text-sm">
-        Verlaufs-Chart
+        {{ $t('widgets.chart.editorPlaceholder') }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #662

## Root cause

`timeRangePresets.ts` stores i18n keys as the `label` field of each preset (correct pattern per AGENTS.MD — pure utility files return keys, translate at callsite). `Widget.vue` however rendered them with `{{ p.label }}` directly — without passing through `$t()`. This caused the raw key strings (e.g. `widgets.chart.timeRange.last_7d`) to appear in the dropdown instead of translated labels.

## Changes

- `frontend/src/widgets/Chart/Widget.vue`
  - `{{ p.label }}` → `{{ $t(p.label) }}` in the time-range select
  - `title="Zeitbereich wählen"` → `:title="$t('widgets.chart.selectTimeRange')"` (was hardcoded German)
  - `Verlaufs-Chart` → `{{ $t('widgets.chart.editorPlaceholder') }}` (was hardcoded German)
  - Fallback label for unnamed series: `` `Serie ${i + 1}` `` → `t('widgets.chart.seriesFallback', { n: i + 1 })`
  - Added `useI18n` import (required for `t()` calls in script)
- `frontend/src/locales/de.json` + `en.json`: 3 new keys added, full parity maintained

## Test plan

- [ ] Open Visu, add a History widget, open the time-range dropdown → labels show in the active locale (German/English), not raw key strings
- [ ] Switch locale in Settings → dropdown labels update reactively
- [ ] `cd frontend && npm run build` — builds without errors, all i18n keys resolved
- [ ] Locale parity check: DE=EN=809 keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)