### PR TITLE
feat(build): add local build script for Docker image and LXC template

### DIFF
--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -234,7 +234,8 @@ jobs:
       - name: Stamp version file
         run: |
           BASE=$(grep -m1 '^## ' RELEASENOTES.md | sed 's/^## *//')
-          RC=$(echo "${{ steps.meta.outputs.version }}" | grep -oP -- '-RC\d*$' || true)
+          TAG="${{ steps.meta.outputs.version }}"
+          if [[ "$TAG" =~ (-RC[0-9]*)$ ]]; then RC="${BASH_REMATCH[1]}"; else RC=""; fi
           echo "${BASE}${RC}" > obs/version
 
       - name: Create app bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,10 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
           echo "GITHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-      - name: Stamp version file
-        run: |
           BASE=$(grep -m1 '^## ' RELEASENOTES.md | sed 's/^## *//')
-          RC=$(echo "${GITHUB_REF##*/}" | grep -oP -- '-RC\d*$' || true)
-          echo "${BASE}${RC}" > obs/version
+          TAG="${GITHUB_REF##*/}"
+          if [[ "$TAG" =~ (-RC[0-9]*)$ ]]; then RC="${BASH_REMATCH[1]}"; else RC=""; fi
+          echo "OBS_VERSION=${BASE}${RC}" >> $GITHUB_ENV
 
       - name: Stamp gui/package.json version
         run: npm pkg set version="${VERSION}" --prefix gui
@@ -134,3 +132,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OBS_VERSION=${{ env.OBS_VERSION }}

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -54,6 +54,12 @@ docker compose up -d
 # Docker Compose (Mosquitto only — for local dev outside Docker)
 docker compose up -d mosquitto
 
+# Build release artifacts locally (only requires Docker)
+./tools/build-local.sh docker    # Docker image (via docker compose build obs + version stamp)
+./tools/build-local.sh lxc       # Proxmox LXC template (.tar.zst); rootfs cached in ~/.cache/obs-lxc-builder/
+./tools/build-local.sh bundle    # app bundle only, no rootfs (fast)
+./tools/build-local.sh all       # docker + lxc
+
 # Admin GUI dev server (proxies /api to localhost:8080)
 cd gui && npm run dev
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,10 @@ RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 # ── Stage 3: runtime image ──────────────────────────────────────────────────
 FROM python:3.14-slim AS runtime
 
+# Version stamp — passed via --build-arg OBS_VERSION=<ver> by CI and build-local.sh.
+# Falls back to "dev-version" so plain `docker build .` still works.
+ARG OBS_VERSION=dev-version
+
 LABEL org.opencontainers.image.title="open bridge server" \
       org.opencontainers.image.description="Open-Source Multiprotocol Server for Building Automation" \
       org.opencontainers.image.licenses="MIT"
@@ -59,6 +63,8 @@ COPY --from=py-builder /install /usr/local
 # Application source
 WORKDIR /app
 COPY obs/ ./obs/
+# Stamp the version into the image without touching the working tree
+RUN echo "$OBS_VERSION" > ./obs/version
 
 # Built Admin-GUI (served by FastAPI from /app/gui_dist)
 COPY --from=node-builder /gui_dist ./gui_dist/

--- a/README.de.md
+++ b/README.de.md
@@ -6,7 +6,7 @@
 [![Tests][tests-badge]][tests]
 [![Coverage][coverage-badge]][coverage]
 
-Go to the [English version](/README.md) version of the documentation.
+> 🇬🇧 [English version](/README.md)
 
 **Offene Gebäudeautomations-Plattform — verbindet KNX, Modbus, MQTT, Home Assistant und mehr**
 
@@ -1628,6 +1628,10 @@ pytest tests/
 # Mit Auto-Fix
 ./tools/lint.sh --fix
 ```
+
+#### Lokale Builds (Docker-Image, LXC-Template, App-Bundle)
+
+Vollständige Dokumentation zu `build-local.sh` — Befehle, Optionen und das Docker-Image-Namensschema — siehe **[tools/README.de.md](tools/README.de.md)**.
 
 ### Lokale Git-Hooks (Pre-Push Gate)
 

--- a/README.md
+++ b/README.md
@@ -1717,7 +1717,7 @@ The database is updated automatically — each new version adds missing tables a
 ---
 
 ## Translations
-We'd like to use [Weblate](https://hosted.weblate.org/projects/open-bridge-server) to support language translations. As soon as this is set up, ontributions would be very much welcome.
+We'd like to use [Weblate](https://hosted.weblate.org/projects/open-bridge-server) to support language translations. As soon as this is set up, contributions would be very much welcome.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Tests][tests-badge]][tests]
 [![Coverage][coverage-badge]][coverage]
 
-Gehe zur [deutschen Version](/README.de.md) der Dokumentation.
+> 🇩🇪 [Deutsche Version](/README.de.md)
 
 **Open building automation platform — connects KNX, Modbus, MQTT, Home Assistant, and more**
 
@@ -1621,6 +1621,10 @@ pytest tests/
 # With auto-fix
 ./tools/lint.sh --fix
 ```
+
+#### Local builds (Docker image, LXC template, app bundle)
+
+See **[tools/README.md](tools/README.md)** for full documentation of `build-local.sh` — commands, options, and the local Docker image naming schema.
 
 ### Local Git Hooks (Pre-Push Gate)
 

--- a/tools/Dockerfile.lxc-builder
+++ b/tools/Dockerfile.lxc-builder
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        debootstrap \
+        python3 \
+        ubuntu-keyring \
+        zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*

