### PR TITLE
[Codex] API-Client-Secret-Dateipfade härten

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -34,7 +34,7 @@
 * Logic engine: Functional Block: "iCalendar" filtering by summary, location, and description. https://github.com/abeggled/openbridgeserver/issues/350
 * Logic engine: Functional Block: "XML Extractor" now has multiple outputs from single input https://github.com/abeggled/openbridgeserver/pull/469
 * Logic engine: Functional Block: "JSON Extractor" now has multiple outputs from single input https://github.com/abeggled/openbridgeserver/pull/468
-* Logic engine: Functional Block: API client nodes can now load optional headers and bearer tokens from secret files. https://github.com/abeggled/openbridgeserver/pull/581
+* Logic engine: API client nodes can load optional headers and bearer tokens from secret files. https://github.com/abeggled/openbridgeserver/pull/581
 * Visu: Add background images https://github.com/abeggled/openbridgeserver/issues/481
 * Visu: Floor plan widget with the ability to place mini widgets on the floor plan https://github.com/abeggled/openbridgeserver/issues/228
 * Visu: History widget: select time period direct from widget https://github.com/abeggled/openbridgeserver/issues/413
@@ -48,6 +48,7 @@
 * Visu: Widgets können per Drag & Drop aus der Palette direkt an eine bestimmte Position auf der Seite gezogen werden; eine blaue Vorschau zeigt die Zielposition. Klick auf ein Widget fügt es weiterhin automatisch an der ersten freien Position ein. Die Widget-Liste ist jetzt sprachspezifisch alphabetisch sortiert. https://github.com/abeggled/openbridgeserver/issues/667
 
 ### Fixes 🐞
