### PR TITLE
fix(visu): ValueDisplay Widget Zeitraum-Dropdown zeigt übersetzte Labels (Issue #662)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -55,7 +55,8 @@
 * Backend: The adapter page automatically reloaded every few seconds, making configuration difficult. https://github.com/abeggled/openbridgeserver/issues/394
 * Backend: Fix view permissions of Demo User https://github.com/abeggled/openbridgeserver/issues/471
 * Backend: History default window changed from 24h to 7d and is now configurable via `history.default_window_hours` (Settings → Historie DB). https://github.com/abeggled/openbridgeserver/pull/582
-GUI: Fixed MQTT binding edit/create dialog becoming blank when switching to write direction; adapter-type resolution and i18n handling in BindingForm were hardened. https://github.com/abeggled/openbridgeserver/issues/656
+* GUI: Fixed MQTT binding edit/create dialog becoming blank when switching to write direction; adapter-type resolution and i18n handling in BindingForm were hardened. https://github.com/abeggled/openbridgeserver/issues/656
+* Visu: History (Chart) widget and Value Display widget time-range dropdowns now show translated labels instead of raw i18n key strings. https://github.com/abeggled/openbridgeserver/issues/662
 * General #375: Proxmox LXC, confusing checksum field content within release notes. https://github.com/abeggled/openbridgeserver/issues/375
 * Logic engine: The object selector now uses the entire available window space. https://github.com/abeggled/openbridgeserver/issues/345
 * Logic engine: Sommer/Winter (DIN) block now fills T1/T2/T3 slots correctly when sensors report at intervals that do not hit hours 7, 12, or 22 exactly (e.g. every 2 or 4 hours). "First-crossing" semantics: each slot is captured on the first measurement at or after its target hour, so daily_avg is always computed and heating mode switches reliably. https://github.com/abeggled/openbridgeserver/issues/548

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -769,7 +769,8 @@
       "clickForFullViewTitle": "Klicken für Vollansicht",
       "qualityBadTitle": "Qualität: schlecht",
       "qualityUncertainTitle": "Qualität: undefiniert",
-      "selectTimeRangeTitle": "Zeitbereich wählen"
+      "selectTimeRangeTitle": "Zeitbereich wählen",
+      "historyFallback": "Verlauf"
     },
     "wetter": {
       "labelCity": "Bezeichnung (Ortname)",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -769,7 +769,8 @@
       "clickForFullViewTitle": "Click for full view",
       "qualityBadTitle": "Quality: bad",
       "qualityUncertainTitle": "Quality: uncertain",
-      "selectTimeRangeTitle": "Select time range"
+      "selectTimeRangeTitle": "Select time range",
+      "historyFallback": "History"
     },
     "wetter": {
       "labelCity": "Label (location name)",

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -595,7 +595,7 @@ const quality = computed(() => props.value?.q ?? null)
               :style="{ color: activeColor }"
             >{{ activeIcon }}</span>
             <span v-else-if="svgBlobUrl" class="inline-block w-6 h-6 shrink-0" :style="svgMaskStyle" />
-            <span class="text-sm font-medium text-gray-700 dark:text-gray-200 truncate">{{ widgetLabel || 'Verlauf' }}</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200 truncate">{{ widgetLabel || $t('widgets.valuedisplay.historyFallback') }}</span>
           </div>
           <div class="flex items-center gap-2 shrink-0">
             <select
@@ -603,7 +603,7 @@ const quality = computed(() => props.value?.q ?? null)
               class="text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-blue-500 cursor-pointer"
               :title="t('widgets.valuedisplay.selectTimeRangeTitle')"
             >
-              <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ p.label }}</option>
+              <option v-for="p in TIME_RANGE_PRESETS" :key="p.value" :value="p.value">{{ $t(p.label) }}</option>
             </select>
             <button
               class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 text-xl leading-none"


### PR DESCRIPTION
Closes #662 (follow-up to #663)

## Root cause

`ValueDisplay/Widget.vue` importiert `TIME_RANGE_PRESETS` aus `Chart/timeRangePresets.ts` und verwendet `{{ p.label }}` ohne `$t()` — gleicher Bug wie in #663 (Chart widget).

## Changes

- `ValueDisplay/Widget.vue` line 606: `{{ p.label }}` → `{{ $t(p.label) }}` (Zeitraum-Dropdown in der History-Ansicht des Value Display Widgets)
- `ValueDisplay/Widget.vue` line 598: `'Verlauf'` (hardcodiertes Deutsch) → `$t('widgets.valuedisplay.historyFallback')`
- `frontend/src/locales/de.json` + `en.json`: neuer Key `widgets.valuedisplay.historyFallback` ergänzt (Parität 810/810)

## Test plan

- [ ] Value Display Widget im History-Modus öffnen → Zeitraum-Dropdown zeigt übersetzte Labels
- [ ] Sprache wechseln → Dropdown-Labels aktualisieren sich
- [ ] `cd frontend && npm run build` — baut fehlerfrei, alle i18n-Keys aufgelöst

🤖 Generated with [Claude Code](https://claude.com/claude-code)