### PR TITLE
Fix Verlauf widget multi-day history range

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -94,6 +94,7 @@
 * Test stability: Monitor/Ringbuffer E2E scenarios stabilized. https://github.com/abeggled/openbridgeserver/pull/494
 * Visu: Internal API base URL usage fixed for E2E/runtime alignment. https://github.com/abeggled/openbridgeserver/pull/484
 * Visu: History widget now updates automatically when new values arrive via WebSocket. https://github.com/abeggled/openbridgeserver/issues/408
+* Visu: History widget now uses aggregated history buckets for multi-day ranges, so periods up to "last 90 days" remain complete and render efficiently instead of only showing the newest 24 hours. https://github.com/abeggled/openbridgeserver/issues/692
 * Visu: RTR Widget now use correct values for room controller (heating) DPT 20.102 https://github.com/abeggled/openbridgeserver/issues/461
 * Visu: Floorplan Widget: positioning broken if floorplan is rotated https://github.com/abeggled/openbridgeserver/issues/440
 * Visu: Slider widget values are now written on pointer release and keyboard commit, avoiding missed writes in browsers that do not reliably fire change after dragging. https://github.com/abeggled/openbridgeserver/pull/559

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -431,4 +431,13 @@ export const history = {
       { headers, silent401: true },
     )
   },