+* Logic Security (Upstream PR #686): API client secret-file paths are restricted to a configured secret directory with bounded regular-file reads.
 * Adapter: KNX IP Secure now works correctly in Docker bridge networks — credentials are extracted directly from the .knxkeys file and passed explicitly to xknx, bypassing the internal UDP DescriptionRequest that fails without host networking. Connection errors now include actionable hints (Docker network mode, gateway tunnel-slot exhaustion). https://github.com/abeggled/openbridgeserver/issues/393
 * Backend: Complete remaining UI translation fixes after i18n rollout. https://github.com/abeggled/openbridgeserver/pull/542
 * Backend: Validate `DataValueEvent` payloads before bridge propagation. https://github.com/abeggled/openbridgeserver/pull/519

--- a/obs/logic/manager.py
+++ b/obs/logic/manager.py
@@ -15,9 +15,12 @@ import http.cookies
 import ipaddress
 import json
 import logging
+import os
 import socket
+import stat
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote, urljoin, urlparse, urlunparse
 
@@ -79,19 +82,6 @@ def _msg_to_str(v: object) -> str:
     return str(v)
 
 
-def _read_secret_file(path: str) -> str:
-    """Read a small root-managed secret file without logging its content."""
-    clean_path = (path or "").strip()
-    if not clean_path:
-        return ""
-    try:
-        with open(clean_path, encoding="utf-8") as handle:
-            return handle.read().strip()
-    except OSError as exc:
-        logger.warning("Could not read api_client secret file %s: %s", clean_path, exc)
-        return ""
-
-
 _THROTTLE_UNITS: dict[str, float] = {
     "ms": 1.0,
     "s": 1000.0,
@@ -104,6 +94,47 @@ _ICAL_MAX_REDIRECTS = 5
 _ICAL_ALLOWED_CONTENT_TYPES = ("text/calendar", "application/ics", "application/octet-stream", "text/plain")
 _NAT64_WELL_KNOWN_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 _PUSHOVER_ATTACHMENT_MAX_BYTES = 5_000_000
+_SECRET_FILE_MAX_BYTES = 8192
+_SECRET_FILE_DEFAULT_ROOT = "/run/secrets"
+
+
+def _secret_file_root() -> Path:
+    return Path(os.environ.get("OBS_SECRET_FILE_DIR", _SECRET_FILE_DEFAULT_ROOT)).resolve()
+
+
+def _read_secret_file(path: str) -> str:
+    secret_path_raw = (path or "").strip()
+    if not secret_path_raw:
+        return ""
+
+    try:
+        secret_root = _secret_file_root()
+        secret_path = Path(secret_path_raw).resolve(strict=True)
+        if not secret_path.is_relative_to(secret_root):
+            logger.warning("Refusing to read secret file outside %s: %s", secret_root, secret_path)
+            return ""
+
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        fd = os.open(secret_path, flags)
+        try:
+            file_stat = os.fstat(fd)
+            if not stat.S_ISREG(file_stat.st_mode):
+                logger.warning("Refusing to read non-regular secret file: %s", secret_path)
+                return ""
+            if file_stat.st_size > _SECRET_FILE_MAX_BYTES:
+                logger.warning("Refusing to read oversized secret file: %s", secret_path)
+                return ""
+            data = os.read(fd, _SECRET_FILE_MAX_BYTES + 1)
+        finally:
+            os.close(fd)
+
+        if len(data) > _SECRET_FILE_MAX_BYTES:
+            logger.warning("Refusing to read oversized secret file: %s", secret_path)
+            return ""
+        return data.decode("utf-8").strip()
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        logger.warning("Could not read secret file %s: %s", secret_path_raw, exc)
+        return ""
 
 
 def _parse_http_url(url: str) -> Any | None:
@@ -1019,14 +1050,15 @@ class LogicManager:
                     extra_headers = _json.loads(hdr_str)
                 except Exception:
                     pass
-            hdr_secret_file = (node.data.get("headers_secret_file") or "").strip()
-            if hdr_secret_file:
+            hdr_file = (node.data.get("headers_secret_file") or "").strip()
+            if hdr_file:
                 try:
-                    secret_headers = _json.loads(_read_secret_file(hdr_secret_file))
-                    if isinstance(secret_headers, dict):
-                        extra_headers = {**extra_headers, **secret_headers}
+                    extra_headers = {
+                        **extra_headers,
+                        **_json.loads(_read_secret_file(hdr_file)),
+                    }
                 except Exception:
-                    logger.warning("api_client headers_secret_file did not contain a JSON object")
+                    pass
             body = out.get("_body")
             # ── Authentication ──────────────────────────────────────────
             auth_type = (node.data.get("auth_type") or "none").lower()
@@ -1038,9 +1070,8 @@ class LogicManager:
                     auth = httpx.BasicAuth(username, password) if auth_type == "basic" else httpx.DigestAuth(username, password)
             elif auth_type == "bearer":
                 token = (node.data.get("auth_token") or "").strip()
-                token_file = (node.data.get("auth_token_file") or "").strip()
-                if not token and token_file:
-                    token = _read_secret_file(token_file)
+                if not token:
+                    token = _read_secret_file(node.data.get("auth_token_file") or "")
                 if token:
                     extra_headers = {
                         **extra_headers,

--- a/obs/logic/node_types.py
+++ b/obs/logic/node_types.py
@@ -839,7 +839,7 @@ BUILTIN_NODE_TYPES: list[NodeTypeDef] = [
             "headers_secret_file": {
                 "type": "string",
                 "default": "",
-                "label": "Header aus Secret-Datei (JSON-Objekt, optional)",
+                "label": "Header-Datei (/run/secrets)",
             },
             "timeout_s": {"type": "number", "default": 10, "label": "Timeout (s)"},
             "auth_type": {
@@ -868,7 +868,7 @@ BUILTIN_NODE_TYPES: list[NodeTypeDef] = [
             "auth_token_file": {
                 "type": "string",
                 "default": "",
-                "label": "Bearer Token aus Secret-Datei",
+                "label": "Bearer-Token-Datei (/run/secrets)",
             },
         },
         color="#0e7490",

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -11,9 +11,10 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from obs.logic.manager import LogicManager, _is_private_host
+from obs.logic.manager import LogicManager, _is_private_host, _read_secret_file
 from obs.logic.models import FlowData
 from tests.unit.conftest import edge, make_executor, node
 
@@ -72,6 +73,64 @@ class TestApiClientSsrfHostGuard:
     @patch("obs.logic.manager.socket.getaddrinfo", return_value=[(None, None, None, None, ("127.0.0.1", 0))])
     def test_loopback_dns_answer_is_allowed(self, _mock_getaddrinfo):
         assert _is_private_host("example.com") is False
+
+
+class TestApiClientSecretFileGuard:
+    """Unit tests for bounded API client secret-file reads."""
+
+    def test_reads_file_from_configured_secret_root(self, tmp_path, monkeypatch):
+        root = tmp_path / "secrets"
+        root.mkdir()
+        secret_file = root / "api-token"
+        secret_file.write_text(" secret-token \n", encoding="utf-8")
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        assert _read_secret_file(str(secret_file)) == "secret-token"
+
+    def test_rejects_file_outside_secret_root(self, tmp_path, monkeypatch):
+        root = tmp_path / "secrets"
+        root.mkdir()
+        outside_file = tmp_path / "outside-token"
+        outside_file.write_text("outside", encoding="utf-8")
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        assert _read_secret_file(str(outside_file)) == ""
+
+    def test_rejects_non_regular_file(self, tmp_path, monkeypatch):
+        root = tmp_path / "secrets"
+        root.mkdir()
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        assert _read_secret_file(str(root)) == ""
+
+    def test_rejects_fifo_without_blocking(self, tmp_path, monkeypatch):
+        if not hasattr(os, "mkfifo"):
+            return
+        root = tmp_path / "secrets"
+        root.mkdir()
+        secret_pipe = root / "api-token-pipe"
+        os.mkfifo(secret_pipe)
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        assert _read_secret_file(str(secret_pipe)) == ""
+
+    def test_rejects_oversized_file(self, tmp_path, monkeypatch):
+        root = tmp_path / "secrets"
+        root.mkdir()
+        secret_file = root / "large-token"
+        secret_file.write_text("x" * 8193, encoding="utf-8")
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        assert _read_secret_file(str(secret_file)) == ""
+
+    def test_rejects_invalid_utf8(self, tmp_path, monkeypatch):
+        root = tmp_path / "secrets"
+        root.mkdir()
+        secret_file = root / "binary-token"
+        secret_file.write_bytes(b"\xff")
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        assert _read_secret_file(str(secret_file)) == ""
 
 
 # ===========================================================================
@@ -271,6 +330,48 @@ class TestApiClientManagerHttp:
         assert outputs["ac"]["success"] is True
         assert isinstance(outputs["ac"]["response"], str)
         assert len(outputs["ac"]["response"]) == 1_000_000
+
+    @patch("obs.logic.manager.httpx.AsyncClient")
+    def test_secret_files_supply_headers_and_bearer_token(self, mock_client_cls, tmp_path, monkeypatch):
+        """Secret-file fields are honored when paths stay inside the configured secret root."""
+        captured_headers: list[dict] = []
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        async def _capture(method, url, **kwargs):
+            captured_headers.append(kwargs.get("headers", {}))
+            return _mock_response(200, {})
+
+        mock_client.request = _capture
+
+        root = tmp_path / "secrets"
+        root.mkdir()
+        headers_file = root / "api-headers.json"
+        token_file = root / "api-token"
+        headers_file.write_text('{"X-Secret": "from-file"}', encoding="utf-8")
+        token_file.write_text("file-token", encoding="utf-8")
+        monkeypatch.setenv("OBS_SECRET_FILE_DIR", str(root))
+
+        manager = _make_manager()
+        _, flow = self._build_graph(
+            extra_data={
+                "headers": '{"X-Base": "inline"}',
+                "auth_type": "bearer",
+                "auth_token": "",
+                "auth_token_file": str(token_file),
+                "headers_secret_file": str(headers_file),
+            },
+        )
+        with patch("obs.logic.manager._is_private_host", return_value=False):
+            with patch("obs.api.v1.websocket.get_ws_manager", side_effect=RuntimeError("no ws")):
+                outputs = self._run(manager, flow)
+
+        assert outputs["ac"]["success"] is True
+        assert len(captured_headers) == 1
+        assert captured_headers[0]["X-Base"] == "inline"
+        assert captured_headers[0]["X-Secret"] == "from-file"
+        assert captured_headers[0]["Authorization"] == "Bearer file-token"
 
     @patch("obs.logic.manager.httpx.AsyncClient")
     def test_localhost_target_is_allowed(self, mock_client_cls):


### PR DESCRIPTION
### Motivation
- PR #581 hat bewusst ermöglicht, dass API-Client-Nodes Header und Bearer Tokens aus Secret-Dateien laden.
- Der eigentliche Fehler war nicht das Nutzer-/Berechtigungsmodell, sondern dass graph-konfigurierte Dateipfade beliebige lokale Pfade erreichen und unbeschränkt gelesen werden konnten.
- Dieser PR behält das Feature aus #581 und härtet den Dateizugriff ein.

### Description
- Behält `headers_secret_file` und `auth_token_file` im API-Client-Schema.
- Führt `_read_secret_file()` wieder ein, aber begrenzt Secret-Dateien auf `OBS_SECRET_FILE_DIR` bzw. default `/run/secrets`.
- Verhindert Pfade außerhalb des Secret-Roots, Symlink-Following beim Öffnen, nicht-reguläre Dateien und Dateien größer als 8192 Bytes.
- Öffnet Secret-Dateien nonblocking, damit FIFOs/Pipes die Logic-Ausführung nicht hängen lassen.
- Lädt Header-JSON aus `headers_secret_file` und nutzt `auth_token_file` nur als Fallback, wenn kein Inline-Bearer-Token gesetzt ist.
- Ergänzt Regressionstests für erlaubte Secret-Dateien, Pfade außerhalb des Secret-Roots, Verzeichnisse/FIFOs, oversized files, invalid UTF-8 und Runtime-Nutzung von Header-/Token-Dateien.
- Aktualisiert `RELEASENOTES.md`: #581 bleibt als Feature dokumentiert, #686 ist das Hardening.

### Verification
- Worktree: `/Volumes/Daten/Projekte/openbridge/openbridgeserver-pr-81`
- Branch: `pr-81-fork`
- HEAD: `84aa0be0ef2be565843b217756e256b7b0b24e45`
- `../openbridgeserver/.venv/bin/python -m ruff check .` passed.
- `../openbridgeserver/.venv/bin/python -m ruff format --check .` passed.
- `../openbridgeserver/.venv/bin/python -m pytest tests/unit/test_api_client.py tests/unit/test_coverage_adapters_hierarchy_logic.py -q` passed: `221 passed`.
- `./scripts/check-i18n-hardcoded-strings.sh` passed: no relevant frontend/i18n files in diff.
- Pre-push hook with project `.venv` passed: `3626 passed, 13 skipped`, coverage total `86%`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bcca789dc832982e86fbca34e4607)