--- a/tools/README.de.md
+++ b/tools/README.de.md
@@ -1,0 +1,438 @@
+# tools/
+
+> 🇬🇧 [English version](README.md)
+
+## build-local.sh — Lokale Build-Artefakte
+
+Erstellt Release-Artefakte lokal. Einzige Voraussetzung: Docker.
+
+```bash
+tools/build-local.sh COMMAND [OPTIONS]
+```
+
+### Befehle
+
+| Befehl   | Beschreibung |
+|----------|-------------|
+| `docker` | Docker-Image bauen (via `docker compose build obs`) |
+| `lxc`    | Proxmox-LXC-Template (`.tar.zst`) bauen — benötigt `--privileged` |
+| `bundle` | App-Bundle ohne Rootfs bauen (deutlich schneller als `lxc`) |
+| `all`    | `docker` + `lxc` nacheinander |
+| `clean`  | Artefakte in `dist/`, Rootfs-Cache und Builder-Image entfernen |
+
+### Optionen
+
+| Option | Standard | Beschreibung |
+|--------|---------|-------------|
+| `--version VER` | `git describe` (s. u.) | Version manuell setzen |
+| `--image NAME` | `localhost/openbridgeserver` | Docker-Image-Name / Registry-Prefix |
+| `--push` | — | Image nach dem Bauen in die Registry pushen |
+| `--repo OWNER/REPO` | Auto aus `git remote origin` | GitHub-Repo für `obs-update`-Skript |
+| `--output DIR` | `dist/` | Ausgabeverzeichnis für LXC/Bundle |
+| `--no-cache` | — | Builder-Image und Rootfs-Cache neu aufbauen |
+
+### Beispiele
+
+```bash
+# Docker-Image für die aktuelle Working-Copy bauen
+tools/build-local.sh docker
+
+# Docker-Image mit fester Version bauen und in eine Registry pushen
+tools/build-local.sh --version 2026.6.0 --push --image ghcr.io/owner/openbridgeserver docker
+
+# LXC-Template bauen (braucht ~10 min beim ersten Mal)
+tools/build-local.sh lxc
+
+# Nur App-Bundle (obs/, gui_dist/, frontend_dist/) bauen — schnell
+tools/build-local.sh bundle
+
+# Alle Artefakte auf einmal
+tools/build-local.sh all
+
+# Build-Artefakte, Rootfs-Cache und Builder-Image aufräumen
+tools/build-local.sh clean
+```
+
+### Namensschema lokaler Docker-Images
+
+Jeder `docker`-Build erzeugt exakt **zwei** Tags, die dasselbe Image-Digest zeigen:
+
+```
+localhost/openbridgeserver:<version>     ← langer Versions-Tag
+localhost/openbridgeserver:<hash>        ← kurzer Hash-Tag
+```
+
+#### Versions-Tag
+
+Format: `<releasenotes-version>[‑RC<n>][‑<commits>‑<hash>][‑dirty]`
+
+| Segment | Quelle | Bedeutung |
+|---------|--------|-----------|
+| `<releasenotes-version>` | Oberste `## `-Zeile in `RELEASENOTES.md` | Aktuelle Release-Version (z. B. `2026.6.0`) |
+| `‑RC<n>` | Git-Tag-Suffix, wenn vorhanden | Release-Candidate-Kennung |
+| `‑<commits>‑<hash>` | `git describe` | Commits seit dem letzten Tag + Commit-Hash |
+| `‑dirty` | `git status` | Working-Tree hat uncommitted Änderungen |
+
+Beispiele:
+
+| Situation | Versions-Tag |
+|-----------|-------------|
+| Exakt auf einem Release-Tag, sauberer Tree | `2026.6.0` |
+| Exakt auf einem RC-Tag, sauberer Tree | `2026.6.0-RC1` |
+| 22 Commits nach dem RC-Tag, sauber | `2026.6.0-RC4-22-e633092` |
+| 22 Commits nach dem RC-Tag, mit Änderungen | `2026.6.0-RC4-22-e633092-dirty` |
+
+#### Hash-Tag
+
+Format: `<hash>[‑dirty]`
+
+Der kurze Commit-Hash (`git rev-parse --short HEAD`), optional gefolgt von `‑dirty` — identisch zum Hash-Segment im Versions-Tag. Dient als unveränderlicher Bezeichner für den exakten Build-Stand:
+
+```
+localhost/openbridgeserver:e633092          ← sauberer Build
+localhost/openbridgeserver:e633092-dirty    ← Build aus schmutzigem Tree
+```
+
+> **Hinweis:** Der `‑dirty`-Suffix erscheint **in beiden Tags** gleichermaßen — ein `dirty`-Versions-Tag und ein sauberer Hash-Tag können nicht entstehen.
+
+#### obs/version im Image
+
+Der gestempelte Wert in `/app/obs/version` (sichtbar unter *Einstellungen → Info*) entspricht dem Versions-Tag **ohne** den `‑<commits>‑<hash>[‑dirty]`-Teil, also:
+
+| Versions-Tag | obs/version im Image |
+|--------------|---------------------|
+| `2026.6.0-RC4-22-e633092-dirty` | `2026.6.0-RC4` |
+| `2026.6.0-RC1` | `2026.6.0-RC1` |
+| `2026.6.0` | `2026.6.0` |
+
+Der Wert wird per `--build-arg OBS_VERSION=...` an den Docker-Build übergeben — die Dateien im Working-Tree (`obs/version`, `gui/package.json`) werden dabei **nicht** verändert.
+
+### Hinweise
+
+- Das `lxc`- und `bundle`-Kommando verwendet ein Builder-Docker-Image (`obs-lxc-builder`), das beim ersten Aufruf automatisch gebaut und im Docker-Layer-Cache gehalten wird.
+- Das debootstrap-Basissystem wird in `~/.cache/obs-lxc-builder/` gecacht — einmal heruntergeladen, dann wiederverwendet. Mit `--no-cache` oder `tools/build-local.sh clean` zurücksetzen.
+- Cross-Architektur-LXC-Builds sind lokal nicht unterstützt; die Ausgabe-Architektur entspricht dem Host. Multi-Arch Docker-Images werden nur in CI gebaut.
+
+---
+
+## testdata_generator.py
+
+Generiert konfigurierbaren Test-Traffic für KNX, Modbus TCP und MQTT.
+Jedes Protokoll läuft als unabhängiger async-Task; alle drei können parallel laufen.
+Der Generator ersetzt eine echte Feldinstallation zum Testen des open bridge servers.
+
+### Voraussetzungen
+
+```bash
+pip install pyyaml xknx pymodbus aiomqtt
+```
+
+Nur die Pakete der tatsächlich verwendeten Protokolle sind erforderlich.
+
+### Starten
+
+```bash
+# Mit eigener Konfiguration
+python tools/testdata_generator.py /pfad/zur/config.yaml
+
+# Ohne Argument: sucht testdata_generator_example.yaml im selben Verzeichnis
+python tools/testdata_generator.py
+```
+
+---
+
+## Konfiguration (YAML)
+
+Die Konfigurationsdatei besteht aus bis zu drei Top-Level-Abschnitten: `knx`, `modbus`, `mqtt`.
+Nicht benötigte Abschnitte einfach weglassen — der Generator startet nur die konfigurierten Protokolle.
+
+### Wert-Modi
+
+Jedes Signal (Telegramm, Register, Topic) verwendet einen der folgenden Modi:
+
+| Modus      | Beschreibung                                      | Parameter                            |
+|------------|---------------------------------------------------|--------------------------------------|
+| `fixed`    | Konstanter Wert                                   | `value: <wert>`                      |
+| `sine`     | Sinuskurve zwischen `min` und `max`               | `min`, `max`, `period` (s, def. 60)  |
+| `random`   | Zufällig gleichverteilt zwischen `min` und `max`  | `min`, `max`                         |
+| `ramp`     | Lineare Rampe von `min` nach `max`, dann Neustart | `min`, `max`, `period` (s, def. 60)  |
+| `sequence` | Zyklisch durch eine Liste von Werten              | `values: [a, b, c, …]`               |
+| `toggle`   | Wechselt bei jedem Schritt zwischen `true`/`false`| —                                    |
+
+---
+
+### KNX
+
+Läuft als KNX/IP Tunneling **Server** (Gateway-Simulator) — kein physischer KNX-Bus nötig.
+Der open bridge server KNX-Adapter verbindet sich als Client zu diesem Server.
+
+**Adapter-Konfiguration im open bridge server:**
+```
+connection_type: tunneling
+host: 127.0.0.1          # IP der Maschine, auf der der Generator läuft
+port: 3671               # muss mit knx.port übereinstimmen
+```
+
+**Konfigurationsstruktur:**
+```yaml
+knx:
+  host: 0.0.0.0          # Netzwerkinterface (0.0.0.0 = alle, 127.0.0.1 = nur lokal)
+  port: 3671             # KNX/IP UDP-Port (Standardport; <1024 braucht root → z.B. 4001 verwenden)
+  max_events_per_second: 3.0   # Optionale globale Rate-Begrenzung (default 3.0)
+
+  telegrams:
+    - group_address: "1/1/1"   # KNX-Gruppenadresse (Pflicht)
+      dpt_id: "DPT9.001"       # DPT-ID aus der DPT-Registry (Pflicht)
+      interval: 5.0            # Sekunden zwischen Telegrammen
+      mode: sine
+      min: 18.0
+      max: 25.0
+      period: 120.0
+```
+
+**Häufige DPT-IDs:**
+
+| DPT       | Typ                     | Wertebereich   |
+|-----------|-------------------------|----------------|
+| DPT1.001  | Boolean (EIN/AUS)       | true / false   |
+| DPT5.001  | 1-Byte Prozent          | 0 – 100        |
+| DPT5.010  | 1-Byte Ganzzahl         | 0 – 255        |
+| DPT9.001  | 2-Byte Float (°C)       | −273 – 670760  |
+| DPT9.004  | 2-Byte Float (lux)      | 0 – 670760     |
+| DPT9.007  | 2-Byte Float (% Feuchte)| 0 – 100        |
+| DPT14.056 | 4-Byte Float            | IEEE 754       |
+
+**Beispiel:**
+```yaml
+knx:
+  host: 0.0.0.0
+  port: 4001
+
+  telegrams:
+    - group_address: "1/1/1"   # Temperatur, Sinuskurve 18–25 °C
+      dpt_id: "DPT9.001"
+      interval: 5.0
+      mode: sine
+      min: 18.0
+      max: 25.0
+      period: 120.0
+
+    - group_address: "1/1/2"   # Helligkeit, Rampe 0–100 %
+      dpt_id: "DPT5.001"
+      interval: 3.0
+      mode: ramp
+      min: 0
+      max: 100
+      period: 60.0
+
+    - group_address: "1/1/3"   # Schalter, Toggle
+      dpt_id: "DPT1.001"
+      interval: 10.0
+      mode: toggle
+
+    - group_address: "1/1/4"   # Fixwert 21.5 °C
+      dpt_id: "DPT9.001"
+      interval: 30.0
+      mode: fixed
+      value: 21.5
+
+    - group_address: "1/1/5"   # Sequenz 0 → 25 → 50 → 75 → 100 %
+      dpt_id: "DPT5.001"
+      interval: 5.0
+      mode: sequence
+      values: [0, 25, 50, 75, 100]
+```
+
+---
+
+### Modbus TCP
+
+Läuft als Modbus **Slave/Server** — open bridge server pollt als Master.
+
+**Adapter-Konfiguration im open bridge server:**
+```
+host: 127.0.0.1          # IP der Maschine, auf der der Generator läuft
+port: 502                # muss mit modbus.port übereinstimmen
+unit_id: 1
+```
+
+**Konfigurationsstruktur:**
+```yaml
+modbus:
+  host: 0.0.0.0
+  port: 502              # Port <1024 braucht root → z.B. 5001 verwenden
+  unit_id: 1
+
+  registers:
+    - register_type: holding   # holding | input | coil | discrete_input
+      address: 0               # Registeradresse (0-basiert)
+      data_format: uint16      # uint16 | uint32 | int16 | int32 | float32
+      scale_factor: 1.0        # Rohwert × scale_factor = physikalischer Wert
+      mode: sine               # Wert-Modus (s. Tabelle oben)
+      min: 0
+      max: 100
+      interval: 2.0            # Sekunden zwischen Updates
+```
+
+**Register-Typen:**
+
+| Typ               | FC  | Lesen/Schreiben | Daten         |
+|-------------------|-----|-----------------|---------------|
+| `holding`         | 3   | R/W             | 16-Bit-Wörter |
+| `input`           | 4   | R               | 16-Bit-Wörter |
+| `coil`            | 1   | R/W             | Boolean       |
+| `discrete_input`  | 2   | R               | Boolean       |
+
+**Hinweis `scale_factor`:** Der Rohwert im Register entspricht `physikalischer Wert / scale_factor`.
+Denselben `scale_factor` im open bridge server Binding konfigurieren.
+
+**Beispiel:**
+```yaml
+modbus:
+  host: 0.0.0.0
+  port: 5001
+  unit_id: 1
+
+  registers:
+    - register_type: holding   # Temperatur 18.0–25.0 °C als uint16 (Rohwert ×0.1)
+      address: 0
+      data_format: uint16
+      scale_factor: 0.1
+      mode: sine
+      min: 180
+      max: 250
+      interval: 2.0
+      period: 120.0
+
+    - register_type: holding   # Windgeschwindigkeit als float32 (2 Register)
+      address: 2
+      data_format: float32
+      scale_factor: 1.0
+      mode: random
+      min: 0.0
+      max: 15.0
+      interval: 3.0
+
+    - register_type: coil      # Relais-Status, Toggle
+      address: 0
+      mode: toggle
+      interval: 8.0
+```
+
+---
+
+### MQTT
+
+Verbindet sich mit einem bestehenden Broker und **publiziert** Werte.
+open bridge server MQTT-Adapter **abonniert** diese Topics.
+
+**Konfigurationsstruktur:**
+```yaml
+mqtt:
+  host: localhost
+  port: 1883
+  username: myuser       # optional
+  password: mypassword   # optional
+
+  topics:
+    - topic: pfad/zum/topic    # MQTT-Topic (Pflicht)
+      interval: 5.0            # Sekunden zwischen Publizierungen
+      retain: false            # optional, default false
+      payload_template: null   # optional, s. unten
+      mode: sine               # Wert-Modus (s. Tabelle oben)
+      min: 0.0
+      max: 100.0
+```
+
+**`payload_template`:** Ermöglicht JSON- oder beliebige Text-Payloads.
+Der Platzhalter `###DP###` wird durch den generierten Wert ersetzt.
+
+```yaml
+payload_template: '{"sensor":"test","value":###DP###,"unit":"°C"}'
+# → publiziert z.B.: {"sensor":"test","value":21.3,"unit":"°C"}
+```
+
+**Beispiel:**
+```yaml
+mqtt:
+  host: localhost
+  port: 1883
+
+  topics:
+    - topic: _testdata/temperature   # Temperatur als Plain-Float
+      interval: 5.0
+      mode: sine
+      min: 18.0
+      max: 25.0
+      period: 120.0
+
+    - topic: _testdata/switch        # Schalter mit Retain
+      interval: 10.0
+      mode: toggle
+      retain: true
+
+    - topic: _testdata/sensor/json   # JSON-Payload
+      interval: 4.0
+      mode: ramp
+      min: 0.0
+      max: 100.0
+      period: 60.0
+      payload_template: '{"sensor":"test","value":###DP###,"unit":"%"}'
+
+    - topic: _testdata/setpoint      # Sequenz
+      interval: 15.0
+      mode: sequence
+      values: [16.0, 18.0, 20.0, 22.0, 24.0]
+      retain: true
+```
+
+---
+
+## testdata-generator.service — systemd (Debian/Ubuntu)
+
+### 1. Anpassen
+
+Die folgenden drei Stellen in `testdata-generator.service` an die eigene Umgebung anpassen:
+
+| Parameter                         | Default                             | Bedeutung                        |
+|-----------------------------------|-------------------------------------|----------------------------------|
+| `User` / `Group`                  | `obs`                               | Systembenutzer für den Prozess   |
+| `WorkingDirectory`                | `/opt/openbridgeserver`             | Installationspfad des Projekts   |
+| `ExecStart` (Python)              | `/usr/bin/python3`                  | Pfad zu Python (`which python3`) |
+| `ExecStart` (letztes Argument)    | `…tools/config.yaml`                | Pfad zur Konfigurationsdatei     |
+
+### 2. Installieren
+
+```bash
+sudo cp /opt/openbridgeserver/tools/testdata-generator.service \
+        /etc/systemd/system/
+
+# Benutzer anlegen (falls noch nicht vorhanden)
+sudo useradd -r -s /bin/false obs
+
+sudo systemctl daemon-reload
+```
+
+### 3. Starten und aktivieren
+
+```bash
+# Sofort starten und beim Boot automatisch starten
+sudo systemctl enable --now testdata-generator
+
+# Nur starten (ohne Autostart)
+sudo systemctl start testdata-generator
+```
+
+### 4. Betrieb
+
+```bash
+sudo systemctl status testdata-generator
+sudo journalctl -u testdata-generator -f
+sudo systemctl stop testdata-generator
+sudo systemctl disable testdata-generator
+```
+
+Der Service startet bei einem Absturz automatisch neu (`Restart=on-failure`).
+Bei einem sauberen Stop via `systemctl stop` wird er **nicht** neu gestartet.
+
+

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,100 +1,215 @@
 # tools/
 
