### PR TITLE
Fix RingBuffer SQLite corruption recovery

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -52,6 +52,7 @@
 * Backend: Complete remaining UI translation fixes after i18n rollout. https://github.com/abeggled/openbridgeserver/pull/542
 * Backend: Validate `DataValueEvent` payloads before bridge propagation. https://github.com/abeggled/openbridgeserver/pull/519
 * Backend: Ringbuffer pause/resume race condition stabilized. https://github.com/abeggled/openbridgeserver/pull/509
+* Backend: Monitor/RingBuffer now recovers automatically from a malformed SQLite database by quarantining the corrupted monitor DB/WAL/SHM files and recreating an empty RingBuffer, preventing repeated EventBus errors and Monitor API failures. https://github.com/abeggled/openbridgeserver/issues/689
 * Backend: InfluxDB v3 writes now use correct `db` query parameter. https://github.com/abeggled/openbridgeserver/pull/511
 * Backend: The adapter page automatically reloaded every few seconds, making configuration difficult. https://github.com/abeggled/openbridgeserver/issues/394
 * Backend: Fix view permissions of Demo User https://github.com/abeggled/openbridgeserver/issues/471

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -745,6 +745,7 @@
     "offlineTitle": "WebSocket offline",
     "queryFailed": "Monitor-Abfrage fehlgeschlagen",
     "recoveryNotice": "Monitor-Self-Healing wurde um {ts} ausgeführt. Der bisherige Monitor-Puffer wurde verworfen; {n} beschädigte Datei(en) wurden isoliert.",
+    "rowMatchTitle": "Treffer: {names}",
     "pause": "⏸ Pause",
     "resume": "▶ Resume",
     "statsTitle": "Ringbuffer Statistik",

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -744,6 +744,7 @@
     "liveTitle": "Live — WebSocket verbunden, Updates aktiv",
     "offlineTitle": "WebSocket offline",
     "queryFailed": "Monitor-Abfrage fehlgeschlagen",
+    "recoveryNotice": "Monitor-Self-Healing wurde um {ts} ausgeführt. Der bisherige Monitor-Puffer wurde verworfen; {n} beschädigte Datei(en) wurden isoliert.",
     "pause": "⏸ Pause",
     "resume": "▶ Resume",
     "statsTitle": "Ringbuffer Statistik",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -745,6 +745,7 @@
     "offlineTitle": "WebSocket offline",
     "queryFailed": "Monitor query failed",
     "recoveryNotice": "Monitor self-healing ran at {ts}. The previous monitor buffer was discarded; {n} corrupted file(s) were quarantined.",
+    "rowMatchTitle": "Match: {names}",
     "pause": "⏸ Pause",
     "resume": "▶ Resume",
     "statsTitle": "Ring Buffer Statistics",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -744,6 +744,7 @@
     "liveTitle": "Live — WebSocket connected, updates active",
     "offlineTitle": "WebSocket offline",
     "queryFailed": "Monitor query failed",
+    "recoveryNotice": "Monitor self-healing ran at {ts}. The previous monitor buffer was discarded; {n} corrupted file(s) were quarantined.",
     "pause": "⏸ Pause",
     "resume": "▶ Resume",
     "statsTitle": "Ring Buffer Statistics",

--- a/gui/src/views/RingBufferView.vue
+++ b/gui/src/views/RingBufferView.vue
@@ -50,7 +50,7 @@
         @edit-set="onEditSet"
         @new-set="onNewSet"
         @changed="onTopbarChanged"
-        @export="showExportDialog = true"
+        @export="openExportDialog"
       >
         <template #time-filter-slot>
           <TimeFilterPopover v-model="timeFilter" @update:modelValue="onTimeFilterChanged" />
@@ -105,7 +105,7 @@
               :data-dp="e.datapoint_id"
               :class="getRowStyle(e.matched_set_ids) ? 'ringbuffer-row-matched' : null"
               :style="getRowStyle(e.matched_set_ids)"
-              :title="rowMatchTitle(e.matched_set_ids)"
+              :title="e.match_title"
             >
               <td class="font-mono text-xs text-slate-400 whitespace-nowrap">{{ fmtDateTime(e.ts) }}</td>
               <td class="text-sm">
@@ -160,7 +160,14 @@ function rowMatchTitle(matchedIds) {
     const set = topbarSetsRef.value.get(id)
     if (set?.name) names.push(set.name)
   }
-  return names.length ? `Match: ${names.join(', ')}` : null
+  return names.length ? t('ringbuffer.rowMatchTitle', { names: names.join(', ') }) : null
+}
+
+function withRowMatchTitle(entry) {
+  return {
+    ...entry,
+    match_title: rowMatchTitle(entry?.matched_set_ids),
+  }
 }
 
 const entries = ref([])
