### PR TITLE
Fix Settings History DB tab rendering

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -49,6 +49,7 @@
 
 ### Fixes 🐞
 * Logic Security (Upstream PR #686): API client secret-file paths are restricted to a configured secret directory with bounded regular-file reads.
+* GUI: Settings → History DB no longer opens as an empty tab when the TimescaleDB DSN placeholder is rendered; the `@` in the PostgreSQL example is escaped for vue-i18n. https://github.com/abeggled/openbridgeserver/issues/690
 * Adapter: KNX IP Secure now works correctly in Docker bridge networks — credentials are extracted directly from the .knxkeys file and passed explicitly to xknx, bypassing the internal UDP DescriptionRequest that fails without host networking. Connection errors now include actionable hints (Docker network mode, gateway tunnel-slot exhaustion). https://github.com/abeggled/openbridgeserver/issues/393
 * Backend: Complete remaining UI translation fixes after i18n rollout. https://github.com/abeggled/openbridgeserver/pull/542
 * Backend: Validate `DataValueEvent` payloads before bridge propagation. https://github.com/abeggled/openbridgeserver/pull/519

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -1692,7 +1692,7 @@
       "organization": "Organisation",
       "bucket": "Bucket",
       "connectionDsn": "Connection DSN",
-      "connectionDsnPlaceholder": "postgresql://user:pass@localhost:5432/obs",
+      "connectionDsnPlaceholder": "postgresql://user:pass{'@'}localhost:5432/obs",
       "testButton": "Verbindung testen",
       "saveButton": "Speichern & aktivieren",
       "saved": "Historie DB gespeichert und aktiviert.",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -1692,7 +1692,7 @@
       "organization": "Organization",
       "bucket": "Bucket",
       "connectionDsn": "Connection DSN",
-      "connectionDsnPlaceholder": "postgresql://user:pass@localhost:5432/obs",
+      "connectionDsnPlaceholder": "postgresql://user:pass{'@'}localhost:5432/obs",
       "testButton": "Test Connection",
       "saveButton": "Save & activate",
       "saved": "History DB saved and activated.",


### PR DESCRIPTION
## Summary
- Escape the `@` in the TimescaleDB DSN placeholder so vue-i18n treats it as literal text
- Add release notes entry for issue #690

## Verification
- `npm run build` in `gui/`

Fixes #690