+  aggregate: (id: string, from: string, to: string, interval: string, fn = 'avg') => {
+    const headers: Record<string, string> = {}
+    if (_writeContext.pageId)      headers['X-Page-Id']       = _writeContext.pageId
+    if (_writeContext.sessionToken) headers['X-Session-Token'] = _writeContext.sessionToken
+    return request<{ bucket: string; v: unknown; n?: number | null }[]>(
+      `/history/${id}/aggregate?fn=${fn}&interval=${interval}&from=${from}&to=${to}`,
+      { headers, silent401: true },
+    )
+  },
 }

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -11,7 +11,7 @@ import {
 import { history } from '@/api/client'
 import { useWebSocket } from '@/composables/useWebSocket'
 import type { DataPointValue } from '@/types'
-import { sortedUniqueTimestamps, weightedAverage, weightedValuesByTimestamp } from './aggregation'
+import { aggregateBucketEndTimestamp, sortedUniqueTimestamps, weightedAverage, weightedValuesByTimestamp } from './aggregation'
 import {
   TIME_RANGE_PRESETS,
   DEFAULT_TIME_RANGE,
@@ -262,7 +262,12 @@ async function loadData() {
     chart.data.datasets = defs.map((s, i) => ({
       yAxisID:         s.axis,
       label:           s.label || (hasMultiple ? t('widgets.chart.seriesFallback', { n: i + 1 }) : ''),
-      data:            results[i].map(d => ({ x: new Date(d.ts).getTime(), y: Number(d.v) })),
+      data:            results[i].map(d => ({
+        x: requestPlan.mode === 'aggregate'
+          ? aggregateBucketEndTimestamp(d.ts, requestPlan.interval, fromDate.getTime(), toDate.getTime())
+          : new Date(d.ts).getTime(),
+        y: Number(d.v),
+      })),
       borderColor:     s.color,
       backgroundColor: s.color + '1a',
       borderWidth:     1.5,

--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -11,7 +11,13 @@ import {
 import { history } from '@/api/client'
 import { useWebSocket } from '@/composables/useWebSocket'
 import type { DataPointValue } from '@/types'
-import { TIME_RANGE_PRESETS, DEFAULT_TIME_RANGE, resolveTimeRange } from './timeRangePresets'
+import { sortedUniqueTimestamps, weightedAverage, weightedValuesByTimestamp } from './aggregation'
+import {
+  TIME_RANGE_PRESETS,
+  DEFAULT_TIME_RANGE,
+  historyRequestPlanForRange,
+  resolveTimeRange,
+} from './timeRangePresets'
 
 Chart.register(
   LineController, LineElement, PointElement,
@@ -49,6 +55,7 @@ watch(() => props.config.time_range, () => {
 
 // 'y' = linke Achse, 'y1' = rechte Achse (Chart.js Achsen-IDs)
 interface SeriesDef { id: string; label: string; color: string; axis: 'y' | 'y1' }
+interface HistoryChartPoint { ts: string; v: unknown; u: string | null; q: string; n?: number }
 
 const COLORS = ['#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899', '#06b6d4', '#f97316']
 
@@ -180,12 +187,28 @@ async function loadData() {
   if (defs.length === 0 || !chart) return
 
   const { from: fromDate, to: toDate } = resolveTimeRange(selectedTimeRange.value)
+  const fromIso = fromDate.toISOString()
+  const toIso = toDate.toISOString()
+  const requestPlan = historyRequestPlanForRange(fromDate, toDate)
 
-  const results = await Promise.all(
-    defs.map(s => history.query(s.id, fromDate.toISOString(), toDate.toISOString())),
-  )
+  let results: HistoryChartPoint[][]
+  let units: string[]
 
-  seriesUnits.value = results.map(r => r[0]?.u ?? '')
+  if (requestPlan.mode === 'aggregate') {
+    const [aggregatedRows, unitRows] = await Promise.all([
+      Promise.all(defs.map(s => history.aggregate(s.id, fromIso, toIso, requestPlan.interval, requestPlan.fn))),
+      Promise.all(defs.map(s => history.query(s.id, fromIso, toIso, 1))),
+    ])
+    results = aggregatedRows.map(rows => rows.map(r => ({ ts: r.bucket, v: r.v, u: null, q: '', n: r.n ?? 1 })))
+    units = unitRows.map(r => r[0]?.u ?? '')
+  } else {
+    results = await Promise.all(
+      defs.map(s => history.query(s.id, fromIso, toIso, requestPlan.limit)),
+    )
+    units = results.map(r => r[0]?.u ?? '')
+  }
+
+  seriesUnits.value = units
 
   const hasMultiple = defs.length > 1
   const hasRight    = defs.some(s => s.axis === 'y1')
@@ -195,32 +218,45 @@ async function loadData() {
   const rightUnit = defs.reduce<string>((u, s, i) => u || (s.axis === 'y1' ? (seriesUnits.value[i] ?? '') : ''), '')
 
   if (isBar) {
-    // Daten in gleich breite Zeitbuckets aggregieren (Durchschnitt je Bucket).
-    // Alle Serien teilen dieselben Bucket-Mittelpunkte → korrekte Gruppierung.
-    const durationHours = (toDate.getTime() - fromDate.getTime()) / 3_600_000
-    const numBuckets    = Math.min(Math.max(Math.round(durationHours * 2), 24), 96)
-    const buckets       = buildBuckets(fromDate.getTime(), toDate.getTime(), numBuckets)
-
-    chart.data.labels   = buckets.map(b => fmtMs(b.mid))
-    chart.data.datasets = defs.map((s, i) => {
-      const raw = results[i]
-      const data = buckets.map(b => {
-        const pts = raw.filter(d => {
-          const ts = new Date(d.ts).getTime()
-          return ts >= b.start && ts < b.end
-        })
-        if (pts.length === 0) return null
-        return pts.reduce((sum, p) => sum + Number(p.v), 0) / pts.length
-      })
-      return {
+    if (requestPlan.mode === 'aggregate') {
+      const bucketTimestamps = sortedUniqueTimestamps(results)
+      chart.data.labels = bucketTimestamps.map(fmtMs)
+      chart.data.datasets = defs.map((s, i) => ({
         yAxisID:         s.axis,
         label:           s.label || (hasMultiple ? t('widgets.chart.seriesFallback', { n: i + 1 }) : ''),
-        data,
+        data:            weightedValuesByTimestamp(results[i], bucketTimestamps),
         backgroundColor: s.color + 'cc',
         borderWidth:     0,
         borderRadius:    2,
-      }
-    })
+      }))
+    } else {
+      // Daten in gleich breite Zeitbuckets aggregieren (Durchschnitt je Bucket).
+      // Alle Serien teilen dieselben Bucket-Mittelpunkte → korrekte Gruppierung.
+      const durationHours = (toDate.getTime() - fromDate.getTime()) / 3_600_000
+      const numBuckets    = Math.min(Math.max(Math.round(durationHours * 2), 24), 96)
+      const buckets       = buildBuckets(fromDate.getTime(), toDate.getTime(), numBuckets)
+
+      chart.data.labels   = buckets.map(b => fmtMs(b.mid))
+      chart.data.datasets = defs.map((s, i) => {
+        const raw = results[i]
+        const data = buckets.map(b => {
+          const pts = raw.filter(d => {
+            const ts = new Date(d.ts).getTime()
+            return ts >= b.start && ts < b.end
+          })
+          if (pts.length === 0) return null
+          return weightedAverage(pts)
+        })
+        return {
+          yAxisID:         s.axis,
+          label:           s.label || (hasMultiple ? t('widgets.chart.seriesFallback', { n: i + 1 }) : ''),
+          data,
+          backgroundColor: s.color + 'cc',
+          borderWidth:     0,
+          borderRadius:    2,
+        }
+      })
+    }
   } else {
     chart.data.labels   = undefined
     chart.data.datasets = defs.map((s, i) => ({

--- a/frontend/src/widgets/Chart/aggregation.test.ts
+++ b/frontend/src/widgets/Chart/aggregation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { sortedUniqueTimestamps, weightedAverage, weightedValuesByTimestamp } from './aggregation'
+
+describe('weightedAverage', () => {
+  it('uses equal weights when sample counts are absent', () => {
+    expect(weightedAverage([{ v: 10 }, { v: 20 }])).toBe(15)
+  })
+
+  it('preserves backend sample weights for aggregated chart buckets', () => {
+    expect(weightedAverage([{ v: 10, n: 1 }, { v: 20, n: 9 }])).toBe(19)
+  })
+
+  it('ignores non-numeric values', () => {
+    expect(weightedAverage([{ v: 'bad', n: 10 }, { v: 12, n: 2 }])).toBe(12)
+  })
+
+  it('returns null when no numeric values are available', () => {
+    expect(weightedAverage([{ v: 'bad', n: 10 }])).toBeNull()
+  })
+})
+
+describe('aggregated bar bucket alignment', () => {
+  const t0 = Date.parse('2026-06-03T10:00:00Z')
+  const t1 = Date.parse('2026-06-03T11:00:00Z')
+  const t2 = Date.parse('2026-06-03T12:00:00Z')
+
+  it('uses backend aggregate bucket timestamps directly', () => {
+    const timestamps = sortedUniqueTimestamps([
+      [{ ts: '2026-06-03T12:00:00Z', v: 30 }],
+      [{ ts: '2026-06-03T10:00:00Z', v: 10 }, { ts: '2026-06-03T11:00:00Z', v: 20 }],
+    ])
+
+    expect(timestamps).toEqual([t0, t1, t2])
+  })
+
+  it('does not create empty frontend buckets between hourly aggregate buckets', () => {
+    const timestamps = [t0, t1]
+    const values = weightedValuesByTimestamp([
+      { ts: '2026-06-03T10:00:00Z', v: 10, n: 1 },
+      { ts: '2026-06-03T11:00:00Z', v: 20, n: 9 },
+    ], timestamps)
+
+    expect(values).toEqual([10, 20])
+  })
+
+  it('keeps missing series buckets as null without shifting values', () => {
+    const values = weightedValuesByTimestamp([
+      { ts: '2026-06-03T11:00:00Z', v: 20, n: 9 },
+    ], [t0, t1])
+
+    expect(values).toEqual([null, 20])
+  })
+})

--- a/frontend/src/widgets/Chart/aggregation.test.ts
+++ b/frontend/src/widgets/Chart/aggregation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { sortedUniqueTimestamps, weightedAverage, weightedValuesByTimestamp } from './aggregation'
+import {
+  aggregateBucketEndTimestamp,
+  sortedUniqueTimestamps,
+  weightedAverage,
+  weightedValuesByTimestamp,
+} from './aggregation'
 
 describe('weightedAverage', () => {
   it('uses equal weights when sample counts are absent', () => {
@@ -49,5 +54,31 @@ describe('aggregated bar bucket alignment', () => {
     ], [t0, t1])
 
     expect(values).toEqual([null, 20])
+  })
+})
+
+describe('aggregateBucketEndTimestamp', () => {
+  it('moves the first partial aggregate bucket inside the requested line range', () => {
+    const fromMs = Date.parse('2026-06-03T12:34:00Z')
+    const toMs = Date.parse('2026-06-10T12:34:00Z')
+
+    expect(aggregateBucketEndTimestamp('2026-06-03T12:00:00Z', '1h', fromMs, toMs))
+      .toBe(Date.parse('2026-06-03T13:00:00Z'))
+  })
+
+  it('caps the final aggregate bucket at the requested range end', () => {
+    const fromMs = Date.parse('2026-06-03T12:34:00Z')
+    const toMs = Date.parse('2026-06-10T12:34:00Z')
+
+    expect(aggregateBucketEndTimestamp('2026-06-10T12:00:00Z', '1h', fromMs, toMs))
+      .toBe(toMs)
+  })
+
+  it('does not let an aggregate timestamp fall before the requested range start', () => {
+    const fromMs = Date.parse('2026-06-03T12:34:00Z')
+    const toMs = Date.parse('2026-06-10T12:34:00Z')
+
+    expect(aggregateBucketEndTimestamp('2026-06-03T06:00:00Z', '6h', fromMs, toMs))
+      .toBe(fromMs)
   })
 })

--- a/frontend/src/widgets/Chart/aggregation.ts
+++ b/frontend/src/widgets/Chart/aggregation.ts
@@ -7,6 +7,17 @@ export interface TimedWeightedChartPoint extends WeightedChartPoint {
   ts: string
 }
 
+const AGGREGATE_INTERVAL_MS: Record<string, number> = {
+  '1m': 60_000,
+  '5m': 5 * 60_000,
+  '15m': 15 * 60_000,
+  '30m': 30 * 60_000,
+  '1h': 3_600_000,
+  '6h': 6 * 3_600_000,
+  '12h': 12 * 3_600_000,
+  '1d': 24 * 3_600_000,
+}
+
 export function weightedAverage(points: WeightedChartPoint[]): number | null {
   const weighted = points.reduce((acc, p) => {
     const value = Number(p.v)
@@ -38,4 +49,18 @@ export function weightedValuesByTimestamp(points: TimedWeightedChartPoint[], tim
     const bucket = grouped.get(ts)
     return bucket ? weightedAverage(bucket) : null
   })
+}
+
+export function aggregateBucketEndTimestamp(
+  bucketTimestamp: string,
+  interval: string,
+  fromMs: number,
+  toMs: number,
+): number {
+  const bucketStartMs = new Date(bucketTimestamp).getTime()
+  const intervalMs = AGGREGATE_INTERVAL_MS[interval]
+
+  if (!Number.isFinite(bucketStartMs) || !Number.isFinite(intervalMs)) return bucketStartMs
+
+  return Math.min(Math.max(bucketStartMs + intervalMs, fromMs), toMs)
 }

--- a/frontend/src/widgets/Chart/aggregation.ts
+++ b/frontend/src/widgets/Chart/aggregation.ts
@@ -1,0 +1,41 @@
+export interface WeightedChartPoint {
+  v: unknown
+  n?: number | null
+}
+
+export interface TimedWeightedChartPoint extends WeightedChartPoint {
+  ts: string
+}
+
+export function weightedAverage(points: WeightedChartPoint[]): number | null {
+  const weighted = points.reduce((acc, p) => {
+    const value = Number(p.v)
+    const weight = Math.max(1, Number(p.n ?? 1))
+    if (!Number.isFinite(value) || !Number.isFinite(weight)) return acc
+    return { sum: acc.sum + value * weight, weight: acc.weight + weight }
+  }, { sum: 0, weight: 0 })
+
+  return weighted.weight > 0 ? weighted.sum / weighted.weight : null
+}
+
+export function sortedUniqueTimestamps(series: TimedWeightedChartPoint[][]): number[] {
+  return [...new Set(series.flatMap(points => points.map(p => new Date(p.ts).getTime()).filter(Number.isFinite)))]
+    .sort((a, b) => a - b)
+}
+
+export function weightedValuesByTimestamp(points: TimedWeightedChartPoint[], timestamps: number[]): (number | null)[] {
+  const grouped = new Map<number, TimedWeightedChartPoint[]>()
+
+  for (const point of points) {
+    const ts = new Date(point.ts).getTime()
+    if (!Number.isFinite(ts)) continue
+    const bucket = grouped.get(ts) ?? []
+    bucket.push(point)
+    grouped.set(ts, bucket)
+  }
+
+  return timestamps.map(ts => {
+    const bucket = grouped.get(ts)
+    return bucket ? weightedAverage(bucket) : null
+  })
+}

--- a/frontend/src/widgets/Chart/timeRangePresets.test.ts
+++ b/frontend/src/widgets/Chart/timeRangePresets.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DAY_MS,
+  DEFAULT_HISTORY_QUERY_LIMIT,
+  historyRequestPlanForRange,
+} from './timeRangePresets'
+
+describe('historyRequestPlanForRange', () => {
+  it('keeps raw history queries for ranges up to one day', () => {
+    const to = new Date('2026-06-03T12:00:00.000Z')
+    const from = new Date('2026-06-02T12:00:00.000Z')
+
+    expect(historyRequestPlanForRange(from, to)).toEqual({
+      mode: 'raw',
+      limit: DEFAULT_HISTORY_QUERY_LIMIT,
+    })
+  })
+
+  it('keeps the exact one-day boundary as a raw query', () => {
+    const to = new Date('2026-06-03T12:00:00.000Z')
+    const from = new Date(to.getTime() - DAY_MS)
+
+    expect(historyRequestPlanForRange(from, to)).toEqual({
+      mode: 'raw',
+      limit: DEFAULT_HISTORY_QUERY_LIMIT,
+    })
+  })
+
+  it('falls back to a raw query for invalid dates', () => {
+    expect(historyRequestPlanForRange(new Date('invalid'), new Date('2026-06-03T12:00:00.000Z'))).toEqual({
+      mode: 'raw',
+      limit: DEFAULT_HISTORY_QUERY_LIMIT,
+    })
+  })
+
+  it('compresses two-day chart ranges into one-hour buckets', () => {
+    const to = new Date('2026-06-03T12:00:00.000Z')
+    const from = new Date('2026-06-01T12:00:00.000Z')
+
+    expect(historyRequestPlanForRange(from, to)).toEqual({
+      mode: 'aggregate',
+      fn: 'avg',
+      interval: '1h',
+    })
+  })
+
+  it('compresses seven-day chart ranges into one-hour buckets', () => {
+    const to = new Date('2026-06-03T12:00:00.000Z')
+    const from = new Date('2026-05-27T12:00:00.000Z')
+
+    expect(historyRequestPlanForRange(from, to)).toEqual({
+      mode: 'aggregate',
+      fn: 'avg',
+      interval: '1h',
+    })
+  })
+
+  it('compresses 30-day chart ranges into six-hour buckets', () => {
+    const to = new Date('2026-06-03T12:00:00.000Z')
+    const from = new Date('2026-05-04T12:00:00.000Z')
+
+    expect(historyRequestPlanForRange(from, to)).toEqual({
+      mode: 'aggregate',
+      fn: 'avg',
+      interval: '6h',
+    })
+  })
+
+  it('compresses 90-day chart ranges into 12-hour buckets', () => {
+    const to = new Date('2026-06-03T12:00:00.000Z')
+    const from = new Date('2026-03-05T12:00:00.000Z')
+
+    expect(historyRequestPlanForRange(from, to)).toEqual({
+      mode: 'aggregate',
+      fn: 'avg',
+      interval: '12h',
+    })
+  })
+})

--- a/frontend/src/widgets/Chart/timeRangePresets.ts
+++ b/frontend/src/widgets/Chart/timeRangePresets.ts
@@ -25,6 +25,28 @@ export const TIME_RANGE_PRESETS: TimeRangePreset[] = [
 ]
 
 export const DEFAULT_TIME_RANGE = 'last_7d'
+export const DEFAULT_HISTORY_QUERY_LIMIT = 10000
+
+export type HistoryAggregateInterval = '1m' | '5m' | '15m' | '30m' | '1h' | '6h' | '12h' | '1d'
+
+export type HistoryRequestPlan =
+  | { mode: 'raw'; limit: number }
+  | { mode: 'aggregate'; fn: 'avg'; interval: HistoryAggregateInterval }
+
+export const DAY_MS = 24 * 60 * 60_000
+
+export function historyRequestPlanForRange(from: Date, to: Date): HistoryRequestPlan {
+  const durationMs = to.getTime() - from.getTime()
+  if (!Number.isFinite(durationMs) || durationMs <= DAY_MS) {
+    return { mode: 'raw', limit: DEFAULT_HISTORY_QUERY_LIMIT }
+  }
+
+  // Use intervals >= 1h for multi-day views so all history backends can compress before transport.
+  if (durationMs <= 7 * DAY_MS) return { mode: 'aggregate', fn: 'avg', interval: '1h' }
+  if (durationMs <= 31 * DAY_MS) return { mode: 'aggregate', fn: 'avg', interval: '6h' }
+  if (durationMs <= 90 * DAY_MS) return { mode: 'aggregate', fn: 'avg', interval: '12h' }
+  return { mode: 'aggregate', fn: 'avg', interval: '1d' }
+}
 
 export function resolveTimeRange(preset: string): { from: Date; to: Date } {
   const now = new Date()
@@ -38,10 +60,10 @@ export function resolveTimeRange(preset: string): { from: Date; to: Date } {
     case 'last_6h':  return { from: new Date(now.getTime() -  6 * 3_600_000), to: now }
     case 'last_12h': return { from: new Date(now.getTime() - 12 * 3_600_000), to: now }
     case 'last_24h': return { from: new Date(now.getTime() - 24 * 3_600_000), to: now }
-    case 'last_2d':  return { from: new Date(now.getTime() -  2 * 86_400_000), to: now }
-    case 'last_7d':  return { from: new Date(now.getTime() -  7 * 86_400_000), to: now }
-    case 'last_30d': return { from: new Date(now.getTime() - 30 * 86_400_000), to: now }
-    case 'last_90d': return { from: new Date(now.getTime() - 90 * 86_400_000), to: now }
+    case 'last_2d':  return { from: new Date(now.getTime() -  2 * DAY_MS), to: now }
+    case 'last_7d':  return { from: new Date(now.getTime() -  7 * DAY_MS), to: now }
+    case 'last_30d': return { from: new Date(now.getTime() - 30 * DAY_MS), to: now }
+    case 'last_90d': return { from: new Date(now.getTime() - 90 * DAY_MS), to: now }
 
     case 'today': {
       const from = new Date(now)
@@ -93,6 +115,6 @@ export function resolveTimeRange(preset: string): { from: Date; to: Date } {
     }
 
     default:
-      return { from: new Date(now.getTime() - 7 * 86_400_000), to: now }
+      return { from: new Date(now.getTime() - 7 * DAY_MS), to: now }
   }
 }

--- a/obs/api/v1/history.py
+++ b/obs/api/v1/history.py
@@ -41,6 +41,7 @@ class HistoryPoint(BaseModel):
 class AggregatedPoint(BaseModel):
     bucket: str
     v: Any
+    n: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,23 @@ def _parse_ts(s: str | None, default: datetime) -> datetime:
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             f"Invalid timestamp: {s!r}",
         )
+
+
+def _format_utc_bucket(bucket: Any) -> str:
+    """Return aggregate bucket timestamps as UTC ISO strings matching raw history."""
+    if isinstance(bucket, datetime):
+        dt = bucket
+    else:
+        try:
+            dt = datetime.fromisoformat(str(bucket).replace("Z", "+00:00"))
+        except ValueError:
+            return str(bucket)
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    else:
+        dt = dt.astimezone(UTC)
+    return dt.isoformat().replace("+00:00", "Z")
 
 
 async def _get_default_history_window_hours(db: Database) -> int:
@@ -168,4 +186,4 @@ async def aggregate_history(
 
     plugin = get_history_plugin()
     rows = await plugin.aggregate(dp_id, fn, interval, from_dt, to_dt)
-    return [AggregatedPoint(**r) for r in rows]
+    return [AggregatedPoint(bucket=_format_utc_bucket(r.get("bucket")), v=r.get("v"), n=r.get("n")) for r in rows]

--- a/obs/history/influxdb_plugin.py
+++ b/obs/history/influxdb_plugin.py
@@ -192,9 +192,11 @@ class InfluxDBHistoryPlugin(HistoryPlugin):
                 out.append({"ts": ts, "v": v, "u": u or None, "q": q or ""})
             else:
                 # Aggregate row: time + aggregated value
-                val_col = [c for c in columns if c != "time"][0] if len(columns) > 1 else "mean"
+                value_columns = [c for c in columns if c not in ("time", "count")]
+                val_col = value_columns[0] if value_columns else "mean"
                 v = row[col_idx.get(val_col, 1)] if val_col in col_idx else None
-                out.append({"bucket": ts, "v": v})
+                n = row[col_idx["count"]] if "count" in col_idx else None
+                out.append({"bucket": ts, "v": v, "n": n})
         return out
 
     async def _run_influxql(self, q: str) -> dict:
@@ -279,7 +281,7 @@ class InfluxDBHistoryPlugin(HistoryPlugin):
         dp = str(datapoint_id)
 
         q = (
-            f'SELECT {influx_fn}(v) FROM "obs" '
+            f'SELECT {influx_fn}(v), COUNT(v) FROM "obs" '
             f"WHERE dp_id='{dp}' "
             f"AND time >= '{from_rfc}' AND time <= '{to_rfc}' "
             f"GROUP BY time({influx_interval}) fill(none)"

--- a/obs/history/sqlite_plugin.py
+++ b/obs/history/sqlite_plugin.py
@@ -118,26 +118,26 @@ class SQLiteHistoryPlugin(HistoryPlugin):
             interval = "1h"
 
         fmt, minutes = _INTERVALS[interval]
+        bucket_expr = _sqlite_bucket_expr(fmt, minutes)
 
         if fn == "last":
-            return await self._aggregate_last(datapoint_id, fmt, minutes, from_ts, to_ts)
+            return await self._aggregate_last(datapoint_id, bucket_expr, minutes, from_ts, to_ts)
 
         sql_fn = {"avg": "AVG", "min": "MIN", "max": "MAX"}.get(fn, "AVG")
 
         if minutes >= 60:
-            # SQLite can truncate to hour or day
-            sql_fmt = fmt
             rows = await self._db.fetchall(
                 f"""SELECT
-                       strftime('{sql_fmt}', ts) AS bucket,
-                       {sql_fn}(CAST(value AS REAL)) AS v
+                       {bucket_expr} AS bucket,
+                       {sql_fn}(CAST(value AS REAL)) AS v,
+                       COUNT(*) AS n
                     FROM history_values
                     WHERE datapoint_id=? AND ts >= ? AND ts <= ?
                     GROUP BY bucket
                     ORDER BY bucket""",
                 (str(datapoint_id), _to_sqlite_ts(from_ts), _to_sqlite_ts(to_ts)),
             )
-            return [{"bucket": r["bucket"], "v": r["v"]} for r in rows]
+            return [{"bucket": r["bucket"], "v": r["v"], "n": r["n"]} for r in rows]
         # Sub-hourly: fetch raw, group in Python
         rows = await self._db.fetchall(
             """SELECT ts, value FROM history_values
@@ -150,7 +150,7 @@ class SQLiteHistoryPlugin(HistoryPlugin):
     async def _aggregate_last(
         self,
         datapoint_id: uuid.UUID,
-        fmt: str,
+        bucket_expr: str,
         minutes: int,
         from_ts: datetime,
         to_ts: datetime,
@@ -158,7 +158,7 @@ class SQLiteHistoryPlugin(HistoryPlugin):
         """Return the last value in each bucket."""
         if minutes >= 60:
             rows = await self._db.fetchall(
-                f"""SELECT strftime('{fmt}', ts) AS bucket, value
+                f"""SELECT {bucket_expr} AS bucket, value
                     FROM history_values
                     WHERE datapoint_id=? AND ts >= ? AND ts <= ?
                     GROUP BY bucket
@@ -214,6 +214,17 @@ def _safe_loads(s: str | None) -> Any:
         return s
 
 
+def _sqlite_bucket_expr(fmt: str, minutes: int) -> str:
+    if minutes == 60 or minutes >= 1440:
+        return f"strftime('{fmt}', ts)"
+
+    if minutes > 60 and minutes % 60 == 0:
+        hours = minutes // 60
+        return f"strftime('%Y-%m-%dT', ts) || printf('%02d:00:00', CAST(CAST(strftime('%H', ts) AS INTEGER) / {hours} AS INTEGER) * {hours})"
+
+    return f"strftime('{fmt}', ts)"
+
+
 def _bucket_key(ts_str: str, minutes: int) -> str:
     """Round ts_str down to the nearest *minutes* bucket."""
     try:
@@ -243,13 +254,13 @@ def _aggregate_python(rows: list, fn: str, minutes: int) -> list[dict]:
         bucket_last[bucket] = val
 
     if fn == "last":
-        return [{"bucket": b, "v": bucket_last[b]} for b in sorted(bucket_last)]
+        return [{"bucket": b, "v": bucket_last[b], "n": len(buckets[b])} for b in sorted(bucket_last)]
     if fn == "avg":
-        return [{"bucket": b, "v": sum(vs) / len(vs)} for b, vs in sorted(buckets.items())]
+        return [{"bucket": b, "v": sum(vs) / len(vs), "n": len(vs)} for b, vs in sorted(buckets.items())]
     if fn == "min":
-        return [{"bucket": b, "v": min(vs)} for b, vs in sorted(buckets.items())]
+        return [{"bucket": b, "v": min(vs), "n": len(vs)} for b, vs in sorted(buckets.items())]
     if fn == "max":
-        return [{"bucket": b, "v": max(vs)} for b, vs in sorted(buckets.items())]
+        return [{"bucket": b, "v": max(vs), "n": len(vs)} for b, vs in sorted(buckets.items())]
     return []
 
 

--- a/obs/history/timescaledb_plugin.py
+++ b/obs/history/timescaledb_plugin.py
@@ -68,7 +68,12 @@ class TimescaleDBHistoryPlugin(HistoryPlugin):
         except ImportError:
             raise RuntimeError("asyncpg is required for the TimescaleDB history plugin. Install it with: pip install asyncpg")
 
-        self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=5)
+        self._pool = await asyncpg.create_pool(
+            self._dsn,
+            min_size=1,
+            max_size=5,
+            server_settings={"timezone": "UTC"},
+        )
         await self._ensure_schema()
 
     async def disconnect(self) -> None:
@@ -224,7 +229,7 @@ class TimescaleDBHistoryPlugin(HistoryPlugin):
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(
                 f"""
-                SELECT {bucket_expr} AS bucket, {pg_fn}(v) AS v
+                SELECT {bucket_expr} AS bucket, {pg_fn}(v) AS v, COUNT(v)::int AS n
                 FROM dp_history
                 WHERE dp_id = $1 AND time >= $2 AND time <= $3 AND v IS NOT NULL
                 GROUP BY bucket
@@ -239,6 +244,7 @@ class TimescaleDBHistoryPlugin(HistoryPlugin):
             {
                 "bucket": r["bucket"].isoformat() if hasattr(r["bucket"], "isoformat") else str(r["bucket"]),
                 "v": r["v"],
+                "n": r["n"],
             }
             for r in rows
         ]

--- a/tests/integration/test_history_aggregate.py
+++ b/tests/integration/test_history_aggregate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import json
 import uuid
 
 import pytest
@@ -40,6 +41,18 @@ async def _write_value(client, auth_headers, dp_id: str, value: float) -> None:
         headers=auth_headers,
     )
     assert resp.status_code == 204, resp.text
+
+
+async def _seed_history_value(dp_id: str, ts: datetime.datetime, value: float) -> None:
+    from obs.db.database import get_db
+
+    db = get_db()
+    ts_str = ts.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    await db.execute_and_commit(
+        """INSERT INTO history_values (datapoint_id, value, unit, quality, ts)
+           VALUES (?,?,?,?,?)""",
+        (dp_id, json.dumps(value), "°C", "good", ts_str),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +113,30 @@ async def test_aggregate_avg_fn(client, auth_headers):
     if buckets:
         assert "bucket" in buckets[0]
         assert "v" in buckets[0]
+
+
+async def test_aggregate_bucket_is_returned_as_utc_iso_timestamp(client, auth_headers):
+    dp = await _create_dp(client, auth_headers)
+    dp_id = dp["id"]
+    await _seed_history_value(dp_id, datetime.datetime(2026, 6, 3, 12, 34, tzinfo=datetime.UTC), 12.0)
+
+    resp = await client.get(
+        f"/api/v1/history/{dp_id}/aggregate",
+        params={
+            "fn": "avg",
+            "interval": "1h",
+            "from": "2026-06-03T12:00:00Z",
+            "to": "2026-06-03T13:00:00Z",
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    buckets = resp.json()
+    assert buckets
+    assert buckets[0]["bucket"] == "2026-06-03T12:00:00Z"
+    assert buckets[0]["n"] == 1
+    assert datetime.datetime.fromisoformat(buckets[0]["bucket"].replace("Z", "+00:00")).tzinfo is not None
 
 
 async def test_aggregate_min_fn(client, auth_headers):

--- a/tests/unit/test_coverage_config_ringbuffer_misc.py
+++ b/tests/unit/test_coverage_config_ringbuffer_misc.py
@@ -1182,6 +1182,18 @@ def test_parse_ts_invalid_raises_422():
     assert exc_info.value.status_code == 422
 
 
+def test_format_utc_bucket_treats_naive_timestamp_as_utc():
+    assert history_api._format_utc_bucket("2026-06-03T12:00:00") == "2026-06-03T12:00:00Z"
+
+
+def test_format_utc_bucket_converts_offset_timestamp_to_utc():
+    assert history_api._format_utc_bucket("2026-06-03T14:00:00+02:00") == "2026-06-03T12:00:00Z"
+
+
+def test_format_utc_bucket_keeps_unparseable_bucket():
+    assert history_api._format_utc_bucket("bucket-1") == "bucket-1"
+
+
 @pytest.mark.asyncio
 async def test_get_default_history_window_hours_missing(monkeypatch):
     """_get_default_history_window_hours returns default when key missing."""

--- a/tests/unit/test_influxdb_plugin.py
+++ b/tests/unit/test_influxdb_plugin.py
@@ -314,8 +314,8 @@ class TestInfluxDBAggregate:
                 {
                     "series": [
                         {
-                            "columns": ["time", "mean"],
-                            "values": [["2024-01-01T00:00:00Z", 10.0]],
+                            "columns": ["time", "mean", "count"],
+                            "values": [["2024-01-01T00:00:00Z", 10.0, 4]],
                         }
                     ]
                 }
@@ -328,6 +328,7 @@ class TestInfluxDBAggregate:
             result = await _plugin().aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(1))
         assert len(result) == 1
         assert result[0]["v"] == pytest.approx(10.0)
+        assert result[0]["n"] == 4
 
     async def test_aggregate_unknown_interval_falls_back_to_1h(self):
         ctx, client = _make_httpx_mock(status=200, json_body=self._agg_response())

--- a/tests/unit/test_sqlite_plugin.py
+++ b/tests/unit/test_sqlite_plugin.py
@@ -17,6 +17,7 @@ from obs.history.sqlite_plugin import (
     _aggregate_python,
     _bucket_key,
     _safe_loads,
+    _sqlite_bucket_expr,
     _to_sqlite_ts,
 )
 
@@ -112,6 +113,14 @@ class TestBucketKey:
         result = _bucket_key("bad-ts-string-xyz", 5)
         # Falls back to ts[:16]
         assert result == "bad-ts-string-xy"
+
+
+class TestSqliteBucketExpr:
+    def test_6h_bucket_expr(self):
+        assert "strftime('%H'" in _sqlite_bucket_expr("%Y-%m-%dT%H:00:00", 360)
+
+    def test_1h_bucket_expr(self):
+        assert _sqlite_bucket_expr("%Y-%m-%dT%H:00:00", 60) == "strftime('%Y-%m-%dT%H:00:00', ts)"
 
 
 class TestAggregatePython:
@@ -280,6 +289,7 @@ class TestSQLiteAggregate:
         result = await plugin.aggregate(dp_id, "avg", "1h", _ts(-1), _ts(60))
         assert len(result) == 1
         assert result[0]["v"] == pytest.approx(15.0)
+        assert result[0]["n"] == 2
 
     async def test_aggregate_min_1h(self, plugin):
         dp_id = uuid.uuid4()
@@ -307,12 +317,37 @@ class TestSQLiteAggregate:
         result = await plugin.aggregate(dp_id, "avg", "5m", _ts(-1), _ts(10))
         assert len(result) == 1
         assert result[0]["v"] == pytest.approx(15.0)
+        assert result[0]["n"] == 2
 
     async def test_aggregate_sub_hourly_last(self, plugin):
         dp_id = uuid.uuid4()
         await self._write_series(plugin, dp_id, [(0, 5.0), (2, 8.0)])
         result = await plugin.aggregate(dp_id, "last", "5m", _ts(-1), _ts(10))
         assert result[0]["v"] == pytest.approx(8.0)
+
+    async def test_aggregate_6h_groups_into_requested_width(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 10.0), (300, 20.0), (360, 30.0)])
+        result = await plugin.aggregate(dp_id, "avg", "6h", _ts(-1), _ts(420))
+        assert [r["bucket"] for r in result] == ["2024-01-01T12:00:00", "2024-01-01T18:00:00"]
+        assert result[0]["v"] == pytest.approx(15.0)
+        assert result[0]["n"] == 2
+
+    async def test_aggregate_12h_groups_into_requested_width(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(-720, 10.0), (-60, 20.0), (0, 30.0), (660, 40.0)])
+        result = await plugin.aggregate(dp_id, "avg", "12h", _ts(-721), _ts(720))
+        assert [r["bucket"] for r in result] == ["2024-01-01T00:00:00", "2024-01-01T12:00:00"]
+        assert result[0]["v"] == pytest.approx(15.0)
+        assert result[1]["v"] == pytest.approx(35.0)
+
+    async def test_aggregate_last_6h_uses_requested_width(self, plugin):
+        dp_id = uuid.uuid4()
+        await self._write_series(plugin, dp_id, [(0, 10.0), (300, 20.0), (360, 30.0)])
+        result = await plugin.aggregate(dp_id, "last", "6h", _ts(-1), _ts(420))
+        assert [r["bucket"] for r in result] == ["2024-01-01T12:00:00", "2024-01-01T18:00:00"]
+        assert result[0]["v"] == pytest.approx(20.0)
+        assert result[1]["v"] == pytest.approx(30.0)
 
     async def test_aggregate_unknown_interval_falls_back_to_1h(self, plugin):
         dp_id = uuid.uuid4()

--- a/tests/unit/test_timescaledb_plugin.py
+++ b/tests/unit/test_timescaledb_plugin.py
@@ -111,7 +111,12 @@ class TestConnect:
         p = _plugin()
         with mock.patch.dict(__import__("sys").modules, {"asyncpg": asyncpg}):
             await p.connect()
-        asyncpg.create_pool.assert_awaited_once()
+        asyncpg.create_pool.assert_awaited_once_with(
+            "postgresql://test/test",
+            min_size=1,
+            max_size=5,
+            server_settings={"timezone": "UTC"},
+        )
         assert p._pool is pool
 
     async def test_connect_detects_timescaledb(self):
@@ -265,10 +270,10 @@ class TestTimescaleQuery:
 # ---------------------------------------------------------------------------
 
 
-def _make_agg_row(bucket_dt, v):
+def _make_agg_row(bucket_dt, v, n=1):
     row = mock.MagicMock()
-    row.__getitem__ = lambda self, k: {"bucket": bucket_dt, "v": v}[k]
-    row.get = lambda k, d=None: {"bucket": bucket_dt, "v": v}.get(k, d)
+    row.__getitem__ = lambda self, k: {"bucket": bucket_dt, "v": v, "n": n}[k]
+    row.get = lambda k, d=None: {"bucket": bucket_dt, "v": v, "n": n}.get(k, d)
     return row
 
 
@@ -281,10 +286,11 @@ class TestTimescaleAggregate:
         return result, conn
 
     async def test_aggregate_avg_timescaledb(self):
-        row = _make_agg_row(_ts(), 10.0)
+        row = _make_agg_row(_ts(), 10.0, n=3)
         p = _plugin()
         result, _ = await self._run(p, fn="avg", rows=[row])
         assert result[0]["v"] == pytest.approx(10.0)
+        assert result[0]["n"] == 3
 
     async def test_aggregate_unknown_interval_falls_back(self):
         p = _plugin()
@@ -338,13 +344,14 @@ class TestTimescaleAggregate:
     async def test_aggregate_bucket_no_isoformat(self):
         """Bucket without isoformat (plain str) falls back to str()."""
         row = mock.MagicMock()
-        row.__getitem__ = lambda self, k: {"bucket": "2024-06-01", "v": 1.0}[k]
+        row.__getitem__ = lambda self, k: {"bucket": "2024-06-01", "v": 1.0, "n": 2}[k]
         pool, conn = _make_pool_mock(rows=[row])
         p = _plugin()
         p._pool = pool
         p._has_timescaledb = True
         result = await p.aggregate(uuid.uuid4(), "avg", "1h", _ts(0), _ts(2))
         assert result[0]["bucket"] == "2024-06-01"
+        assert result[0]["n"] == 2
 
     async def test_aggregate_requires_pool(self):
         p = _plugin()


### PR DESCRIPTION
## Summary
- use the History aggregate endpoint for multi-day Chart/Verlauf widget ranges instead of pulling large raw result sets
- keep raw history queries for ranges up to 24 hours
- choose compressed bucket intervals for 2/7/30/90-day ranges so long periods remain complete and render efficiently
- normalize aggregate bucket timestamps to UTC ISO strings with `Z`, matching raw history points and avoiding local-time chart shifts
- pin TimescaleDB asyncpg sessions to UTC for deterministic bucket truncation paths
- preserve SQLite 6h/12h aggregation widths so long-range plans do not fall back to hourly buckets
- include aggregate sample counts (`n`) and use weighted averages when aggregated data is re-bucketed for raw bar charts
- align aggregated bar charts directly to backend bucket timestamps instead of creating a mismatched frontend bucket grid
- preserve series units for aggregated charts via a lightweight latest-point lookup
- update release notes for issue #692

Fixes #692

## Tests
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format . --check`
- `.venv/bin/pytest tests/unit/test_sqlite_plugin.py tests/unit/test_timescaledb_plugin.py tests/unit/test_influxdb_plugin.py -k aggregate`
- `.venv/bin/pytest tests/integration/test_history_aggregate.py`
- `npm run typecheck`
- `npm test`