@@ -181,6 +188,10 @@ function onEditSet(id) {
 function onNewSet() {
   editorTargetId.value = null
   showFilterEditor.value = true
+}
+
+function openExportDialog() {
+  showExportDialog.value = true
 }
 
 async function onFilterEditorDeleted() {
@@ -234,7 +245,7 @@ const { paused, queuedCount, enqueue: enqueueLive, pause: pauseLive, resume: res
 
 function markAndEnqueueLive(entry) {
   liveIngressSeq += 1
-  enqueueLive(entry)
+  enqueueLive(withRowMatchTitle(entry))
 }
 
 function entryIdentity(entry) {
@@ -415,7 +426,7 @@ async function load() {
       const resp = await ringbufferApi.queryV2(buildQueryV2())
       data = resp.data
     }
-    const loadedEntries = Array.isArray(data) ? data : []
+    const loadedEntries = Array.isArray(data) ? data.map(withRowMatchTitle) : []
     const liveArrivedDuringLoad = liveIngressSeq !== liveSeqAtLoadStart
     entries.value = liveArrivedDuringLoad
       ? mergeEntriesKeepingLiveFirst(entries.value, loadedEntries)

--- a/gui/src/views/RingBufferView.vue
+++ b/gui/src/views/RingBufferView.vue
@@ -179,6 +179,8 @@ const showExportDialog = ref(false)
 const editorTargetId = ref(null)
 const topbarChipsRef = ref(null)
 const recoveryNotice = ref('')
+let recoveryNoticeRefreshPromise = null
+let lastRecoveryNoticeRefreshAt = 0
 
 function onEditSet(id) {
   editorTargetId.value = id
@@ -331,6 +333,17 @@ async function loadRecoveryNotice() {
   }
 }
 
+function refreshRecoveryNoticeSoon() {
+  if (recoveryNotice.value) return
+  if (recoveryNoticeRefreshPromise) return
+  const now = Date.now()
+  if (lastRecoveryNoticeRefreshAt && now - lastRecoveryNoticeRefreshAt < 5000) return
+  lastRecoveryNoticeRefreshAt = now
+  recoveryNoticeRefreshPromise = loadRecoveryNotice().finally(() => {
+    recoveryNoticeRefreshPromise = null
+  })
+}
+
 function buildQueryV2() {
   const payload = {
     filters: {},
@@ -343,6 +356,8 @@ function buildQueryV2() {
 }
 
 function onLiveEntry(entry) {
+  refreshRecoveryNoticeSoon()
+
   // First gate: honor the active TimeFilterPopover. Entries outside the
   // resolved window are dropped — a fixed past window or a point ± span
   // window in the past therefore produces a static table, matching user

--- a/gui/src/views/RingBufferView.vue
+++ b/gui/src/views/RingBufferView.vue
@@ -66,6 +66,14 @@
       @deleted="onFilterEditorDeleted"
     />
 
+    <div
+      v-if="recoveryNotice"
+      class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-300"
+      data-testid="ringbuffer-recovery-notice"
+    >
+      {{ recoveryNotice }}
+    </div>
+
     <!-- Soft-modal CSV/TSV export dialog (#427) -->
     <ExportDialog
       v-model="showExportDialog"
@@ -163,6 +171,7 @@ const showFilterEditor = ref(false)
 const showExportDialog = ref(false)
 const editorTargetId = ref(null)
 const topbarChipsRef = ref(null)
+const recoveryNotice = ref('')
 
 function onEditSet(id) {
   editorTargetId.value = id
@@ -295,6 +304,22 @@ async function loadFiltersets() {
   }
 }
 
+async function loadRecoveryNotice() {
+  try {
+    const { data } = await ringbufferApi.stats()
+    if (!data?.last_recovery_at) {
+      recoveryNotice.value = ''
+      return
+    }
+    recoveryNotice.value = t('ringbuffer.recoveryNotice', {
+      ts: fmtDateTime(data.last_recovery_at),
+      n: Number(data.last_recovery_file_count ?? 0),
+    })
+  } catch {
+    recoveryNotice.value = ''
+  }
+}
+
 function buildQueryV2() {
   const payload = {
     filters: {},
@@ -401,6 +426,7 @@ async function load() {
     entries.value = []
     listError.value = extractErrorMessage(error, t('ringbuffer.queryFailed'))
   } finally {
+    await loadRecoveryNotice()
     loading.value = false
   }
 }

--- a/gui/tests/helpers/mountRingBufferView.js
+++ b/gui/tests/helpers/mountRingBufferView.js
@@ -34,6 +34,8 @@ export function makeRingbufferApiMock(overrides = {}) {
         max_file_size_bytes: null,
         max_age: null,
         file_size_bytes: 0,
+        last_recovery_at: null,
+        last_recovery_file_count: 0,
       },
     }),
     config: vi.fn().mockResolvedValue({ data: {} }),

--- a/gui/tests/views/RingBufferView.mount.spec.js
+++ b/gui/tests/views/RingBufferView.mount.spec.js
@@ -54,4 +54,63 @@ describe('RingBufferView mounts', () => {
     expect(notice.text()).toContain('Monitor-Self-Healing')
     expect(notice.text()).toContain('2026-06-03T06:00:00.000Z')
   })
+
+  it('refreshes the recovery notice after live entries', async () => {
+    const { mountRingBufferView, makeRingbufferApiMock, flushPromises } = await import('../helpers/mountRingBufferView.js')
+    const ringbufferApi = makeRingbufferApiMock({
+      stats: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            total: 0,
+            oldest_ts: null,
+            newest_ts: null,
+            storage: 'file',
+            max_entries: 10000,
+            max_file_size_bytes: null,
+            max_age: null,
+            file_size_bytes: 0,
+            last_recovery_at: null,
+            last_recovery_file_count: 0,
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            total: 1,
+            oldest_ts: null,
+            newest_ts: null,
+            storage: 'file',
+            max_entries: 10000,
+            max_file_size_bytes: null,
+            max_age: null,
+            file_size_bytes: 0,
+            last_recovery_at: '2026-06-03T07:00:00.000Z',
+            last_recovery_file_count: 1,
+          },
+        }),
+    })
+
+    const { wrapper, emitLive } = await mountRingBufferView({ ringbufferApi, wsConnected: true })
+
+    expect(wrapper.find('[data-testid="ringbuffer-recovery-notice"]').exists()).toBe(false)
+
+    emitLive({
+      id: 1,
+      ts: '2026-06-03T07:00:01.000Z',
+      datapoint_id: 'dp-live',
+      topic: 'dp/dp-live/value',
+      old_value: null,
+      new_value: 1,
+      source_adapter: 'api',
+      quality: 'good',
+      matched_set_ids: [],
+    })
+    await flushPromises()
+
+    const notice = wrapper.find('[data-testid="ringbuffer-recovery-notice"]')
+    expect(ringbufferApi.stats).toHaveBeenCalledTimes(2)
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('Monitor-Self-Healing')
+    expect(notice.text()).toContain('2026-06-03T07:00:00.000Z')
+  })
 })

--- a/gui/tests/views/RingBufferView.mount.spec.js
+++ b/gui/tests/views/RingBufferView.mount.spec.js
@@ -27,4 +27,31 @@ describe('RingBufferView mounts', () => {
     expect(wrapper.find('[data-testid="select-filterset"]').exists()).toBe(false)
     expect(wrapper.findComponent({ name: 'TopbarFilterChips' }).exists()).toBe(true)
   })
+
+  it('shows an inline recovery notice when stats report monitor self-healing', async () => {
+    const { mountRingBufferView, makeRingbufferApiMock } = await import('../helpers/mountRingBufferView.js')
+    const ringbufferApi = makeRingbufferApiMock({
+      stats: vi.fn().mockResolvedValue({
+        data: {
+          total: 0,
+          oldest_ts: null,
+          newest_ts: null,
+          storage: 'file',
+          max_entries: 10000,
+          max_file_size_bytes: null,
+          max_age: null,
+          file_size_bytes: 0,
+          last_recovery_at: '2026-06-03T06:00:00.000Z',
+          last_recovery_file_count: 2,
+        },
+      }),
+    })
+
+    const { wrapper } = await mountRingBufferView({ ringbufferApi })
+    const notice = wrapper.find('[data-testid="ringbuffer-recovery-notice"]')
+
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('Monitor-Self-Healing')
+    expect(notice.text()).toContain('2026-06-03T06:00:00.000Z')
+  })
 })