+> 🇩🇪 [Deutsche Version](README.de.md)
+
+## build-local.sh — Local Build Artifacts
+
+Builds release artifacts locally. Only requirement: Docker.
+
+```bash
+tools/build-local.sh COMMAND [OPTIONS]
+```
+
+### Commands
+
+| Command  | Description |
+|----------|-------------|
+| `docker` | Build Docker image (via `docker compose build obs`) |
+| `lxc`    | Build Proxmox LXC template (`.tar.zst`) — requires `--privileged` |
+| `bundle` | Build app bundle without rootfs (much faster than `lxc`) |
+| `all`    | `docker` + `lxc` in sequence |
+| `clean`  | Remove artifacts in `dist/`, rootfs cache, and builder image |
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--version VER` | `git describe` (see below) | Override version manually |
+| `--image NAME` | `localhost/openbridgeserver` | Docker image name / registry prefix |
+| `--push` | — | Push image to registry after build |
+| `--repo OWNER/REPO` | Auto-detected from `git remote origin` | GitHub repo for `obs-update` script |
+| `--output DIR` | `dist/` | Output directory for LXC/bundle artifacts |
+| `--no-cache` | — | Rebuild builder image and rootfs cache from scratch |
+
+### Examples
+
+```bash
+# Build Docker image for the current working copy
+tools/build-local.sh docker
+
+# Build Docker image with an explicit version and push to a registry
+tools/build-local.sh --version 2026.6.0 --push --image ghcr.io/owner/openbridgeserver docker
+
+# Build LXC template (~10 min on first run)
+tools/build-local.sh lxc
+
+# Build app bundle only (obs/, gui_dist/, frontend_dist/) — fast
+tools/build-local.sh bundle
+
+# Build all artifacts at once
+tools/build-local.sh all
+
+# Remove build artifacts, rootfs cache, and builder image
+tools/build-local.sh clean
+```
+
+### Local Docker Image Naming Schema
+
+Every `docker` build produces exactly **two** tags pointing to the same image digest:
+
+```
+localhost/openbridgeserver:<version>     ← long version tag
+localhost/openbridgeserver:<hash>        ← short hash tag
+```
+
+#### Version tag
+
+Format: `<releasenotes-version>[‑RC<n>][‑<commits>‑<hash>][‑dirty]`
+
+| Segment | Source | Meaning |
+|---------|--------|---------|
+| `<releasenotes-version>` | Top `## ` headline in `RELEASENOTES.md` | Current release version (e.g. `2026.6.0`) |
+| `‑RC<n>` | Git tag suffix, if present | Release candidate identifier |
+| `‑<commits>‑<hash>` | `git describe` | Commits since last tag + commit hash |
+| `‑dirty` | `git status` | Working tree has uncommitted changes |
+
+Examples:
+
+| Situation | Version tag |
+|-----------|-------------|
+| Exactly on a release tag, clean tree | `2026.6.0` |
+| Exactly on an RC tag, clean tree | `2026.6.0-RC1` |
+| 22 commits after the RC tag, clean | `2026.6.0-RC4-22-e633092` |
+| 22 commits after the RC tag, with changes | `2026.6.0-RC4-22-e633092-dirty` |
+
+#### Hash tag
+
+Format: `<hash>[‑dirty]`
+
+The short commit hash (`git rev-parse --short HEAD`), optionally followed by `‑dirty` — identical to the hash segment in the version tag. Serves as an immutable identifier for the exact build state:
+
+```
+localhost/openbridgeserver:e633092          ← clean build
+localhost/openbridgeserver:e633092-dirty    ← build from a dirty working tree
+```
+
+> **Note:** The `‑dirty` suffix always appears **in both tags** consistently — a `dirty` version tag and a clean hash tag cannot occur together.
+
+#### obs/version inside the image
+
+The stamped value in `/app/obs/version` (visible under *Settings → Info*) matches the version tag **without** the `‑<commits>‑<hash>[‑dirty]` part:
+
+| Version tag | obs/version in image |
+|-------------|---------------------|
+| `2026.6.0-RC4-22-e633092-dirty` | `2026.6.0-RC4` |
+| `2026.6.0-RC1` | `2026.6.0-RC1` |
+| `2026.6.0` | `2026.6.0` |
+
+The value is passed via `--build-arg OBS_VERSION=...` to the Docker build — the files in the working tree (`obs/version`, `gui/package.json`) are **never modified**.
+
+### Notes
+
+- The `lxc` and `bundle` commands use a builder Docker image (`obs-lxc-builder`) that is built automatically on first run and kept in the Docker layer cache.
+- The debootstrap base system is cached in `~/.cache/obs-lxc-builder/` — downloaded once, then reused. Reset with `--no-cache` or `tools/build-local.sh clean`.
+- Cross-architecture LXC builds are not supported locally; the output architecture matches the host. Multi-arch Docker images are only built in CI.
+
+---
+
 ## testdata_generator.py
 
-Generiert konfigurierbaren Test-Traffic für KNX, Modbus TCP und MQTT.
-Jedes Protokoll läuft als unabhängiger async-Task; alle drei können parallel laufen.
-Der Generator ersetzt eine echte Feldinstallation zum Testen des open bridge servers.
+Generates configurable test traffic for KNX, Modbus TCP, and MQTT.
+Each protocol runs as an independent async task; all three can run in parallel.
+The generator replaces a real field installation for testing the open bridge server.
 
-### Voraussetzungen
+### Prerequisites
 
 ```bash
 pip install pyyaml xknx pymodbus aiomqtt
 ```
 
-Nur die Pakete der tatsächlich verwendeten Protokolle sind erforderlich.
+Only the packages for the protocols you actually use are required.
 
-### Starten
+### Starting
 
 ```bash
-# Mit eigener Konfiguration
-python tools/testdata_generator.py /pfad/zur/config.yaml
+# With a custom configuration file
+python tools/testdata_generator.py /path/to/config.yaml
 
-# Ohne Argument: sucht testdata_generator_example.yaml im selben Verzeichnis
+# Without argument: looks for testdata_generator_example.yaml in the same directory
 python tools/testdata_generator.py
 ```
 
 ---
 
-## Konfiguration (YAML)
+## Configuration (YAML)
 
-Die Konfigurationsdatei besteht aus bis zu drei Top-Level-Abschnitten: `knx`, `modbus`, `mqtt`.
-Nicht benötigte Abschnitte einfach weglassen — der Generator startet nur die konfigurierten Protokolle.
+The configuration file consists of up to three top-level sections: `knx`, `modbus`, `mqtt`.
+Simply omit sections you don't need — the generator only starts the configured protocols.
 
-### Wert-Modi
+### Value Modes
 
-Jedes Signal (Telegramm, Register, Topic) verwendet einen der folgenden Modi:
+Each signal (telegram, register, topic) uses one of the following modes:
 
-| Modus      | Beschreibung                                      | Parameter                            |
+| Mode       | Description                                       | Parameters                           |
 |------------|---------------------------------------------------|--------------------------------------|
-| `fixed`    | Konstanter Wert                                   | `value: <wert>`                      |
-| `sine`     | Sinuskurve zwischen `min` und `max`               | `min`, `max`, `period` (s, def. 60)  |
-| `random`   | Zufällig gleichverteilt zwischen `min` und `max`  | `min`, `max`                         |
-| `ramp`     | Lineare Rampe von `min` nach `max`, dann Neustart | `min`, `max`, `period` (s, def. 60)  |
-| `sequence` | Zyklisch durch eine Liste von Werten              | `values: [a, b, c, …]`               |
-| `toggle`   | Wechselt bei jedem Schritt zwischen `true`/`false`| —                                    |
+| `fixed`    | Constant value                                    | `value: <val>`                       |
+| `sine`     | Sine curve between `min` and `max`                | `min`, `max`, `period` (s, def. 60)  |
+| `random`   | Uniformly random between `min` and `max`          | `min`, `max`                         |
+| `ramp`     | Linear ramp from `min` to `max`, then restart     | `min`, `max`, `period` (s, def. 60)  |
+| `sequence` | Cycles through a list of values                   | `values: [a, b, c, …]`               |
+| `toggle`   | Alternates between `true`/`false` on each step    | —                                    |
 
 ---
 
 ### KNX
 
-Läuft als KNX/IP Tunneling **Server** (Gateway-Simulator) — kein physischer KNX-Bus nötig.
-Der open bridge server KNX-Adapter verbindet sich als Client zu diesem Server.
+Runs as a KNX/IP Tunneling **Server** (gateway simulator) — no physical KNX bus required.
+The open bridge server KNX adapter connects to this server as a client.
 
-**Adapter-Konfiguration im open bridge server:**
+**Adapter configuration in open bridge server:**
 ```
 connection_type: tunneling
-host: 127.0.0.1          # IP der Maschine, auf der der Generator läuft
-port: 3671               # muss mit knx.port übereinstimmen
+host: 127.0.0.1          # IP of the machine running the generator
+port: 3671               # must match knx.port
 ```
 
-**Konfigurationsstruktur:**
+**Configuration structure:**
 ```yaml
 knx:
-  host: 0.0.0.0          # Netzwerkinterface (0.0.0.0 = alle, 127.0.0.1 = nur lokal)
-  port: 3671             # KNX/IP UDP-Port (Standardport; <1024 braucht root → z.B. 4001 verwenden)
-  max_events_per_second: 3.0   # Optionale globale Rate-Begrenzung (default 3.0)
+  host: 0.0.0.0          # Network interface (0.0.0.0 = all, 127.0.0.1 = local only)
+  port: 3671             # KNX/IP UDP port (standard; <1024 requires root → use e.g. 4001)
+  max_events_per_second: 3.0   # Optional global rate limit (default 3.0)
 
   telegrams:
-    - group_address: "1/1/1"   # KNX-Gruppenadresse (Pflicht)
-      dpt_id: "DPT9.001"       # DPT-ID aus der DPT-Registry (Pflicht)
-      interval: 5.0            # Sekunden zwischen Telegrammen
+    - group_address: "1/1/1"   # KNX group address (required)
+      dpt_id: "DPT9.001"       # DPT ID from the DPT registry (required)
+      interval: 5.0            # Seconds between telegrams
       mode: sine
       min: 18.0
       max: 25.0
       period: 120.0
 ```
 
