### PR TITLE
fix(build): align LXC Python with Docker on 3.14

### DIFF
--- a/.github/BRANCH_PROTECTION_CHECKLIST.md
+++ b/.github/BRANCH_PROTECTION_CHECKLIST.md
@@ -16,8 +16,8 @@ Use this checklist to configure robust pull request safety for `main`.
 - [ ] Require status checks to pass before merging
 - [ ] Require branches to be up to date before merging
 - [ ] Select required checks (exact names from Actions):
-- [ ] `Tests (3.12)`
 - [ ] `Tests (3.13)`
+- [ ] `Tests (3.14)`
 - [ ] `Ruff`
 
 Optional, if enabled:

--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   TEMPLATE_NAME: openbridgeserver
-  BASE_OS: ubuntu-plucky
+  BASE_OS: ubuntu-resolute
 
 jobs:
   build:
@@ -57,6 +57,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y debootstrap zstd ubuntu-keyring
+          # Ubuntu releases all share the generic 'gutsy' debootstrap script.
+          # The runner's debootstrap may predate resolute (26.04); symlink it if missing.
+          if [[ ! -e /usr/share/debootstrap/scripts/resolute ]]; then
+            sudo ln -sf gutsy /usr/share/debootstrap/scripts/resolute
+          fi
 
       # ── Build GUI and frontend on the runner (no Node needed in the LXC) ─────
       - name: Setup Node.js
@@ -253,7 +258,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: base-system-cache.tar.zst
-          key: base-system-ubuntu-plucky-${{ matrix.arch }}-v1
+          key: base-system-ubuntu-resolute-${{ matrix.arch }}-v1
 
       - name: Create or restore base system
         run: |
@@ -272,15 +277,15 @@ jobs:
               --arch=${{ matrix.arch }} \
               --components=main,restricted,universe \
               --include=systemd,systemd-sysv,dbus,apt-utils,locales,iproute2,wget,curl,ca-certificates,less,logrotate,openssh-server,ifupdown \
-              plucky \
+              resolute \
               "$ROOTFS" \
               ${{ matrix.mirror }}
 
             # Write arch-specific sources.list before entering the chroot
             sudo tee "$ROOTFS/etc/apt/sources.list" > /dev/null <<SOURCES
-          deb ${{ matrix.mirror }} plucky main restricted universe multiverse
-          deb ${{ matrix.mirror }} plucky-updates main restricted universe multiverse
-          deb ${{ matrix.security_mirror }} plucky-security main restricted universe multiverse
+          deb ${{ matrix.mirror }} resolute main restricted universe multiverse
+          deb ${{ matrix.mirror }} resolute-updates main restricted universe multiverse
+          deb ${{ matrix.security_mirror }} resolute-security main restricted universe multiverse
           SOURCES
 
             sudo chroot "$ROOTFS" /bin/bash <<'BASESCRIPT'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload test results to Codecov
         uses: codecov/codecov-action@v6
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -533,12 +533,12 @@ RCs never receive the `latest` tag.
 
 ### LXC Template
 
-- Base OS: **Ubuntu 26.04 (Plucky)** — chosen for native Python 3.14 support
+- Base OS: **Ubuntu 26.04 LTS (Resolute)** — chosen for native Python 3.14 support
 - The build job runs as a **matrix** (two parallel jobs): `amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm` (native runner — no QEMU)
   - `amd64` uses `archive.ubuntu.com`; `arm64` uses `ports.ubuntu.com/ubuntu-ports` (including security updates)
 - Three release assets are produced:
-  - `ubuntu-plucky-openbridgeserver_<version>_amd64.tar.zst` — full Proxmox CT template (x86-64)
-  - `ubuntu-plucky-openbridgeserver_<version>_arm64.tar.zst` — full Proxmox CT template (ARM64)
+  - `openbridgeserver-lxc_<version>_amd64.tar.zst` — full Proxmox CT template (x86-64)
+  - `openbridgeserver-lxc_<version>_arm64.tar.zst` — full Proxmox CT template (ARM64)
   - `openbridgeserver-app-bundle_<version>.tar.gz` — arch-agnostic app archive (`obs/`, `gui_dist/`, `frontend_dist/`, `requirements.txt`, `obs-update`) used for in-place updates; built once from the amd64 job
 - App installs to `/opt/obs/`, Python venv at `/opt/obs/venv/`, data volume at `/data/`
 - Installed version tracked in `/opt/obs/version` (written by `obs-update` after each install)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1 (pre-implementation)  
 **Lizenz:** MIT  
-**Zielplattform:** Python 3.11+, Linux, ARM Cortex-A72 / x86_64  
+**Zielplattform:** Python 3.13+, Linux, ARM Cortex-A72 / x86_64  
 **Stand:** 2026-03-26
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # open bridge server — Multi-Stage Dockerfile (3 stages)
 # Stage 1 (node-builder):   npm install + vite build → gui_dist/ + frontend_dist/
 # Stage 2 (py-builder):     pip install Python deps
-# Stage 3 (runtime):        python:3.11-slim, copies all artefacts
+# Stage 3 (runtime):        python:3.14-slim, copies all artefacts
 #
 # Target: Linux x86_64 and ARM64 (Cortex-A72 / Raspberry Pi 4)
 # ---------------------------------------------------------------------------

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -19,7 +19,7 @@ Zielgruppe: Bestehende Timberwolf Server (TWS) Anwender und Neueinsteiger in der
 | Anforderung | Wert |
 |---|---|
 | Zielplattform | Linux, ARM Cortex-A72 (ARMv8-A) und x86_64 |