--- a/obs/api/v1/ringbuffer.py
+++ b/obs/api/v1/ringbuffer.py
@@ -111,6 +111,8 @@ class RingBufferStats(BaseModel):
     max_file_size_bytes: int | None
     max_age: int | None
     file_size_bytes: int
+    last_recovery_at: str | None = None
+    last_recovery_file_count: int = 0
 
 
 class RingBufferConfig(BaseModel):

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -893,11 +893,7 @@ class RingBuffer:
             directory = os.path.dirname(path) or "."
             prefix = f"{os.path.basename(path)}.corrupt-"
             try:
-                candidates = [
-                    os.path.join(directory, name)
-                    for name in os.listdir(directory)
-                    if name.startswith(prefix)
-                ]
+                candidates = [os.path.join(directory, name) for name in os.listdir(directory) if name.startswith(prefix)]
             except FileNotFoundError:
                 continue
             stale = sorted(candidates, reverse=True)[_MAX_QUARANTINE_FILES_PER_STORAGE_FILE:]

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -494,7 +494,6 @@ class RingBuffer:
 
         # Capture old value from our own tracking (reliable in asyncio)
         old_value = self._last_values.get(dp_id)
-        self._last_values[dp_id] = event.value
 
         try:
             from obs.core.registry import get_registry
@@ -520,6 +519,7 @@ class RingBuffer:
             metadata_version=1,
             metadata=metadata,
         )