-**Häufige DPT-IDs:**
+**Common DPT IDs:**
 
-| DPT       | Typ                     | Wertebereich   |
-|-----------|-------------------------|----------------|
-| DPT1.001  | Boolean (EIN/AUS)       | true / false   |
-| DPT5.001  | 1-Byte Prozent          | 0 – 100        |
-| DPT5.010  | 1-Byte Ganzzahl         | 0 – 255        |
-| DPT9.001  | 2-Byte Float (°C)       | −273 – 670760  |
-| DPT9.004  | 2-Byte Float (lux)      | 0 – 670760     |
-| DPT9.007  | 2-Byte Float (% Feuchte)| 0 – 100        |
-| DPT14.056 | 4-Byte Float            | IEEE 754       |
+| DPT       | Type                      | Value range    |
+|-----------|---------------------------|----------------|
+| DPT1.001  | Boolean (ON/OFF)          | true / false   |
+| DPT5.001  | 1-byte percent            | 0 – 100        |
+| DPT5.010  | 1-byte integer            | 0 – 255        |
+| DPT9.001  | 2-byte float (°C)         | −273 – 670760  |
+| DPT9.004  | 2-byte float (lux)        | 0 – 670760     |
+| DPT9.007  | 2-byte float (% humidity) | 0 – 100        |
+| DPT14.056 | 4-byte float              | IEEE 754       |
 
-**Beispiel:**
+**Example:**
 ```yaml
 knx:
   host: 0.0.0.0
   port: 4001
 
   telegrams:
-    - group_address: "1/1/1"   # Temperatur, Sinuskurve 18–25 °C
+    - group_address: "1/1/1"   # Temperature, sine curve 18–25 °C
       dpt_id: "DPT9.001"
       interval: 5.0
       mode: sine
@@ -102,7 +217,7 @@ knx:
       max: 25.0
       period: 120.0
 
-    - group_address: "1/1/2"   # Helligkeit, Rampe 0–100 %
+    - group_address: "1/1/2"   # Brightness, ramp 0–100 %
       dpt_id: "DPT5.001"
       interval: 3.0
       mode: ramp
@@ -110,18 +225,18 @@ knx:
       max: 100
       period: 60.0
 
-    - group_address: "1/1/3"   # Schalter, Toggle
+    - group_address: "1/1/3"   # Switch, toggle
       dpt_id: "DPT1.001"
       interval: 10.0
       mode: toggle
 
-    - group_address: "1/1/4"   # Fixwert 21.5 °C
+    - group_address: "1/1/4"   # Fixed value 21.5 °C
       dpt_id: "DPT9.001"
       interval: 30.0
       mode: fixed
       value: 21.5
 
-    - group_address: "1/1/5"   # Sequenz 0 → 25 → 50 → 75 → 100 %
+    - group_address: "1/1/5"   # Sequence 0 → 25 → 50 → 75 → 100 %
       dpt_id: "DPT5.001"
       interval: 5.0
       mode: sequence
@@ -132,46 +247,46 @@ knx:
 
 ### Modbus TCP
 
-Läuft als Modbus **Slave/Server** — open bridge server pollt als Master.
+Runs as a Modbus **Slave/Server** — open bridge server polls as master.
 
-**Adapter-Konfiguration im open bridge server:**
+**Adapter configuration in open bridge server:**
 ```
-host: 127.0.0.1          # IP der Maschine, auf der der Generator läuft
-port: 502                # muss mit modbus.port übereinstimmen
+host: 127.0.0.1          # IP of the machine running the generator
+port: 502                # must match modbus.port
 unit_id: 1
 ```
 
-**Konfigurationsstruktur:**
+**Configuration structure:**
 ```yaml
 modbus:
   host: 0.0.0.0
-  port: 502              # Port <1024 braucht root → z.B. 5001 verwenden
+  port: 502              # Port <1024 requires root → use e.g. 5001
   unit_id: 1
 
   registers:
     - register_type: holding   # holding | input | coil | discrete_input
-      address: 0               # Registeradresse (0-basiert)
+      address: 0               # Register address (0-based)
       data_format: uint16      # uint16 | uint32 | int16 | int32 | float32
-      scale_factor: 1.0        # Rohwert × scale_factor = physikalischer Wert
-      mode: sine               # Wert-Modus (s. Tabelle oben)
+      scale_factor: 1.0        # raw value × scale_factor = physical value
+      mode: sine               # Value mode (see table above)
       min: 0
       max: 100
-      interval: 2.0            # Sekunden zwischen Updates
+      interval: 2.0            # Seconds between updates
 ```
 
-**Register-Typen:**
+**Register types:**
 
-| Typ               | FC  | Lesen/Schreiben | Daten         |
-|-------------------|-----|-----------------|---------------|
-| `holding`         | 3   | R/W             | 16-Bit-Wörter |
-| `input`           | 4   | R               | 16-Bit-Wörter |
-| `coil`            | 1   | R/W             | Boolean       |
-| `discrete_input`  | 2   | R               | Boolean       |
+| Type              | FC  | Read/Write | Data          |
+|-------------------|-----|------------|---------------|
+| `holding`         | 3   | R/W        | 16-bit words  |
+| `input`           | 4   | R          | 16-bit words  |
+| `coil`            | 1   | R/W        | Boolean       |
+| `discrete_input`  | 2   | R          | Boolean       |
 
-**Hinweis `scale_factor`:** Der Rohwert im Register entspricht `physikalischer Wert / scale_factor`.
-Denselben `scale_factor` im open bridge server Binding konfigurieren.
+**Note on `scale_factor`:** The raw register value equals `physical value / scale_factor`.
+Configure the same `scale_factor` in the open bridge server binding.
 
-**Beispiel:**
+**Example:**
 ```yaml
 modbus:
   host: 0.0.0.0
@@ -179,7 +294,7 @@ modbus:
   unit_id: 1
 
   registers:
-    - register_type: holding   # Temperatur 18.0–25.0 °C als uint16 (Rohwert ×0.1)
+    - register_type: holding   # Temperature 18.0–25.0 °C as uint16 (raw ×0.1)
       address: 0
       data_format: uint16
       scale_factor: 0.1
@@ -189,7 +304,7 @@ modbus:
       interval: 2.0
       period: 120.0
 
-    - register_type: holding   # Windgeschwindigkeit als float32 (2 Register)
+    - register_type: holding   # Wind speed as float32 (2 registers)
       address: 2
       data_format: float32
       scale_factor: 1.0
@@ -198,7 +313,7 @@ modbus:
       max: 15.0
       interval: 3.0
 
-    - register_type: coil      # Relais-Status, Toggle
+    - register_type: coil      # Relay status, toggle
       address: 0
       mode: toggle
       interval: 8.0
@@ -208,10 +323,10 @@ modbus:
 
 ### MQTT
 
-Verbindet sich mit einem bestehenden Broker und **publiziert** Werte.
-open bridge server MQTT-Adapter **abonniert** diese Topics.
+Connects to an existing broker and **publishes** values.
+The open bridge server MQTT adapter **subscribes** to these topics.
 
-**Konfigurationsstruktur:**
+**Configuration structure:**
 ```yaml
 mqtt:
   host: localhost
@@ -220,43 +335,43 @@ mqtt:
   password: mypassword   # optional
 
   topics:
-    - topic: pfad/zum/topic    # MQTT-Topic (Pflicht)
-      interval: 5.0            # Sekunden zwischen Publizierungen
+    - topic: path/to/topic     # MQTT topic (required)
+      interval: 5.0            # Seconds between publications
       retain: false            # optional, default false
-      payload_template: null   # optional, s. unten
-      mode: sine               # Wert-Modus (s. Tabelle oben)
+      payload_template: null   # optional, see below
+      mode: sine               # Value mode (see table above)
       min: 0.0
       max: 100.0
 ```
 
-**`payload_template`:** Ermöglicht JSON- oder beliebige Text-Payloads.
-Der Platzhalter `###DP###` wird durch den generierten Wert ersetzt.
+**`payload_template`:** Enables JSON or arbitrary text payloads.
+The placeholder `###DP###` is replaced with the generated value.
 
 ```yaml
 payload_template: '{"sensor":"test","value":###DP###,"unit":"°C"}'
-# → publiziert z.B.: {"sensor":"test","value":21.3,"unit":"°C"}
+# → publishes e.g.: {"sensor":"test","value":21.3,"unit":"°C"}
 ```
 
-**Beispiel:**
+**Example:**
 ```yaml
 mqtt:
   host: localhost
   port: 1883
 
   topics:
-    - topic: _testdata/temperature   # Temperatur als Plain-Float
+    - topic: _testdata/temperature   # Temperature as plain float
       interval: 5.0
       mode: sine
       min: 18.0
       max: 25.0
       period: 120.0
 
-    - topic: _testdata/switch        # Schalter mit Retain
+    - topic: _testdata/switch        # Switch with retain
       interval: 10.0
       mode: toggle
       retain: true
 
-    - topic: _testdata/sensor/json   # JSON-Payload
+    - topic: _testdata/sensor/json   # JSON payload
       interval: 4.0
       mode: ramp
       min: 0.0
@@ -264,7 +379,7 @@ mqtt:
       period: 60.0
       payload_template: '{"sensor":"test","value":###DP###,"unit":"%"}'
 
-    - topic: _testdata/setpoint      # Sequenz
+    - topic: _testdata/setpoint      # Sequence
       interval: 15.0
       mode: sequence
       values: [16.0, 18.0, 20.0, 22.0, 24.0]
@@ -275,40 +390,40 @@ mqtt:
 
 ## testdata-generator.service — systemd (Debian/Ubuntu)
 
-### 1. Anpassen
+### 1. Customize
 
-Die folgenden drei Stellen in `testdata-generator.service` an die eigene Umgebung anpassen:
+Adjust the following settings in `testdata-generator.service` for your environment:
 
-| Parameter                         | Default                             | Bedeutung                        |
-|-----------------------------------|-------------------------------------|----------------------------------|
-| `User` / `Group`                  | `obs`                               | Systembenutzer für den Prozess   |
-| `WorkingDirectory`                | `/opt/openbridgeserver`             | Installationspfad des Projekts   |
-| `ExecStart` (Python)              | `/usr/bin/python3`                  | Pfad zu Python (`which python3`) |
-| `ExecStart` (letztes Argument)    | `…tools/config.yaml`                | Pfad zur Konfigurationsdatei     |
+| Parameter                      | Default                         | Meaning                           |
+|--------------------------------|---------------------------------|-----------------------------------|
+| `User` / `Group`               | `obs`                           | System user for the process       |
+| `WorkingDirectory`             | `/opt/openbridgeserver`         | Project installation path         |
+| `ExecStart` (Python)           | `/usr/bin/python3`              | Path to Python (`which python3`)  |
+| `ExecStart` (last argument)    | `…tools/config.yaml`            | Path to the configuration file    |
 
-### 2. Installieren
+### 2. Install
 
 ```bash
 sudo cp /opt/openbridgeserver/tools/testdata-generator.service \
         /etc/systemd/system/
 