-| Programmiersprache | Python 3.11+ |
+| Programmiersprache | Python 3.13+ |
 | Max. DataPoints pro Instanz | 100'000 |
 | Lizenz | MIT (alle Komponenten) |
 | API-First | Web GUI nutzt ausschliesslich die öffentliche API |

--- a/README.de.md
+++ b/README.de.md
@@ -81,7 +81,7 @@ Das LXC-Template enthält ein vollständiges Ubuntu 26.04-System mit **open brid
 **Schritt 2 — Container erstellen**
 
 1. Im Proxmox-Menü **Create CT** wählen.
-2. Als Template das gerade heruntergeladene `ubuntu-plucky-openbridgeserver_…` auswählen.
+2. Als Template das gerade heruntergeladene `openbridgeserver-lxc_…` auswählen.
 3. Hostname, Passwort, CPU, RAM und Netzwerk nach Bedarf konfigurieren — empfohlen: mindestens 512 MB RAM.
 4. Container starten.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The LXC template contains a complete Ubuntu 26.04 system with **open bridge serv
 **Step 2 — Create the container**
 
 1. In the Proxmox menu, select **Create CT**.
-2. Choose the just-downloaded `ubuntu-plucky-openbridgeserver_…` as the template.
+2. Choose the just-downloaded `openbridgeserver-lxc_…` as the template.
 3. Configure hostname, password, CPU, RAM, and network as needed — recommended: at least 512 MB RAM.
 4. Start the container.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # open bridge server Dependencies
-# Python 3.11+
+# Python 3.13+
 
 # Web Framework
 fastapi>=0.136.1,<1       # pre-1.0; a 1.0 release may carry breaking changes

--- a/tools/_lxc-inner.sh
+++ b/tools/_lxc-inner.sh
@@ -12,7 +12,7 @@ ARCH=$(dpkg --print-architecture)
 TEMPLATE_NAME="openbridgeserver"
 TEMPLATE_FILE="${TEMPLATE_NAME}-lxc_${VERSION}_${ARCH}.tar.zst"
 APP_BUNDLE_FILE="${TEMPLATE_NAME}-app-bundle_${VERSION}.tar.gz"
-CACHE_FILE="/cache/base-system-ubuntu-plucky-${ARCH}.tar.zst"
+CACHE_FILE="/cache/base-system-ubuntu-resolute-${ARCH}.tar.zst"
 ROOTFS="/tmp/rootfs"
 
 if [[ "$ARCH" == "arm64" ]]; then
@@ -216,19 +216,24 @@ if [[ "$NO_CACHE" != "true" ]] && [[ -f "$CACHE_FILE" ]]; then
     echo "==> Restoring base system from cache (~/.cache/obs-lxc-builder)..."
     tar --zstd -xf "$CACHE_FILE" -C "$ROOTFS"
 else
-    echo "==> Running debootstrap for plucky/${ARCH} (this may take several minutes)..."
+    echo "==> Running debootstrap for resolute/${ARCH} (this may take several minutes)..."
+    # Ubuntu releases all share the generic 'gutsy' debootstrap script.
+    # The builder image's debootstrap may predate resolute (26.04); symlink it if missing.
+    if [[ ! -e /usr/share/debootstrap/scripts/resolute ]]; then
+        ln -sf gutsy /usr/share/debootstrap/scripts/resolute
+    fi
     debootstrap \
         --arch="$ARCH" \
         --components=main,restricted,universe \
         --include=systemd,systemd-sysv,dbus,apt-utils,locales,iproute2,wget,curl,ca-certificates,less,logrotate,openssh-server,ifupdown \
-        plucky \
+        resolute \
         "$ROOTFS" \
         "$MIRROR"
 
     tee "$ROOTFS/etc/apt/sources.list" > /dev/null << SOURCES
-deb $MIRROR plucky main restricted universe multiverse
-deb $MIRROR plucky-updates main restricted universe multiverse
-deb $SECURITY_MIRROR plucky-security main restricted universe multiverse
+deb $MIRROR resolute main restricted universe multiverse
+deb $MIRROR resolute-updates main restricted universe multiverse
+deb $SECURITY_MIRROR resolute-security main restricted universe multiverse
 SOURCES
 
     chroot "$ROOTFS" /bin/bash << 'BASESCRIPT'


### PR DESCRIPTION
The Docker image ships Python 3.14 (python:3.14-slim) but the LXC template debootstrapped Ubuntu plucky (25.04), whose native python3 is 3.13. Bump the LXC base to resolute (Ubuntu 26.04 LTS), which provides Python 3.14 natively — matching the runtime image without a third-party PPA (deadsnakes does not publish for plucky).

- lxc-template.yml + _lxc-inner.sh: plucky -> resolute (suite, sources.list, cache key); add gutsy->resolute debootstrap-script symlink fallback for older debootstrap on the runner/builder
- unittest.yml: test matrix 3.12,3.13 -> 3.13,3.14; move Codecov upload to the shipped 3.14 runtime
- docs: state Python 3.13+ floor consistently (requirements.txt, PROJECT_SPEC.md, ARCHITECTURE.md, AGENTS.MD), fix template asset names, update branch-protection check names