+        self._last_values[dp_id] = event.value
 
     async def _build_metadata_snapshot(
         self,

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -194,7 +194,12 @@ class RingBuffer:
                 self._max_entries = resolved_max_entries
                 self._max_file_size_bytes = int(resolved_max_file_size) if resolved_max_file_size is not None else None
                 self._max_age = int(resolved_max_age) if resolved_max_age is not None else None
-                await self._trim()
+                try:
+                    await self._trim()
+                except Exception as exc:
+                    if not self._can_recover_from(exc):
+                        raise
+                    await self._recover_corrupt_storage_locked(exc)
                 logger.info(
                     "RingBuffer reconfigured in-place → %s, max_entries=%s, max_file_size_bytes=%s, max_age=%s",
                     storage,

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -31,6 +31,11 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 _UNSET = object()
 _ALLOWED_STORAGE_MODELS = {"memory", "disk", "file"}
+_SQLITE_CORRUPTION_MARKERS = (
+    "database disk image is malformed",
+    "file is not a database",
+    "integrity_check failed",
+)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS ringbuffer (
@@ -127,15 +132,13 @@ class RingBuffer:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        path = ":memory:" if self._storage == "memory" else self._disk_path
-        self._conn = await aiosqlite.connect(path)
-        self._conn.row_factory = aiosqlite.Row
-        await self._conn.execute("PRAGMA foreign_keys=ON")
-        if self._storage in {"disk", "file"}:
-            await self._conn.execute("PRAGMA journal_mode=WAL")
-        await self._conn.executescript(_SCHEMA)
-        await self._ensure_compat_schema()
-        await self._conn.commit()
+        async with self._lock:
+            try:
+                await self._open_connection_locked()
+            except Exception as exc:
+                if not self._can_recover_from(exc):
+                    raise
+                await self._recover_corrupt_storage_locked(exc)
         logger.info(
             "RingBuffer started (%s, max_entries=%s, max_file_size_bytes=%s, max_age=%s)",
             self._storage,
@@ -145,9 +148,7 @@ class RingBuffer:
         )
 
     async def stop(self) -> None:
-        if self._conn:
-            await self._conn.close()
-            self._conn = None
+        await self._close_connection()
 
     # ------------------------------------------------------------------
     # Runtime config switch
@@ -202,8 +203,7 @@ class RingBuffer:
 
             # Model switch: close old connection and start empty without migration.
             old_storage = self._storage
-            if self._conn:
-                await self._conn.close()
+            await self._close_connection()
 
             self._storage = storage
             self._max_entries = resolved_max_entries
@@ -211,14 +211,7 @@ class RingBuffer:
             self._max_age = int(resolved_max_age) if resolved_max_age is not None else None
 
             # Open new connection
-            path = ":memory:" if storage == "memory" else self._disk_path
-            self._conn = await aiosqlite.connect(path)
-            self._conn.row_factory = aiosqlite.Row
-            await self._conn.execute("PRAGMA foreign_keys=ON")
-            if storage in {"disk", "file"}:
-                await self._conn.execute("PRAGMA journal_mode=WAL")
-            await self._conn.executescript(_SCHEMA)
-            await self._ensure_compat_schema()
+            await self._open_connection_locked()
             await self._conn.execute("DELETE FROM ringbuffer")
             await self._conn.commit()
             self._last_values.clear()
@@ -251,25 +244,67 @@ class RingBuffer:
             return
         metadata_obj = metadata or {}
         async with self._lock:
-            cursor = await self._conn.execute(
-                """INSERT INTO ringbuffer
-                   (ts, datapoint_id, topic, old_value, new_value, source_adapter, quality, metadata_version, metadata)
-                   VALUES (?,?,?,?,?,?,?,?,?)""",
-                (
+            try:
+                await self._record_locked(
                     ts,
                     datapoint_id,
                     topic,
-                    json.dumps(old_value),
-                    json.dumps(new_value),
+                    old_value,
+                    new_value,
                     source_adapter,
                     quality,
                     metadata_version,
-                    json.dumps(metadata_obj),
-                ),
-            )
-            await self._persist_metadata_indexes(cursor.lastrowid, metadata_obj)
-            await self._conn.commit()
-            await self._trim(reference_ts=ts)
+                    metadata_obj,
+                )
+            except Exception as exc:
+                if not self._can_recover_from(exc):
+                    raise
+                await self._recover_corrupt_storage_locked(exc)
+                await self._record_locked(
+                    ts,
+                    datapoint_id,
+                    topic,
+                    old_value,
+                    new_value,
+                    source_adapter,
+                    quality,
+                    metadata_version,
+                    metadata_obj,
+                )
+
+    async def _record_locked(
+        self,
+        ts: str,
+        datapoint_id: str,
+        topic: str,
+        old_value: Any,
+        new_value: Any,
+        source_adapter: str,
+        quality: str,
+        metadata_version: int,
+        metadata_obj: dict[str, Any],
+    ) -> None:
+        if not self._conn:
+            return
+        cursor = await self._conn.execute(
+            """INSERT INTO ringbuffer
+               (ts, datapoint_id, topic, old_value, new_value, source_adapter, quality, metadata_version, metadata)
+               VALUES (?,?,?,?,?,?,?,?,?)""",
+            (
+                ts,
+                datapoint_id,
+                topic,
+                json.dumps(old_value),
+                json.dumps(new_value),
+                source_adapter,
+                quality,
+                metadata_version,
+                json.dumps(metadata_obj),
+            ),
+        )
+        await self._persist_metadata_indexes(cursor.lastrowid, metadata_obj)
+        await self._conn.commit()
+        await self._trim(reference_ts=ts)
 
     async def _trim(self, reference_ts: str | None = None) -> None:
         """Apply retention rules and keep max_entries compatibility."""
@@ -668,12 +703,16 @@ class RingBuffer:
             sql += f" ORDER BY id {direction}"
 
         rows: list[Any]
-        if value_filters:
-            rows = await self._fetchall(sql, params)
-        else:
+        if not value_filters:
             sql += " LIMIT ? OFFSET ?"
             params.append(limit)
             params.append(offset)
+        try:
+            rows = await self._fetchall(sql, params)
+        except Exception as exc:
+            if not self._can_recover_from(exc):
+                raise
+            await self._recover_corrupt_storage(exc)
             rows = await self._fetchall(sql, params)
 
         entries = [
@@ -723,8 +762,15 @@ class RingBuffer:
                 "max_age": self._max_age,
                 "file_size_bytes": 0,
             }
-        async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
-            row = await cur.fetchone()
+        try:
+            async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
+                row = await cur.fetchone()
+        except Exception as exc:
+            if not self._can_recover_from(exc):
+                raise
+            await self._recover_corrupt_storage(exc)
+            async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
+                row = await cur.fetchone()
         oldest_ts = row[1] if row else None
         return {
             "total": row[0] if row else 0,
@@ -766,6 +812,79 @@ class RingBuffer:
         async with self._conn.execute(sql, params) as cur:
             return await cur.fetchall()
 
+    async def _open_connection_locked(self) -> None:
+        path = ":memory:" if self._storage == "memory" else self._disk_path
+        if self._storage in {"disk", "file"}:
+            directory = os.path.dirname(path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+        conn: aiosqlite.Connection | None = None
+        try:
+            conn = await aiosqlite.connect(path)
+            conn.row_factory = aiosqlite.Row
+            await conn.execute("PRAGMA foreign_keys=ON")
+            if self._storage in {"disk", "file"}:
+                await conn.execute("PRAGMA journal_mode=WAL")
+            self._conn = conn
+            await self._conn.executescript(_SCHEMA)
+            await self._ensure_compat_schema()
+            if self._storage in {"disk", "file"}:
+                await self._assert_integrity_ok()
+            await self._conn.commit()
+        except Exception:
+            if conn:
+                await conn.close()
+            if self._conn is conn:
+                self._conn = None
+            raise
+
+    async def _assert_integrity_ok(self) -> None:
+        if not self._conn:
+            return
+        async with self._conn.execute("PRAGMA integrity_check") as cur:
+            row = await cur.fetchone()
+        result = row[0] if row else ""
+        if str(result).lower() != "ok":
+            raise aiosqlite.DatabaseError(f"SQLite integrity_check failed: {result}")
+
+    async def _close_connection(self) -> None:
+        if self._conn:
+            await self._conn.close()
+            self._conn = None
+
+    async def _recover_corrupt_storage(self, exc: Exception) -> None:
+        async with self._lock:
+            await self._recover_corrupt_storage_locked(exc)
+
+    async def _recover_corrupt_storage_locked(self, exc: Exception) -> None:
+        if self._storage == "memory":
+            logger.warning("RingBuffer in-memory SQLite connection is corrupt; recreating empty database: %s", exc)
+            await self._close_connection()
+            await self._open_connection_locked()
+            self._last_values.clear()
+            return
+
+        logger.warning("RingBuffer SQLite database is corrupt; quarantining and recreating empty database: %s", exc)
+        await self._close_connection()
+        moved_paths = self._quarantine_storage_files()
+        await self._open_connection_locked()
+        self._last_values.clear()
+        logger.warning("RingBuffer recovered with empty database; quarantined files=%s", moved_paths)
+
+    def _quarantine_storage_files(self) -> list[str]:
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        moved: list[str] = []
+        for path in (self._disk_path, f"{self._disk_path}-wal", f"{self._disk_path}-shm"):
+            if not os.path.exists(path):
+                continue
+            target = f"{path}.corrupt-{stamp}"
+            os.replace(path, target)
+            moved.append(target)
+        return moved
+
+    def _can_recover_from(self, exc: Exception) -> bool:
+        return self._storage in {"disk", "file", "memory"} and _is_sqlite_corruption(exc)
+
 
 def _safe_loads(s: str | None) -> Any:
     if s is None:
@@ -779,6 +898,13 @@ def _safe_loads(s: str | None) -> Any:
 def _safe_loads_dict(s: str | None) -> dict[str, Any]:
     loaded = _safe_loads(s)
     return loaded if isinstance(loaded, dict) else {}
+
+
+def _is_sqlite_corruption(exc: Exception) -> bool:
+    if not isinstance(exc, aiosqlite.Error):
+        return False
+    message = str(exc).lower()
+    return any(marker in message for marker in _SQLITE_CORRUPTION_MARKERS)
 
 
 def _normalize_string_filters(values: list[str] | None) -> list[str]:

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -211,7 +211,12 @@ class RingBuffer:
             self._max_age = int(resolved_max_age) if resolved_max_age is not None else None
 
             # Open new connection
-            await self._open_connection_locked()
+            try:
+                await self._open_connection_locked()
+            except Exception as exc:
+                if not self._can_recover_from(exc):
+                    raise
+                await self._recover_corrupt_storage_locked(exc)
             await self._conn.execute("DELETE FROM ringbuffer")
             await self._conn.commit()
             self._last_values.clear()

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -721,8 +721,13 @@ class RingBuffer:
             if not self._can_recover_from(exc):
                 raise
             async with self._lock:
-                await self._recover_corrupt_storage_locked(exc)
-                rows = await self._fetchall(sql, params)
+                try:
+                    rows = await self._fetchall(sql, params)
+                except Exception as locked_exc:
+                    if not self._can_recover_from(locked_exc):
+                        raise
+                    await self._recover_corrupt_storage_locked(locked_exc)
+                    rows = await self._fetchall(sql, params)
 
         entries = [
             RingBufferEntry(
@@ -780,9 +785,15 @@ class RingBuffer:
             if not self._can_recover_from(exc):
                 raise
             async with self._lock:
-                await self._recover_corrupt_storage_locked(exc)
-                async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
-                    row = await cur.fetchone()
+                try:
+                    async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
+                        row = await cur.fetchone()
+                except Exception as locked_exc:
+                    if not self._can_recover_from(locked_exc):
+                        raise
+                    await self._recover_corrupt_storage_locked(locked_exc)
+                    async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
+                        row = await cur.fetchone()
         oldest_ts = row[1] if row else None
         return {
             "total": row[0] if row else 0,

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -36,6 +36,7 @@ _SQLITE_CORRUPTION_MARKERS = (
     "file is not a database",
     "integrity_check failed",
 )
+_MAX_QUARANTINE_FILES_PER_STORAGE_FILE = 3
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS ringbuffer (
@@ -717,8 +718,9 @@ class RingBuffer:
         except Exception as exc:
             if not self._can_recover_from(exc):
                 raise
-            await self._recover_corrupt_storage(exc)
-            rows = await self._fetchall(sql, params)
+            async with self._lock:
+                await self._recover_corrupt_storage_locked(exc)
+                rows = await self._fetchall(sql, params)
 
         entries = [
             RingBufferEntry(
@@ -773,9 +775,10 @@ class RingBuffer:
         except Exception as exc:
             if not self._can_recover_from(exc):
                 raise
-            await self._recover_corrupt_storage(exc)
-            async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
-                row = await cur.fetchone()
+            async with self._lock:
+                await self._recover_corrupt_storage_locked(exc)
+                async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
+                    row = await cur.fetchone()
         oldest_ts = row[1] if row else None
         return {
             "total": row[0] if row else 0,
@@ -857,21 +860,11 @@ class RingBuffer:
             await self._conn.close()
             self._conn = None
 
-    async def _recover_corrupt_storage(self, exc: Exception) -> None:
-        async with self._lock:
-            await self._recover_corrupt_storage_locked(exc)
-
     async def _recover_corrupt_storage_locked(self, exc: Exception) -> None:
-        if self._storage == "memory":
-            logger.warning("RingBuffer in-memory SQLite connection is corrupt; recreating empty database: %s", exc)
-            await self._close_connection()
-            await self._open_connection_locked()
-            self._last_values.clear()
-            return
-
         logger.warning("RingBuffer SQLite database is corrupt; quarantining and recreating empty database: %s", exc)
         await self._close_connection()
         moved_paths = self._quarantine_storage_files()
+        self._cleanup_quarantine_files()
         await self._open_connection_locked()
         self._last_values.clear()
         logger.warning("RingBuffer recovered with empty database; quarantined files=%s", moved_paths)
@@ -887,8 +880,27 @@ class RingBuffer:
             moved.append(target)
         return moved
 
+    def _cleanup_quarantine_files(self) -> None:
+        for path in (self._disk_path, f"{self._disk_path}-wal", f"{self._disk_path}-shm"):
+            directory = os.path.dirname(path) or "."
+            prefix = f"{os.path.basename(path)}.corrupt-"
+            try:
+                candidates = [
+                    os.path.join(directory, name)
+                    for name in os.listdir(directory)
+                    if name.startswith(prefix)
+                ]
+            except FileNotFoundError:
+                continue
+            stale = sorted(candidates, reverse=True)[_MAX_QUARANTINE_FILES_PER_STORAGE_FILE:]
+            for candidate in stale:
+                try:
+                    os.remove(candidate)
+                except FileNotFoundError:
+                    pass
+
     def _can_recover_from(self, exc: Exception) -> bool:
-        return self._storage in {"disk", "file", "memory"} and _is_sqlite_corruption(exc)
+        return self._storage in {"disk", "file"} and _is_sqlite_corruption(exc)
 
 
 def _safe_loads(s: str | None) -> Any:

--- a/obs/ringbuffer/ringbuffer.py
+++ b/obs/ringbuffer/ringbuffer.py
@@ -126,6 +126,8 @@ class RingBuffer:
         self._max_age = max_age
         self._conn: aiosqlite.Connection | None = None
         self._last_values: dict[str, Any] = {}  # dp_id → last recorded value
+        self._last_recovery_at: str | None = None
+        self._last_recovery_files: list[str] = []
         self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
@@ -768,6 +770,8 @@ class RingBuffer:
                 "max_file_size_bytes": self._max_file_size_bytes,
                 "max_age": self._max_age,
                 "file_size_bytes": 0,
+                "last_recovery_at": self._last_recovery_at,
+                "last_recovery_file_count": len(self._last_recovery_files),
             }
         try:
             async with self._conn.execute("SELECT COUNT(*) AS c, MIN(ts) AS oldest, MAX(ts) AS newest FROM ringbuffer") as cur:
@@ -790,6 +794,8 @@ class RingBuffer:
             "max_file_size_bytes": self._max_file_size_bytes,
             "max_age": self._max_age,
             "file_size_bytes": await self._current_storage_bytes(),
+            "last_recovery_at": self._last_recovery_at,
+            "last_recovery_file_count": len(self._last_recovery_files),
         }
 
     async def _persist_metadata_indexes(self, entry_id: int, metadata: dict[str, Any]) -> None:
@@ -867,6 +873,8 @@ class RingBuffer:
         self._cleanup_quarantine_files()
         await self._open_connection_locked()
         self._last_values.clear()
+        self._last_recovery_at = _isoformat_utc(datetime.now(UTC))
+        self._last_recovery_files = moved_paths
         logger.warning("RingBuffer recovered with empty database; quarantined files=%s", moved_paths)
 
     def _quarantine_storage_files(self) -> list[str]:

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import aiosqlite
 import pytest
@@ -100,6 +102,58 @@ async def test_file_storage_recovers_malformed_database_during_record(tmp_path: 
         assert calls["count"] == 2
         assert [entry.new_value for entry in entries] == [1]
         assert list(tmp_path.glob("ringbuffer-malformed-record.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
+async def test_handle_value_event_preserves_last_value_after_record_recovery(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-event-recovery-last-value.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+
+        def _raise_runtime_error():
+            raise RuntimeError("registry unavailable")
+
+        monkeypatch.setattr("obs.core.registry.get_registry", _raise_runtime_error)
+
+        calls = {"count": 0}
+        original_record_locked = rb._record_locked  # noqa: SLF001
+
+        async def _raise_malformed_once(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise aiosqlite.OperationalError("database disk image is malformed")
+            return await original_record_locked(*args, **kwargs)
+
+        monkeypatch.setattr(rb, "_record_locked", _raise_malformed_once)
+        dp_id = "dp-event-recovery"
+
+        await rb.handle_value_event(
+            SimpleNamespace(
+                datapoint_id=dp_id,
+                ts=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+                value=10,
+                source_adapter="api",
+                quality="good",
+            )
+        )
+        await rb.handle_value_event(
+            SimpleNamespace(
+                datapoint_id=dp_id,
+                ts=datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC),
+                value=11,
+                source_adapter="api",
+                quality="good",
+            )
+        )
+
+        entries = await rb.query(q=dp_id, limit=10)
+
+        assert calls["count"] == 3
+        assert [entry.new_value for entry in entries] == [11, 10]
+        assert entries[0].old_value == 10
+        assert list(tmp_path.glob("ringbuffer-event-recovery-last-value.db.corrupt-*"))
     finally:
         await rb.stop()
 

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -128,6 +128,7 @@ async def test_memory_storage_does_not_attempt_corruption_recovery(monkeypatch):
     rb = RingBuffer(storage="memory", max_entries=100)
     await rb.start()
     try:
+
         async def _always_malformed(*args, **kwargs):
             raise aiosqlite.DatabaseError("database disk image is malformed")
 

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -338,3 +338,37 @@ async def test_reconfigure_same_model_keeps_entries(tmp_path: Path):
         assert stats["max_age"] == 60
     finally:
         await rb.stop()
+
+
+async def test_reconfigure_same_model_recovers_malformed_file_storage(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-same-model-recovery.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+
+        calls = {"count": 0}
+        original_trim = rb._trim  # noqa: SLF001
+
+        async def _raise_malformed_once(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise aiosqlite.DatabaseError("database disk image is malformed")
+            return await original_trim(*args, **kwargs)
+
+        monkeypatch.setattr(rb, "_trim", _raise_malformed_once)
+
+        await rb.reconfigure("file", 50, max_file_size_bytes=1_000_000, max_age=60)
+        await _record_value(rb, 2, "2026-01-01T00:00:01.000Z")
+
+        entries = await rb.query(q="dp-storage-v2", limit=10)
+        stats = await rb.stats()
+
+        assert [entry.new_value for entry in entries] == [2]
+        assert stats["max_entries"] == 50
+        assert stats["max_file_size_bytes"] == 1_000_000
+        assert stats["max_age"] == 60
+        assert stats["last_recovery_at"]
+        assert list(tmp_path.glob("ringbuffer-same-model-recovery.db.corrupt-*"))
+    finally:
+        await rb.stop()

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -210,7 +210,7 @@ async def test_file_storage_recovers_malformed_database_during_query(tmp_path: P
 
         async def _raise_malformed_once(*args, **kwargs):
             calls["count"] += 1
-            if calls["count"] == 1:
+            if calls["count"] <= 2:
                 raise aiosqlite.DatabaseError("file is not a database")
             return await original_fetchall(*args, **kwargs)
 
@@ -218,9 +218,40 @@ async def test_file_storage_recovers_malformed_database_during_query(tmp_path: P
 
         entries = await rb.query(q="dp-storage-v2", limit=10)
 
-        assert calls["count"] == 2
+        assert calls["count"] == 3
         assert entries == []
         assert list(tmp_path.glob("ringbuffer-malformed-query.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
+async def test_file_storage_skips_duplicate_recovery_after_stale_query_error(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-stale-query-error.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+
+        calls = {"count": 0, "recoveries": 0}
+        original_fetchall = rb._fetchall  # noqa: SLF001
+
+        async def _raise_stale_malformed_once(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise aiosqlite.DatabaseError("file is not a database")
+            return await original_fetchall(*args, **kwargs)
+
+        async def _count_recovery(*args, **kwargs):
+            calls["recoveries"] += 1
+
+        monkeypatch.setattr(rb, "_fetchall", _raise_stale_malformed_once)
+        monkeypatch.setattr(rb, "_recover_corrupt_storage_locked", _count_recovery)
+
+        entries = await rb.query(q="dp-storage-v2", limit=10)
+
+        assert calls == {"count": 2, "recoveries": 0}
+        assert [entry.new_value for entry in entries] == [1]
+        assert not list(tmp_path.glob("ringbuffer-stale-query-error.db.corrupt-*"))
     finally:
         await rb.stop()
 
@@ -238,7 +269,7 @@ async def test_file_storage_recovers_malformed_database_during_stats(tmp_path: P
         def _raise_malformed_once(sql, *args, **kwargs):
             if str(sql).startswith("SELECT COUNT(*) AS c"):
                 calls["count"] += 1
-                if calls["count"] == 1:
+                if calls["count"] <= 2:
                     raise aiosqlite.DatabaseError("SQLite integrity_check failed: bad page")
             return original_execute(sql, *args, **kwargs)
 
@@ -246,7 +277,7 @@ async def test_file_storage_recovers_malformed_database_during_stats(tmp_path: P
 
         stats = await rb.stats()
 
-        assert calls["count"] == 1
+        assert calls["count"] == 2
         assert stats["total"] == 0
         assert stats["file_size_bytes"] >= 0
         assert list(tmp_path.glob("ringbuffer-malformed-stats.db.corrupt-*"))

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -84,6 +84,62 @@ async def test_file_storage_recovers_malformed_database_during_record(tmp_path: 
         await rb.stop()
 
 
+async def test_file_storage_recovers_malformed_database_during_query(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-malformed-query.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+
+        calls = {"count": 0}
+        original_fetchall = rb._fetchall  # noqa: SLF001
+
+        async def _raise_malformed_once(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise aiosqlite.DatabaseError("file is not a database")
+            return await original_fetchall(*args, **kwargs)
+
+        monkeypatch.setattr(rb, "_fetchall", _raise_malformed_once)
+
+        entries = await rb.query(q="dp-storage-v2", limit=10)
+
+        assert calls["count"] == 2
+        assert entries == []
+        assert list(tmp_path.glob("ringbuffer-malformed-query.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
+async def test_file_storage_recovers_malformed_database_during_stats(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-malformed-stats.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+
+        original_execute = rb._conn.execute  # noqa: SLF001
+        calls = {"count": 0}
+
+        def _raise_malformed_once(sql, *args, **kwargs):
+            if str(sql).startswith("SELECT COUNT(*) AS c"):
+                calls["count"] += 1
+                if calls["count"] == 1:
+                    raise aiosqlite.DatabaseError("SQLite integrity_check failed: bad page")
+            return original_execute(sql, *args, **kwargs)
+
+        monkeypatch.setattr(rb._conn, "execute", _raise_malformed_once)  # noqa: SLF001
+
+        stats = await rb.stats()
+
+        assert calls["count"] == 1
+        assert stats["total"] == 0
+        assert stats["file_size_bytes"] >= 0
+        assert list(tmp_path.glob("ringbuffer-malformed-stats.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
 async def test_reconfigure_model_switch_restarts_empty_without_migration(tmp_path: Path):
     db_path = tmp_path / "ringbuffer-model-switch.db"
     rb = RingBuffer(storage="disk", max_entries=100, disk_path=str(db_path))

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import aiosqlite
 import pytest
 
 from obs.ringbuffer.ringbuffer import RingBuffer
@@ -39,6 +40,48 @@ async def test_file_storage_restart_persists_entries(tmp_path: Path):
         assert [entry.new_value for entry in entries] == [1]
     finally:
         await rb2.stop()
+
+
+async def test_file_storage_recovers_malformed_database_on_start(tmp_path: Path):
+    db_path = tmp_path / "ringbuffer-malformed-start.db"
+    db_path.write_bytes(b"not a sqlite database")
+
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+        entries = await rb.query(q="dp-storage-v2", limit=10)
+
+        assert [entry.new_value for entry in entries] == [1]
+        assert list(tmp_path.glob("ringbuffer-malformed-start.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
+async def test_file_storage_recovers_malformed_database_during_record(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-malformed-record.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        calls = {"count": 0}
+        original_record_locked = rb._record_locked  # noqa: SLF001
+
+        async def _raise_malformed_once(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise aiosqlite.OperationalError("database disk image is malformed")
+            return await original_record_locked(*args, **kwargs)
+
+        monkeypatch.setattr(rb, "_record_locked", _raise_malformed_once)
+
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+        entries = await rb.query(q="dp-storage-v2", limit=10)
+
+        assert calls["count"] == 2
+        assert [entry.new_value for entry in entries] == [1]
+        assert list(tmp_path.glob("ringbuffer-malformed-record.db.corrupt-*"))
+    finally:
+        await rb.stop()
 
 
 async def test_reconfigure_model_switch_restarts_empty_without_migration(tmp_path: Path):

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -51,8 +51,11 @@ async def test_file_storage_recovers_malformed_database_on_start(tmp_path: Path)
     try:
         await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
         entries = await rb.query(q="dp-storage-v2", limit=10)
+        stats = await rb.stats()
 
         assert [entry.new_value for entry in entries] == [1]
+        assert stats["last_recovery_at"]
+        assert stats["last_recovery_file_count"] == 1
         assert list(tmp_path.glob("ringbuffer-malformed-start.db.corrupt-*"))
     finally:
         await rb.stop()

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -58,6 +58,23 @@ async def test_file_storage_recovers_malformed_database_on_start(tmp_path: Path)
         await rb.stop()
 
 
+async def test_file_storage_limits_quarantined_database_files(tmp_path: Path):
+    db_path = tmp_path / "ringbuffer-quarantine-limit.db"
+    for index in range(5):
+        (tmp_path / f"ringbuffer-quarantine-limit.db.corrupt-20260101T00000{index}000000Z").write_bytes(b"old")
+    db_path.write_bytes(b"not a sqlite database")
+
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        quarantined = sorted(tmp_path.glob("ringbuffer-quarantine-limit.db.corrupt-*"))
+
+        assert len(quarantined) == 3
+        assert any(path.read_bytes() == b"not a sqlite database" for path in quarantined)
+    finally:
+        await rb.stop()
+
+
 async def test_file_storage_recovers_malformed_database_during_record(tmp_path: Path, monkeypatch):
     db_path = tmp_path / "ringbuffer-malformed-record.db"
     rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
@@ -80,6 +97,45 @@ async def test_file_storage_recovers_malformed_database_during_record(tmp_path: 
         assert calls["count"] == 2
         assert [entry.new_value for entry in entries] == [1]
         assert list(tmp_path.glob("ringbuffer-malformed-record.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
+async def test_file_storage_recovery_retry_failure_propagates(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "ringbuffer-retry-fails.db"
+    rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+
+        async def _always_malformed(*args, **kwargs):
+            raise aiosqlite.DatabaseError("database disk image is malformed")
+
+        monkeypatch.setattr(rb, "_fetchall", _always_malformed)
+
+        with pytest.raises(aiosqlite.DatabaseError, match="database disk image is malformed"):
+            await rb.query(q="dp-storage-v2", limit=10)
+
+        assert list(tmp_path.glob("ringbuffer-retry-fails.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
+async def test_memory_storage_does_not_attempt_corruption_recovery(monkeypatch):
+    rb = RingBuffer(storage="memory", max_entries=100)
+    await rb.start()
+    try:
+        async def _always_malformed(*args, **kwargs):
+            raise aiosqlite.DatabaseError("database disk image is malformed")
+
+        async def _fail_if_called(*args, **kwargs):
+            raise AssertionError("memory storage should not run file recovery")
+
+        monkeypatch.setattr(rb, "_fetchall", _always_malformed)
+        monkeypatch.setattr(rb, "_recover_corrupt_storage_locked", _fail_if_called)
+
+        with pytest.raises(aiosqlite.DatabaseError, match="database disk image is malformed"):
+            await rb.query(q="dp-storage-v2", limit=10)
     finally:
         await rb.stop()
 

--- a/tests/integration/test_ringbuffer_storage_v2.py
+++ b/tests/integration/test_ringbuffer_storage_v2.py
@@ -157,6 +157,25 @@ async def test_reconfigure_model_switch_restarts_empty_without_migration(tmp_pat
         await rb.stop()
 
 
+async def test_reconfigure_model_switch_recovers_malformed_file_storage(tmp_path: Path):
+    db_path = tmp_path / "ringbuffer-reconfigure-malformed.db"
+    db_path.write_bytes(b"not a sqlite database")
+    rb = RingBuffer(storage="memory", max_entries=100, disk_path=str(db_path))
+    await rb.start()
+    try:
+        await rb.reconfigure("file", 100)
+        await _record_value(rb, 1, "2026-01-01T00:00:00.000Z")
+
+        entries = await rb.query(q="dp-storage-v2", limit=10)
+        stats = await rb.stats()
+
+        assert [entry.new_value for entry in entries] == [1]
+        assert stats["storage"] == "file"
+        assert list(tmp_path.glob("ringbuffer-reconfigure-malformed.db.corrupt-*"))
+    finally:
+        await rb.stop()
+
+
 async def test_reconfigure_same_model_keeps_entries(tmp_path: Path):
     db_path = tmp_path / "ringbuffer-same-model.db"
     rb = RingBuffer(storage="file", max_entries=100, disk_path=str(db_path))

--- a/tests/unit/test_ringbuffer_legacy_guards.py
+++ b/tests/unit/test_ringbuffer_legacy_guards.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import pytest
 
 from obs.ringbuffer import ringbuffer as rb_mod
-from obs.ringbuffer.ringbuffer import RingBuffer, _safe_loads, get_ringbuffer, reset_ringbuffer
+from obs.ringbuffer.ringbuffer import RingBuffer, _is_sqlite_corruption, _safe_loads, get_ringbuffer, reset_ringbuffer
 
 
 @pytest.mark.asyncio
@@ -138,3 +138,11 @@ def test_safe_loads_and_singleton_guard_paths():
     rb_mod.reset_ringbuffer()
     with pytest.raises(RuntimeError, match="RingBuffer not initialized"):
         rb_mod.get_ringbuffer()
+
+
+def test_sqlite_corruption_detector_only_matches_sqlite_corruption_errors():
+    assert _is_sqlite_corruption(rb_mod.aiosqlite.OperationalError("database disk image is malformed")) is True
+    assert _is_sqlite_corruption(rb_mod.aiosqlite.DatabaseError("file is not a database")) is True
+    assert _is_sqlite_corruption(rb_mod.aiosqlite.DatabaseError("SQLite integrity_check failed: bad page")) is True
+    assert _is_sqlite_corruption(rb_mod.aiosqlite.OperationalError("database is locked")) is False
+    assert _is_sqlite_corruption(RuntimeError("database disk image is malformed")) is False


### PR DESCRIPTION
## Summary
- recover the RingBuffer when its SQLite database is malformed
- quarantine corrupted DB/WAL/SHM files and recreate an empty monitor database
- cap retained quarantined DB/WAL/SHM files to avoid unbounded disk growth on repeated corruption
- serialize recovery + retry for read paths and recover during storage reconfiguration too
- expose the last recovery timestamp/count through monitor stats and show an inline Monitor warning after self-healing
- create the RingBuffer DB parent directory when opening file-backed storage
- add regression coverage for startup, write-time, query-time, stats-time, and reconfigure-time corruption

## Tests
- `.venv/bin/pytest tests/integration/test_ringbuffer_storage_v2.py tests/unit/test_ringbuffer_legacy_guards.py tests/unit/test_ringbuffer_baseline.py tests/unit/test_ringbuffer_query_v2.py -q`
- `.venv/bin/ruff check obs/ringbuffer/ringbuffer.py obs/api/v1/ringbuffer.py tests/integration/test_ringbuffer_storage_v2.py tests/unit/test_ringbuffer_legacy_guards.py`
- `npm run test -- RingBufferView.mount.spec.js` (from `gui/`)
- `.venv/bin/pytest tests/integration/test_ringbuffer_storage_v2.py tests/unit/test_ringbuffer_legacy_guards.py tests/unit/test_ringbuffer_baseline.py tests/unit/test_ringbuffer_query_v2.py --cov=obs.ringbuffer.ringbuffer --cov-report=term-missing -q`

Fixes #689