### PR TITLE
fix(visu): center fixed-width page grid

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -89,6 +89,7 @@
 * Visu: Floorplan Widget: positioning broken if floorplan is rotated https://github.com/abeggled/openbridgeserver/issues/440
 * Visu: Slider widget values are now written on pointer release and keyboard commit, avoiding missed writes in browsers that do not reliably fire change after dragging. https://github.com/abeggled/openbridgeserver/pull/559
 * Visu: History widget displays translated labels instead of variable name
+* Visu: Fixed-width Visu pages are now centered horizontally in the viewer. https://github.com/abeggled/openbridgeserver/pull/672
 
 ### Known Issues 🔔
 * none

--- a/frontend/src/views/VisuViewer.vue
+++ b/frontend/src/views/VisuViewer.vue
@@ -243,7 +243,7 @@ function gridStyle(w: WidgetInstance) {
     <!-- PAGE → Widget-Grid (feste Pixelbreite = Editor WYSIWYG) -->
     <main v-else class="flex-1 p-4 overflow-auto" :style="viewerBackgroundStyle">
       <div
-        class="grid"
+        class="grid mx-auto"
         :style="{
           gridTemplateColumns: `repeat(${COLS}, ${CELL_W}px)`,
           gridAutoRows: `${ROW_H}px`,


### PR DESCRIPTION
## Summary
- center the fixed-width Visu page grid in the viewer
- keep existing WYSIWYG grid dimensions and widget coordinates unchanged

## Verification
- npm ci
- npm run build on unchanged origin/main
- npm run typecheck
- npm run build