-# Benutzer anlegen (falls noch nicht vorhanden)
+# Create user if it doesn't exist yet
 sudo useradd -r -s /bin/false obs
 
 sudo systemctl daemon-reload
 ```
 
-### 3. Starten und aktivieren
+### 3. Start and enable
 
 ```bash
-# Sofort starten und beim Boot automatisch starten
+# Start immediately and enable at boot
 sudo systemctl enable --now testdata-generator
 
-# Nur starten (ohne Autostart)
+# Start only (without autostart)
 sudo systemctl start testdata-generator
 ```
 
-### 4. Betrieb
+### 4. Operations
 
 ```bash
 sudo systemctl status testdata-generator
@@ -317,5 +432,5 @@ sudo systemctl stop testdata-generator
 sudo systemctl disable testdata-generator
 ```
 
-Der Service startet bei einem Absturz automatisch neu (`Restart=on-failure`).
-Bei einem sauberen Stop via `systemctl stop` wird er **nicht** neu gestartet.
+The service restarts automatically on crash (`Restart=on-failure`).
+A clean stop via `systemctl stop` does **not** trigger a restart.

--- a/tools/_lxc-inner.sh
+++ b/tools/_lxc-inner.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# Inner LXC build script — runs as root inside the obs-lxc-builder container.
+# Invoked by tools/build-local.sh; not intended to be run directly.
+set -euo pipefail
+
+VERSION="${VERSION:-0.0.0-local}"
+REPO="${REPO:-unknown/openbridgeserver}"
+BUNDLE_ONLY="${BUNDLE_ONLY:-false}"
+NO_CACHE="${NO_CACHE:-false}"
+
+ARCH=$(dpkg --print-architecture)
+TEMPLATE_NAME="openbridgeserver"
+TEMPLATE_FILE="${TEMPLATE_NAME}-lxc_${VERSION}_${ARCH}.tar.zst"
+APP_BUNDLE_FILE="${TEMPLATE_NAME}-app-bundle_${VERSION}.tar.gz"
+CACHE_FILE="/cache/base-system-ubuntu-plucky-${ARCH}.tar.zst"
+ROOTFS="/tmp/rootfs"
+
+if [[ "$ARCH" == "arm64" ]]; then
+    MIRROR="http://ports.ubuntu.com/ubuntu-ports"
+    SECURITY_MIRROR="http://ports.ubuntu.com/ubuntu-ports"
+else
+    MIRROR="http://archive.ubuntu.com/ubuntu"
+    SECURITY_MIRROR="http://security.ubuntu.com/ubuntu"
+fi
+
+# ── Prepare build directory ───────────────────────────────────────────────────
+echo "==> Preparing build directory..."
+mkdir -p /build
+cp -r /workspace/. /build/
+rm -rf /build/gui/node_modules /build/frontend/node_modules /build/.venv
+cd /build
+
+# ── Stamp version ─────────────────────────────────────────────────────────────
+BASE=$(grep -m1 '^## ' RELEASENOTES.md | sed 's/^## *//')
+RC=$(echo "$VERSION" | grep -oP -- '-RC\d*$' || true)
+echo "${BASE}${RC}" > obs/version
+npm pkg set version="$VERSION" --prefix gui
+
+# ── Build frontends ───────────────────────────────────────────────────────────
+echo "==> Building Admin GUI..."
+cd gui
+npm install --prefer-offline
+npm run build
+cd ..
+
+echo "==> Building Visu frontend..."
+cd frontend
+npm install --prefer-offline
+npm run build
+cd ..
+
+# ── Write obs-update ───────────────────────────────────────────────────────────
+cat > /tmp/obs-update << 'SCRIPTEOF'
+#!/bin/bash
+set -euo pipefail
+
+REPO="__REPO__"
+INSTALL_DIR="/opt/obs"
+SERVICE="obs"
+
+CURRENT=$(cat "$INSTALL_DIR/version" 2>/dev/null || echo "unknown")
+echo "Fetching release information..."
+ALL_RELEASES=$(curl -sf "https://api.github.com/repos/${REPO}/releases")
+
+# Build ordered list via semantic version sort, stopping after 2 stables
+VERSION_LIST=$(echo "$ALL_RELEASES" | python3 -c "
+import sys, json, re
+
+releases = json.load(sys.stdin)
+
+def sort_key(tag):
+    m = re.match(r'^(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?\$', tag, re.IGNORECASE)
+    if not m:
+        return (0, 0, 0, 0, 0)
+    y, mn, p = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    rc = int(m.group(4)) if m.group(4) else None
+    return (y, mn, p, 1 if rc is None else 0, rc or 0)
+
+candidates = sorted(
+    [r for r in releases if not r['draft']],
+    key=lambda r: sort_key(r['tag_name']), reverse=True
+)
+
+stables_seen = 0
+for r in candidates:
+    kind = 'rc' if r['prerelease'] else 'stable'
+    print(kind + ' ' + r['tag_name'])
+    if not r['prerelease']:
+        stables_seen += 1
+        if stables_seen >= 2:
+            break
+")
+
+echo "Current version: $CURRENT"
+echo ""
+
+OPTIONS=()
+LABELS=()
+
+while IFS=' ' read -r TYPE TAG; do
+    OPTIONS+=("$TAG")
+    MARKER=""
+    [[ "$TAG" == "$CURRENT" ]] && MARKER=", current"
+    if [[ "$TYPE" == "stable" ]]; then
+        LABELS+=("$TAG  (stable${MARKER})")
+    else
+        LABELS+=("$TAG  (release candidate${MARKER})")
+    fi
+done <<< "$VERSION_LIST"
+
+if [[ ${#OPTIONS[@]} -eq 0 ]]; then
+    echo "No releases found."
+    exit 0
+fi
+
+echo "Available versions:"
+for i in "${!OPTIONS[@]}"; do
+    echo "  $((i+1))) ${LABELS[$i]}"
+done
+echo "  0) Cancel"
+echo ""
+
+while true; do
+    read -rp "Select version to install [0-${#OPTIONS[@]}]: " CHOICE
+    if [[ "$CHOICE" =~ ^[0-9]+$ ]] && [[ "$CHOICE" -ge 0 ]] && [[ "$CHOICE" -le "${#OPTIONS[@]}" ]]; then
+        break
+    fi
+    echo "Invalid selection, please try again."
+done
+
+if [[ "$CHOICE" -eq 0 ]]; then
+    echo "Cancelled."
+    exit 0
+fi
+
+TARGET="${OPTIONS[$((CHOICE-1))]}"
+
+if [[ "$TARGET" == "$CURRENT" ]]; then
+    echo "$TARGET is already installed."
+    exit 0
+fi
+
+echo "Installing $TARGET ..."
+
+ASSET_INFO=$(echo "$ALL_RELEASES" | python3 -c "
+import sys, json
+target = '${TARGET}'
+releases = json.load(sys.stdin)
+r = next((r for r in releases if r['tag_name'] == target), None)
+if r:
+    bundle = next((a for a in r['assets'] if 'app-bundle' in a['name'] and a['name'].endswith('.tar.gz')), None)
+    checksum = next((a for a in r['assets'] if 'app-bundle' in a['name'] and a['name'].endswith('.tar.gz.sha512')), None)
+    if bundle and checksum:
+        print(bundle['browser_download_url'])
+        print(checksum['browser_download_url'])
+")
+
+BUNDLE_URL=$(echo "$ASSET_INFO" | sed -n '1p')
+CHECKSUM_URL=$(echo "$ASSET_INFO" | sed -n '2p')
+
+if [[ -z "$BUNDLE_URL" ]] || [[ -z "$CHECKSUM_URL" ]]; then
+    echo "Error: missing app-bundle or checksum asset for $TARGET" >&2
+    exit 1
+fi
+
+BUNDLE_FILENAME=$(basename "$BUNDLE_URL")
+CHECKSUM_FILENAME=$(basename "$CHECKSUM_URL")
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+echo "Downloading $BUNDLE_URL ..."
+curl -fL "$BUNDLE_URL" -o "$TMP/$BUNDLE_FILENAME"
+echo "Downloading $CHECKSUM_URL ..."
+curl -fL "$CHECKSUM_URL" -o "$TMP/$CHECKSUM_FILENAME"
+
+(cd "$TMP" && sha512sum -c "$CHECKSUM_FILENAME")
+
+systemctl stop "$SERVICE"
+
+tar -xzf "$TMP/$BUNDLE_FILENAME" -C "$INSTALL_DIR"
+"$INSTALL_DIR/venv/bin/pip" install --no-cache-dir -q -r "$INSTALL_DIR/requirements.txt"
+
+# Self-update: replace this script with the version from the bundle
+cp "$INSTALL_DIR/obs-update" /usr/local/bin/obs-update
+chmod +x /usr/local/bin/obs-update
+rm -f "$INSTALL_DIR/obs-update"
+
+echo "$TARGET" > "$INSTALL_DIR/version"
+
+systemctl start "$SERVICE"
+echo "Done. Now running $TARGET."
+SCRIPTEOF
+
+sed -i "s|__REPO__|$REPO|g" /tmp/obs-update
+chmod +x /tmp/obs-update
+cp /tmp/obs-update obs-update
+
+# ── App bundle ─────────────────────────────────────────────────────────────────
+echo "==> Creating app bundle..."
+tar -czf "/tmp/$APP_BUNDLE_FILE" obs/ gui_dist/ frontend_dist/ requirements.txt obs-update
+(cd /tmp && sha512sum "$APP_BUNDLE_FILE" > "$APP_BUNDLE_FILE.sha512")
+cp "/tmp/$APP_BUNDLE_FILE" "/tmp/$APP_BUNDLE_FILE.sha512" /output/
+
+if [[ "${BUNDLE_ONLY}" == "true" ]]; then
+    echo ""
+    echo "==> Bundle-only mode complete. Artifacts:"
+    ls -lh /output/
+    exit 0
+fi
+
+# ── Base system (debootstrap or restore from cache) ───────────────────────────
+mkdir -p "$ROOTFS"
+
+if [[ "$NO_CACHE" != "true" ]] && [[ -f "$CACHE_FILE" ]]; then
+    echo "==> Restoring base system from cache (~/.cache/obs-lxc-builder)..."
+    tar --zstd -xf "$CACHE_FILE" -C "$ROOTFS"
+else
+    echo "==> Running debootstrap for plucky/${ARCH} (this may take several minutes)..."
+    debootstrap \
+        --arch="$ARCH" \
+        --components=main,restricted,universe \
+        --include=systemd,systemd-sysv,dbus,apt-utils,locales,iproute2,wget,curl,ca-certificates,less,logrotate,openssh-server,ifupdown \
+        plucky \
+        "$ROOTFS" \
+        "$MIRROR"
+
+    tee "$ROOTFS/etc/apt/sources.list" > /dev/null << SOURCES
+deb $MIRROR plucky main restricted universe multiverse
+deb $MIRROR plucky-updates main restricted universe multiverse
+deb $SECURITY_MIRROR plucky-security main restricted universe multiverse
+SOURCES
+
+    chroot "$ROOTFS" /bin/bash << 'BASESCRIPT'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+locale-gen
+update-locale LANG=en_US.UTF-8
+
+ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+echo "UTC" > /etc/timezone
+
+cat > /etc/network/interfaces << 'EOF'
+auto lo
+iface lo inet loopback
+EOF
+
+echo "localhost" > /etc/hostname
+
+cat > /etc/hosts << 'EOF'
+127.0.0.1   localhost
+::1         localhost ip6-localhost ip6-loopback
+ff02::1     ip6-allnodes
+ff02::2     ip6-allrouters
+EOF
+
+echo "# Proxmox manages container mounts" > /etc/fstab
+
+mkdir -p /etc/systemd/system-preset
+echo "disable systemd-networkd-wait-online.service" \
+    > /etc/systemd/system-preset/00-pve-template.preset
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+BASESCRIPT
+
+    echo "==> Saving base system to cache..."
+    tar --zstd -cf "$CACHE_FILE" -C "$ROOTFS" .
+fi
+
+# ── Install app ────────────────────────────────────────────────────────────────
+echo "==> Installing app into rootfs..."
+cp /etc/resolv.conf "$ROOTFS/etc/resolv.conf"
+
+mount -t proc proc "$ROOTFS/proc"
+trap 'mountpoint -q "$ROOTFS/proc" && umount "$ROOTFS/proc" || true' EXIT
+
+mkdir -p "$ROOTFS/opt/obs"
+cp -r obs              "$ROOTFS/opt/obs/"
+cp -r gui_dist         "$ROOTFS/opt/obs/"
+cp -r frontend_dist    "$ROOTFS/opt/obs/"
+cp    requirements.txt "$ROOTFS/opt/obs/"
+echo "$VERSION" | tee "$ROOTFS/opt/obs/version" > /dev/null
+cp /tmp/obs-update "$ROOTFS/usr/local/bin/obs-update"
+
+chroot "$ROOTFS" /bin/bash << 'INSTALL'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y python3 python3-pip python3-venv gcc libffi-dev libssl-dev mosquitto mosquitto-clients
+
+python3 -m venv /opt/obs/venv
+/opt/obs/venv/bin/pip install --no-cache-dir -r /opt/obs/requirements.txt
+
+mkdir -p /data
+
+cat > /etc/obs.env << 'EOF'
+OBS_DATABASE__PATH=/data/obs.db
+OBS_CONFIG=/data/config.yaml
+EOF
+chmod 600 /etc/obs.env
+
+cat > /etc/systemd/system/obs.service << 'EOF'
+[Unit]
+Description=open bridge server
+After=network.target mosquitto.service
+Requires=mosquitto.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/obs
+ExecStart=/opt/obs/venv/bin/python3 -m obs
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=/etc/obs.env
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/mosquitto/mosquitto.conf << 'MQTTCONF'
+pid_file /run/mosquitto/mosquitto.pid
+
+allow_anonymous false
+password_file /etc/mosquitto/passwd
+
+listener 1883
+protocol mqtt
+
+listener 9001
+protocol websockets
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+
+max_connections 100
+max_keepalive 120
+MQTTCONF
+
+cat > /opt/obs/obs-first-boot.sh << 'FIRSTBOOT'
+#!/bin/bash
+set -euo pipefail
+
+MQTT_PASSWORD=$(python3 -c "import secrets, string; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))")
+JWT_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(48))")
+
+mosquitto_passwd -c -b /etc/mosquitto/passwd obs "$MQTT_PASSWORD"
+chmod 640 /etc/mosquitto/passwd
+chown mosquitto:mosquitto /etc/mosquitto/passwd
+
+cat >> /etc/obs.env << EOF
+OBS_MQTT__HOST=localhost
+OBS_MQTT__PORT=1883
+OBS_MQTT__USERNAME=obs
+OBS_MQTT__PASSWORD=$MQTT_PASSWORD
+OBS_MOSQUITTO__PASSWD_FILE=/etc/mosquitto/passwd
+OBS_MOSQUITTO__RELOAD_COMMAND=systemctl reload mosquitto
+OBS_MOSQUITTO__SERVICE_USERNAME=obs
+OBS_MOSQUITTO__SERVICE_PASSWORD=$MQTT_PASSWORD
+OBS_SECURITY__JWT_SECRET=$JWT_SECRET
+EOF
+chmod 600 /etc/obs.env
+FIRSTBOOT
+chmod +x /opt/obs/obs-first-boot.sh
+
+cat > /etc/systemd/system/obs-first-boot.service << 'FIRSTBOOTSVC'
+[Unit]
+Description=open bridge server — first-boot MQTT credential setup
+Before=mosquitto.service obs.service
+ConditionPathExists=!/etc/obs-first-boot-done
+
+[Service]
+Type=oneshot
+ExecStart=/opt/obs/obs-first-boot.sh
+ExecStartPost=/bin/touch /etc/obs-first-boot-done
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+FIRSTBOOTSVC
+
+systemctl enable obs.service mosquitto.service obs-first-boot.service
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+INSTALL
+
+# Unmount proc now — before finalization and packaging.
+# The EXIT trap would fire too late (after tar), causing "Permission denied" on
+# /proc/sys pseudo-files and xattr warnings from still-mounted proc sub-mounts.
+umount "$ROOTFS/proc"
+trap - EXIT
+
+# ── Finalize ───────────────────────────────────────────────────────────────────
+echo "==> Finalizing rootfs..."
+chroot "$ROOTFS" /bin/bash << 'CLEANUP'
+set -euo pipefail
+truncate -s 0 /etc/machine-id
+rm -f /etc/ssh/ssh_host_*
+find /var/log -type f -exec truncate -s 0 {} \;
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+rm -f /root/.bash_history
+truncate -s 0 /etc/resolv.conf
+CLEANUP
+
+# ── Package ────────────────────────────────────────────────────────────────────
+echo "==> Packaging as $TEMPLATE_FILE..."
+cd "$ROOTFS"
+tar --numeric-owner --acls --xattrs \
+    -cf - . | zstd -T0 -9 -o "/tmp/$TEMPLATE_FILE"
+cd /tmp
+sha512sum "$TEMPLATE_FILE" > "$TEMPLATE_FILE.sha512"
+cp "$TEMPLATE_FILE" "$TEMPLATE_FILE.sha512" /output/
+
+echo ""
+echo "==> Done! Artifacts:"
+ls -lh /output/

--- a/tools/build-local.sh
+++ b/tools/build-local.sh
@@ -9,7 +9,7 @@ BUILDER_IMAGE="obs-lxc-builder:latest"
 
 # ── Defaults ───────────────────────────────────────────────────────────────────
 VERSION=""
-IMAGE_NAME="openbridgeserver"
+IMAGE_NAME="localhost/openbridgeserver"
 PUSH=false
 REPO=""
 OUTPUT_DIR="${PROJECT_ROOT}/dist"
@@ -31,7 +31,7 @@ Commands:
 
 Options:
   --version VER    Override version (default: git describe --tags --always --dirty)
-  --image   NAME   Docker image name/prefix (default: openbridgeserver)
+  --image   NAME   Docker image name/prefix (default: localhost/openbridgeserver)
                    For registry push: e.g. ghcr.io/owner/openbridgeserver
   --push           Push Docker image to registry after build
   --repo    REPO   GitHub repo slug for the obs-update script, e.g. owner/openbridgeserver
@@ -44,11 +44,10 @@ Examples:
   tools/build-local.sh docker
   tools/build-local.sh --version 2026.6.0 lxc
   tools/build-local.sh --push --image ghcr.io/owner/openbridgeserver docker
-  tools/build-local.sh --no-cache lxc
-  tools/build-local.sh all
-  tools/build-local.sh clean
 
 Notes:
+  - The docker command passes the version via --build-arg OBS_VERSION so
+    obs/version and gui/package.json in the working tree are never modified.
   - The lxc and bundle commands use a builder Docker image (obs-lxc-builder) that is
     built automatically on first run and cached via Docker layer cache.
   - The debootstrap base system is cached in ~/.cache/obs-lxc-builder/ to speed up
@@ -129,35 +128,26 @@ build_docker() {
     require_docker
     echo "==> Building Docker image ${IMAGE_NAME}:${version}..."
 
-    # Stamp obs/version and gui/package.json; restore both on exit
-    local orig_obs_version orig_pkg_json
-    orig_obs_version=$(cat "$PROJECT_ROOT/obs/version")
-    orig_pkg_json=$(cat "$PROJECT_ROOT/gui/package.json")
-    restore_stamps() {
-        echo "$orig_obs_version" > "$PROJECT_ROOT/obs/version"
-        printf '%s\n' "$orig_pkg_json" > "$PROJECT_ROOT/gui/package.json"
-    }
-    trap restore_stamps EXIT
-
-    local base rc
+    # Derive the stamped obs/version string from RELEASENOTES.md + optional RC suffix.
+    # This is passed as a build-arg so the working tree is never modified.
+    local base rc obs_version
     base=$(grep -m1 '^## ' "$PROJECT_ROOT/RELEASENOTES.md" | sed 's/^## *//')
     if [[ "$version" =~ (-RC[0-9]*)$ ]]; then rc="${BASH_REMATCH[1]}"; else rc=""; fi
-    echo "${base}${rc}" > "$PROJECT_ROOT/obs/version"
-    (command -v npm &>/dev/null && npm pkg set version="$version" --prefix "$PROJECT_ROOT/gui") || true
+    obs_version="${base}${rc}"
 
-    # Build via docker compose — reuses compose context, Dockerfile, and .env build args
-    docker compose --project-directory "$PROJECT_ROOT" build obs
+    # Build via docker compose — passes OBS_VERSION build-arg into the Dockerfile
+    docker compose --project-directory "$PROJECT_ROOT" build \
+        --build-arg OBS_VERSION="$obs_version" obs
 
-    restore_stamps
-    trap - EXIT
-
-    # Retag the compose-built image with the proper versioned name
+    # Retag the compose-built image with versioned names and remove the compose tag
     local githash src_image
     githash=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
     src_image=$(compose_image_tag)
 
     docker tag "$src_image" "${IMAGE_NAME}:${version}"
     docker tag "$src_image" "${IMAGE_NAME}:${githash}"
+    # Remove the intermediate compose-named tag (keep only our versioned tags)
+    docker image rm "$src_image" 2>/dev/null || true
     echo "==> Tagged: ${IMAGE_NAME}:${version}, ${IMAGE_NAME}:${githash}"
 
     if [[ "$PUSH" == "true" ]]; then

--- a/tools/build-local.sh
+++ b/tools/build-local.sh
@@ -9,7 +9,7 @@ BUILDER_IMAGE="obs-lxc-builder:latest"
 
 # ── Defaults ───────────────────────────────────────────────────────────────────
 VERSION=""
-IMAGE_NAME="obs"
+IMAGE_NAME="openbridgeserver"
 PUSH=false
 REPO=""
 OUTPUT_DIR="${PROJECT_ROOT}/dist"
@@ -27,10 +27,11 @@ Commands:
   lxc       Build LXC .tar.zst template (runs inside Docker, needs --privileged)
   bundle    Build app bundle only (no rootfs, much faster than lxc)
   all       Build docker + lxc
+  clean     Remove dist/ artifacts, rootfs cache, and builder image
 
 Options:
   --version VER    Override version (default: git describe --tags --always --dirty)
-  --image   NAME   Docker image name/prefix (default: obs)
+  --image   NAME   Docker image name/prefix (default: openbridgeserver)
                    For registry push: e.g. ghcr.io/owner/openbridgeserver
   --push           Push Docker image to registry after build
   --repo    REPO   GitHub repo slug for the obs-update script, e.g. owner/openbridgeserver
@@ -45,6 +46,7 @@ Examples:
   tools/build-local.sh --push --image ghcr.io/owner/openbridgeserver docker
   tools/build-local.sh --no-cache lxc
   tools/build-local.sh all
+  tools/build-local.sh clean
 
 Notes:
   - The lxc and bundle commands use a builder Docker image (obs-lxc-builder) that is
@@ -100,6 +102,24 @@ check_privileged() {
     fi
 }
 
+# Locate the image that docker compose just built for the obs service.
+# Docker Compose names images as <project>-<service> (v2) or <project>_<service> (legacy);
+# try both so the result is independent of the Compose version.
+compose_image_tag() {
+    local project_name
+    project_name=$(cd "$PROJECT_ROOT" && docker compose config 2>/dev/null | awk '/^name:/{print $2; exit}')
+    local hyphen="${project_name}-obs:latest"
+    local underscore="${project_name}_obs:latest"
+    if docker image inspect "$hyphen" &>/dev/null; then
+        echo "$hyphen"
+    elif docker image inspect "$underscore" &>/dev/null; then
+        echo "$underscore"
+    else
+        echo "error: could not find compose-built image (tried $hyphen and $underscore)" >&2
+        exit 1
+    fi
+}
+
 # ── Build functions ────────────────────────────────────────────────────────────
 build_docker() {
     local version="$1"
@@ -128,20 +148,18 @@ build_docker() {
     restore_stamps
     trap - EXIT
 
-    # If a custom image name or push was requested, retag the compose-built image
-    if [[ "$IMAGE_NAME" != "obs" ]] || [[ "$PUSH" == "true" ]]; then
-        local githash project_name src_image
-        githash=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
-        project_name=$(cd "$PROJECT_ROOT" && docker compose config 2>/dev/null | awk '/^name:/{print $2; exit}')
-        src_image="${project_name}-obs:latest"
+    # Retag the compose-built image with the proper versioned name
+    local githash src_image
+    githash=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
+    src_image=$(compose_image_tag)
 
-        docker tag "$src_image" "${IMAGE_NAME}:${version}"
-        docker tag "$src_image" "${IMAGE_NAME}:${githash}"
-        if [[ "$PUSH" == "true" ]]; then
-            docker push "${IMAGE_NAME}:${version}"
-            docker push "${IMAGE_NAME}:${githash}"
-        fi
-        echo "==> Tagged: ${IMAGE_NAME}:${version}, ${IMAGE_NAME}:${githash}"
+    docker tag "$src_image" "${IMAGE_NAME}:${version}"
+    docker tag "$src_image" "${IMAGE_NAME}:${githash}"
+    echo "==> Tagged: ${IMAGE_NAME}:${version}, ${IMAGE_NAME}:${githash}"
+
+    if [[ "$PUSH" == "true" ]]; then
+        docker push "${IMAGE_NAME}:${version}"
+        docker push "${IMAGE_NAME}:${githash}"
     fi
 
     echo "==> Docker image built successfully."
@@ -192,18 +210,53 @@ build_bundle() {
     echo "==> Bundle artifacts written to $OUTPUT_DIR"
 }
 
+build_clean() {
+    echo "==> Cleaning build artifacts..."
+
+    local removed=0
+
+    # dist/ artifacts
+    if [[ -d "$OUTPUT_DIR" ]]; then
+        local files
+        files=$(find "$OUTPUT_DIR" -maxdepth 1 \( -name "*.tar.zst" -o -name "*.tar.gz" -o -name "*.sha512" \) 2>/dev/null)
+        if [[ -n "$files" ]]; then
+            echo "$files" | xargs rm -f
+            echo "    Removed artifacts from $OUTPUT_DIR/"
+            removed=1
+        fi
+    fi
+
+    # Rootfs cache
+    local cache_dir="$HOME/.cache/obs-lxc-builder"
+    if compgen -G "$cache_dir/*.tar.zst" &>/dev/null; then
+        rm -f "$cache_dir"/*.tar.zst
+        echo "    Removed rootfs cache from $cache_dir/"
+        removed=1
+    fi
+
+    # Builder image
+    if docker image inspect "$BUILDER_IMAGE" &>/dev/null 2>&1; then
+        docker image rm "$BUILDER_IMAGE"
+        echo "    Removed builder image $BUILDER_IMAGE"
+        removed=1
+    fi
+
+    [[ "$removed" -eq 0 ]] && echo "    Nothing to clean."
+    echo "==> Done."
+}
+
 # ── Argument parsing ───────────────────────────────────────────────────────────
 COMMAND=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        docker|lxc|bundle|all)  COMMAND="$1"; shift ;;
-        --version)              VERSION="$2"; shift 2 ;;
-        --image)                IMAGE_NAME="$2"; shift 2 ;;
-        --push)                 PUSH=true; shift ;;
-        --repo)                 REPO="$2"; shift 2 ;;
-        --output)               OUTPUT_DIR="$2"; shift 2 ;;
-        --no-cache)             NO_CACHE=true; shift ;;
-        -h|--help)              usage; exit 0 ;;
+        docker|lxc|bundle|all|clean)  COMMAND="$1"; shift ;;
+        --version)                    VERSION="$2"; shift 2 ;;
+        --image)                      IMAGE_NAME="$2"; shift 2 ;;
+        --push)                       PUSH=true; shift ;;
+        --repo)                       REPO="$2"; shift 2 ;;
+        --output)                     OUTPUT_DIR="$2"; shift 2 ;;
+        --no-cache)                   NO_CACHE=true; shift ;;
+        -h|--help)                    usage; exit 0 ;;
         *)
             echo "error: unknown argument: $1" >&2
             usage >&2
@@ -215,6 +268,13 @@ if [[ -z "$COMMAND" ]]; then
     echo "error: no command specified" >&2
     usage >&2
     exit 2
+fi
+
+# clean needs no version/repo resolution
+if [[ "$COMMAND" == "clean" ]]; then
+    require_docker
+    build_clean
+    exit 0
 fi
 
 # ── Resolve defaults ───────────────────────────────────────────────────────────

--- a/tools/build-local.sh
+++ b/tools/build-local.sh
@@ -60,7 +60,11 @@ EOF
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 detect_version() {
-    git -C "$PROJECT_ROOT" describe --tags --always --dirty 2>/dev/null || echo "0.0.0-local"
+    local v
+    v=$(git -C "$PROJECT_ROOT" describe --tags --always --dirty 2>/dev/null || echo "0.0.0-local")
+    # git describe prefixes the commit hash with 'g' (e.g. 2026.6.0-RC4-22-ge633092-dirty).
+    # Strip the 'g' so the hash segment matches `git rev-parse --short HEAD` exactly.
+    echo "${v//-g/-}"
 }
 
 detect_repo() {
@@ -140,19 +144,21 @@ build_docker() {
         --build-arg OBS_VERSION="$obs_version" obs
 
     # Retag the compose-built image with versioned names and remove the compose tag
-    local githash src_image
+    local githash dirty githash_tag src_image
     githash=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
+    dirty=$(git -C "$PROJECT_ROOT" status --porcelain 2>/dev/null)
+    githash_tag="${githash}$([[ -n "$dirty" ]] && echo "-dirty" || true)"
     src_image=$(compose_image_tag)
 
     docker tag "$src_image" "${IMAGE_NAME}:${version}"
-    docker tag "$src_image" "${IMAGE_NAME}:${githash}"
+    docker tag "$src_image" "${IMAGE_NAME}:${githash_tag}"
     # Remove the intermediate compose-named tag (keep only our versioned tags)
     docker image rm "$src_image" 2>/dev/null || true
-    echo "==> Tagged: ${IMAGE_NAME}:${version}, ${IMAGE_NAME}:${githash}"
+    echo "==> Tagged: ${IMAGE_NAME}:${version}, ${IMAGE_NAME}:${githash_tag}"
 
     if [[ "$PUSH" == "true" ]]; then
         docker push "${IMAGE_NAME}:${version}"
-        docker push "${IMAGE_NAME}:${githash}"
+        docker push "${IMAGE_NAME}:${githash_tag}"
     fi
 
     echo "==> Docker image built successfully."

--- a/tools/build-local.sh
+++ b/tools/build-local.sh
@@ -67,7 +67,10 @@ detect_version() {
 detect_repo() {
     local url result
     url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || echo "")
-    result=$(echo "$url" | sed -E 's|.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
+    # Strip trailing .git, then extract the owner/repo suffix after github.com: or github.com/
+    # Pure Bash — no sed, avoids BSD vs GNU sed ERE incompatibilities (non-greedy, etc.)
+    url="${url%.git}"
+    result="${url##*github.com[:/]}"   # remove everything up to and including github.com: or github.com/
     if [[ "$result" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
         echo "$result"
     else
@@ -138,7 +141,7 @@ build_docker() {
 
     local base rc
     base=$(grep -m1 '^## ' "$PROJECT_ROOT/RELEASENOTES.md" | sed 's/^## *//')
-    rc=$(echo "$version" | grep -oP -- '-RC\d*$' || true)
+    if [[ "$version" =~ (-RC[0-9]*)$ ]]; then rc="${BASH_REMATCH[1]}"; else rc=""; fi
     echo "${base}${rc}" > "$PROJECT_ROOT/obs/version"
     (command -v npm &>/dev/null && npm pkg set version="$version" --prefix "$PROJECT_ROOT/gui") || true
 

--- a/tools/build-local.sh
+++ b/tools/build-local.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Build open bridge server artifacts locally.
+# Only requirement: Docker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+BUILDER_IMAGE="obs-lxc-builder:latest"
+
+# ── Defaults ───────────────────────────────────────────────────────────────────
+VERSION=""
+IMAGE_NAME="obs"
+PUSH=false
+REPO=""
+OUTPUT_DIR="${PROJECT_ROOT}/dist"
+NO_CACHE=false
+
+# ── Usage ──────────────────────────────────────────────────────────────────────
+usage() {
+    cat << 'EOF'
+Usage: tools/build-local.sh [OPTIONS] COMMAND
+
+Build open bridge server artifacts locally. Only requirement: Docker.
+
+Commands:
+  docker    Build Docker image via docker compose build obs
+  lxc       Build LXC .tar.zst template (runs inside Docker, needs --privileged)
+  bundle    Build app bundle only (no rootfs, much faster than lxc)
+  all       Build docker + lxc
+
+Options:
+  --version VER    Override version (default: git describe --tags --always --dirty)
+  --image   NAME   Docker image name/prefix (default: obs)
+                   For registry push: e.g. ghcr.io/owner/openbridgeserver
+  --push           Push Docker image to registry after build
+  --repo    REPO   GitHub repo slug for the obs-update script, e.g. owner/openbridgeserver
+                   (default: auto-detected from git remote origin)
+  --output  DIR    Output directory for LXC/bundle artifacts (default: dist/)
+  --no-cache       Rebuild builder image without cache and skip the rootfs cache
+  -h, --help       Show this help
+
+Examples:
+  tools/build-local.sh docker
+  tools/build-local.sh --version 2026.6.0 lxc
+  tools/build-local.sh --push --image ghcr.io/owner/openbridgeserver docker
+  tools/build-local.sh --no-cache lxc
+  tools/build-local.sh all
+
+Notes:
+  - The lxc and bundle commands use a builder Docker image (obs-lxc-builder) that is
+    built automatically on first run and cached via Docker layer cache.
+  - The debootstrap base system is cached in ~/.cache/obs-lxc-builder/ to speed up
+    repeated lxc builds. Remove that directory or pass --no-cache to rebuild from scratch.
+  - Cross-arch LXC builds are not supported locally; the output arch matches the host.
+  - For multi-arch Docker builds, ensure QEMU binfmts are registered first:
+      docker run --privileged --rm tonistiigi/binfmt --install all
+EOF
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+detect_version() {
+    git -C "$PROJECT_ROOT" describe --tags --always --dirty 2>/dev/null || echo "0.0.0-local"
+}
+
+detect_repo() {
+    local url result
+    url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || echo "")
+    result=$(echo "$url" | sed -E 's|.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
+    if [[ "$result" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+        echo "$result"
+    else
+        echo ""
+    fi
+}
+
+require_docker() {
+    if ! command -v docker &>/dev/null; then
+        echo "error: docker not found — please install Docker" >&2
+        exit 1
+    fi
+}
+
+ensure_builder_image() {
+    echo "==> Building LXC builder image (obs-lxc-builder)..."
+    local no_cache_flag=()
+    [[ "$NO_CACHE" == "true" ]] && no_cache_flag=(--no-cache)
+    docker build "${no_cache_flag[@]}" \
+        --tag "$BUILDER_IMAGE" \
+        --file "$SCRIPT_DIR/Dockerfile.lxc-builder" \
+        "$SCRIPT_DIR"
+}
+
+check_privileged() {
+    if ! docker run --rm --privileged "$BUILDER_IMAGE" \
+        /bin/bash -c "mount -t tmpfs tmpfs /tmp && umount /tmp" >/dev/null 2>&1; then
+        echo "error: --privileged containers lack mount capability on this Docker setup." >&2
+        echo "       The LXC build needs it for debootstrap and chroot mounts." >&2
+        echo "       Likely cause: rootless Docker (check: docker info | grep -i rootless)." >&2
+        exit 1
+    fi
+}
+
+# ── Build functions ────────────────────────────────────────────────────────────
+build_docker() {
+    local version="$1"
+    require_docker
+    echo "==> Building Docker image ${IMAGE_NAME}:${version}..."
+
+    # Stamp obs/version and gui/package.json; restore both on exit
+    local orig_obs_version orig_pkg_json
+    orig_obs_version=$(cat "$PROJECT_ROOT/obs/version")
+    orig_pkg_json=$(cat "$PROJECT_ROOT/gui/package.json")
+    restore_stamps() {
+        echo "$orig_obs_version" > "$PROJECT_ROOT/obs/version"
+        printf '%s\n' "$orig_pkg_json" > "$PROJECT_ROOT/gui/package.json"
+    }
+    trap restore_stamps EXIT
+
+    local base rc
+    base=$(grep -m1 '^## ' "$PROJECT_ROOT/RELEASENOTES.md" | sed 's/^## *//')
+    rc=$(echo "$version" | grep -oP -- '-RC\d*$' || true)
+    echo "${base}${rc}" > "$PROJECT_ROOT/obs/version"
+    (command -v npm &>/dev/null && npm pkg set version="$version" --prefix "$PROJECT_ROOT/gui") || true
+
+    # Build via docker compose — reuses compose context, Dockerfile, and .env build args
+    docker compose --project-directory "$PROJECT_ROOT" build obs
+
+    restore_stamps
+    trap - EXIT
+
+    # If a custom image name or push was requested, retag the compose-built image
+    if [[ "$IMAGE_NAME" != "obs" ]] || [[ "$PUSH" == "true" ]]; then
+        local githash project_name src_image
+        githash=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "local")
+        project_name=$(cd "$PROJECT_ROOT" && docker compose config 2>/dev/null | awk '/^name:/{print $2; exit}')
+        src_image="${project_name}-obs:latest"
+
+        docker tag "$src_image" "${IMAGE_NAME}:${version}"
+        docker tag "$src_image" "${IMAGE_NAME}:${githash}"
+        if [[ "$PUSH" == "true" ]]; then
+            docker push "${IMAGE_NAME}:${version}"
+            docker push "${IMAGE_NAME}:${githash}"
+        fi
+        echo "==> Tagged: ${IMAGE_NAME}:${version}, ${IMAGE_NAME}:${githash}"
+    fi
+
+    echo "==> Docker image built successfully."
+}
+
+build_lxc() {
+    local version="$1" repo="$2"
+    require_docker
+    ensure_builder_image
+    check_privileged
+
+    local cache_dir="$HOME/.cache/obs-lxc-builder"
+    mkdir -p "$OUTPUT_DIR" "$cache_dir"
+    echo "==> Building LXC template version=${version}..."
+
+    docker run --rm --privileged \
+        --env VERSION="$version" \
+        --env REPO="$repo" \
+        --env NO_CACHE="$NO_CACHE" \
+        --volume "$PROJECT_ROOT:/workspace:ro" \
+        --volume "$OUTPUT_DIR:/output" \
+        --volume "$cache_dir:/cache" \
+        --volume "$SCRIPT_DIR/_lxc-inner.sh:/build-lxc.sh:ro" \
+        "$BUILDER_IMAGE" \
+        /bin/bash /build-lxc.sh
+
+    echo "==> LXC artifacts written to $OUTPUT_DIR"
+}
+
+build_bundle() {
+    local version="$1" repo="$2"
+    require_docker
+    ensure_builder_image
+
+    mkdir -p "$OUTPUT_DIR"
+    echo "==> Building app bundle version=${version}..."
+
+    docker run --rm \
+        --env VERSION="$version" \
+        --env REPO="$repo" \
+        --env BUNDLE_ONLY="true" \
+        --volume "$PROJECT_ROOT:/workspace:ro" \
+        --volume "$OUTPUT_DIR:/output" \
+        --volume "$SCRIPT_DIR/_lxc-inner.sh:/build-lxc.sh:ro" \
+        "$BUILDER_IMAGE" \
+        /bin/bash /build-lxc.sh
+
+    echo "==> Bundle artifacts written to $OUTPUT_DIR"
+}
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+COMMAND=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        docker|lxc|bundle|all)  COMMAND="$1"; shift ;;
+        --version)              VERSION="$2"; shift 2 ;;
+        --image)                IMAGE_NAME="$2"; shift 2 ;;
+        --push)                 PUSH=true; shift ;;
+        --repo)                 REPO="$2"; shift 2 ;;
+        --output)               OUTPUT_DIR="$2"; shift 2 ;;
+        --no-cache)             NO_CACHE=true; shift ;;
+        -h|--help)              usage; exit 0 ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 2 ;;
+    esac
+done
+
+if [[ -z "$COMMAND" ]]; then
+    echo "error: no command specified" >&2
+    usage >&2
+    exit 2
+fi
+
+# ── Resolve defaults ───────────────────────────────────────────────────────────
+[[ -z "$VERSION" ]] && VERSION=$(detect_version)
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(detect_repo)
+    if [[ -z "$REPO" ]]; then
+        echo "warning: could not auto-detect GitHub repo from git remote" >&2
+        echo "         obs-update will use placeholder — pass --repo owner/repo to fix" >&2
+        REPO="unknown/openbridgeserver"
+    fi
+fi
+
+echo "Version : $VERSION"
+[[ "$COMMAND" != "docker" ]] && echo "Repo    : $REPO"
+[[ "$COMMAND" != "docker" ]] && echo "Output  : $OUTPUT_DIR"
+echo ""
+
+# ── Dispatch ───────────────────────────────────────────────────────────────────
+case "$COMMAND" in
+    docker)
+        build_docker "$VERSION"
+        ;;
+    lxc)
+        build_lxc "$VERSION" "$REPO"
+        ;;
+    bundle)
+        build_bundle "$VERSION" "$REPO"
+        ;;
+    all)
+        build_docker "$VERSION"
+        build_lxc    "$VERSION" "$REPO"
+        echo ""
+        echo "==> All builds complete."
+        echo "    Docker : ${IMAGE_NAME}:${VERSION}"
+        echo "    LXC    : $OUTPUT_DIR"
+        ;;
+esac


### PR DESCRIPTION
Introduces tools/build-local.sh as a single entry point for building release artifacts locally. Only requirement is Docker — no host packages needed.

- tools/build-local.sh main script (docker / lxc / bundle / all)
- tools/Dockerfile.lxc-builder Ubuntu 24.04 builder image (debootstrap, Node 24, zstd)
- tools/_lxc-inner.sh inner build script that runs inside the privileged container, mirroring the steps of .github/workflows/lxc-template.yml

The docker subcommand builds via `docker compose build obs` (reuses the existing compose config and .env build args) with version stamping from git. The lxc subcommand runs debootstrap inside a --privileged container and caches the base system in ~/.cache/obs-lxc-builder/ to speed up repeated builds. The bundle subcommand builds only the app bundle without the rootfs.

Closes #694