### PR TITLE
ci(nightly): publish nightly LXC builds as dated GitHub pre-releases

### DIFF
--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -4,8 +4,7 @@ on:
   push:
     tags:
       - '*'
-    tags-ignore:
-      - 'nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
+      - '!nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
 
   workflow_dispatch:
 

--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -4,7 +4,9 @@ on:
   push:
     tags:
       - '*'
-      - '!nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
+    tags-ignore:
+      - 'nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
+
   workflow_dispatch:
 
 env:

--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+      - '!nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
   workflow_dispatch:
 
 env:

--- a/.github/workflows/nightly-lxc.yml
+++ b/.github/workflows/nightly-lxc.yml
@@ -159,3 +159,26 @@ jobs:
               gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag
             fi
           done < releases.tsv
+
+      - name: Delete dispatched run artifacts
+        # The .tar.zst / .tar.gz / .sha512 files now live on the nightly
+        # pre-release, so the source Actions artifacts are redundant. Delete
+        # them to avoid storage growth (lxc-template.yml sets no retention-days,
+        # so they would otherwise linger at the repo default ~90 days).
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.watch.outputs.run_id }}
+        run: |
+          set -euo pipefail
+
+          gh api --paginate "/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+            --jq '.artifacts[] | [.id, .name] | @tsv' \
+            > run-artifacts.tsv
+
+          while IFS=$'\t' read -r ARTIFACT_ID ARTIFACT_NAME; do
+            [[ -z "$ARTIFACT_ID" ]] && continue
+            echo "Deleting dispatched-run artifact ${ARTIFACT_NAME} (${ARTIFACT_ID})"
+            gh api --method DELETE "/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}"
+          done < run-artifacts.tsv

--- a/.github/workflows/nightly-lxc.yml
+++ b/.github/workflows/nightly-lxc.yml
@@ -101,6 +101,13 @@ jobs:
 
           TAG="nightly-$(date -u +%Y%m%d)"
           DAY="$(date -u +%Y-%m-%d)"
+          RUN_ID="${{ steps.watch.outputs.run_id }}"
+          TARGET_SHA="$(gh run view "$RUN_ID" --repo "$REPO" --json headSha --jq .headSha)"
+
+          if [[ -z "$TARGET_SHA" ]]; then
+            echo "Could not determine commit SHA for run ${RUN_ID}; aborting." >&2
+            exit 1
+          fi
 
           mapfile -t ASSETS < <(find artifacts -type f \
             \( -name '*.tar.zst' -o -name '*.tar.gz' -o -name '*.sha512' \) | sort)
@@ -116,8 +123,9 @@ jobs:
 
           gh release create "$TAG" \
             --repo "$REPO" \
+            --target "$TARGET_SHA" \
             --title "Nightly $DAY" \
-            --notes "Automated nightly LXC template + app-bundle build for ${DAY} (commit ${GITHUB_SHA}). Pre-release — not for production use." \
+            --notes "Automated nightly LXC template + app-bundle build for ${DAY} (commit ${TARGET_SHA}). Pre-release — not for production use." \
             --prerelease \
             "${ASSETS[@]}"
 

--- a/.github/workflows/nightly-lxc.yml
+++ b/.github/workflows/nightly-lxc.yml
@@ -144,11 +144,8 @@ jobs:
 
           CUTOFF_EPOCH="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
 
-          gh release list \
-            --repo "$REPO" \
-            --limit 200 \
-            --json tagName,createdAt \
-            --jq '.[] | select(.tagName | startswith("nightly-")) | [.tagName, .createdAt] | @tsv' \
+          gh api --paginate "/repos/${REPO}/releases?per_page=100" \
+            --jq '.[] | select(.tag_name | startswith("nightly-")) | [.tag_name, .created_at] | @tsv' \
             > releases.tsv
 
           while IFS=$'\t' read -r TAG CREATED_AT; do

--- a/.github/workflows/nightly-lxc.yml
+++ b/.github/workflows/nightly-lxc.yml
@@ -119,9 +119,9 @@ jobs:
 
           # Re-runs on the same day (e.g. manual + scheduled) replace that day's
           # nightly release instead of failing on an existing tag.
-if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-  gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag
-fi
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag
+          fi
 
           gh release create "$TAG" \
             --repo "$REPO" \

--- a/.github/workflows/nightly-lxc.yml
+++ b/.github/workflows/nightly-lxc.yml
@@ -7,14 +7,15 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
 
 concurrency:
   group: nightly-lxc
   cancel-in-progress: false
 
 env:
-  LXC_ARTIFACT_RETENTION_DAYS: 14
+  # How many days of nightly pre-releases to keep (one release per day).
+  NIGHTLY_RETENTION_DAYS: 14
 
 jobs:
   dispatch:
@@ -38,6 +39,7 @@ jobs:
           echo "dispatch_ts=$DISPATCH_TS" >> "$GITHUB_OUTPUT"
 
       - name: Wait for dispatched build to finish
+        id: watch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -61,37 +63,91 @@ jobs:
           done
 
           if [[ -z "$RUN_ID" ]]; then
-            echo "Could not locate the dispatched lxc-template run; skipping prune." >&2
+            echo "Could not locate the dispatched lxc-template run; aborting." >&2
             exit 1
           fi
 
           echo "Watching lxc-template run ${RUN_ID}"
           # --exit-status makes this step fail if the build concluded in failure,
-          # which short-circuits the prune step below.
+          # which short-circuits the publish/prune steps below.
           gh run watch "$RUN_ID" --repo "$REPO" --exit-status --interval 30
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Prune old LXC artifacts
-        # Only runs when the dispatched build succeeded (previous steps green).
-        # This guarantees we never delete the last good nightly artifacts during
-        # a prolonged build outage.
+      - name: Download build artifacts from dispatched run
         if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          RETENTION_DAYS: ${{ env.LXC_ARTIFACT_RETENTION_DAYS }}
+          RUN_ID: ${{ steps.watch.outputs.run_id }}
+        run: |
+          set -euo pipefail
+
+          rm -rf artifacts
+          # Grabs all artifacts of the run (lxc-amd64, lxc-arm64, app-bundle),
+          # each into its own subdirectory under artifacts/.
+          gh run download "$RUN_ID" --repo "$REPO" --dir artifacts
+          echo "Downloaded artifacts:"
+          find artifacts -type f -printf '  %p\n'
+
+      - name: Publish nightly release
+        # Date-based, addressable pre-release so users get a stable download URL
+        # per build instead of having to dig through Actions artifacts.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          TAG="nightly-$(date -u +%Y%m%d)"
+          DAY="$(date -u +%Y-%m-%d)"
+
+          mapfile -t ASSETS < <(find artifacts -type f \
+            \( -name '*.tar.zst' -o -name '*.tar.gz' -o -name '*.sha512' \) | sort)
+
+          if [[ ${#ASSETS[@]} -eq 0 ]]; then
+            echo "No build assets found to publish." >&2
+            exit 1
+          fi
+
+          # Re-runs on the same day (e.g. manual + scheduled) replace that day's
+          # nightly release instead of failing on an existing tag.
+          gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag 2>/dev/null || true
+
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "Nightly $DAY" \
+            --notes "Automated nightly LXC template + app-bundle build for ${DAY} (commit ${GITHUB_SHA}). Pre-release — not for production use." \
+            --prerelease \
+            "${ASSETS[@]}"
+
+          echo "Published $TAG with ${#ASSETS[@]} assets."
+
+      - name: Prune old nightly releases
+        # Only runs when the build and publish succeeded, so a failed nightly
+        # never deletes previously published nightly releases.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RETENTION_DAYS: ${{ env.NIGHTLY_RETENTION_DAYS }}
         run: |
           set -euo pipefail
 
           CUTOFF_EPOCH="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
-          gh api --paginate "/repos/${REPO}/actions/artifacts?per_page=100" \
-            --jq '.artifacts[] | select((.name == "lxc-amd64") or (.name == "lxc-arm64") or (.name == "app-bundle")) | [.id, .created_at, .name] | @tsv' \
-            > artifacts.tsv
 
-          while IFS=$'\t' read -r ARTIFACT_ID CREATED_AT ARTIFACT_NAME; do
-            [[ -z "$ARTIFACT_ID" ]] && continue
+          gh release list \
+            --repo "$REPO" \
+            --limit 200 \
+            --json tagName,createdAt \
+            --jq '.[] | select(.tagName | startswith("nightly-")) | [.tagName, .createdAt] | @tsv' \
+            > releases.tsv
+
+          while IFS=$'\t' read -r TAG CREATED_AT; do
+            [[ -z "$TAG" ]] && continue
             CREATED_EPOCH="$(date -u -d "$CREATED_AT" +%s)"
             if (( CREATED_EPOCH < CUTOFF_EPOCH )); then
-              echo "Deleting old LXC artifact ${ARTIFACT_NAME} (${ARTIFACT_ID}) from ${CREATED_AT}"
-              gh api --method DELETE "/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}"
+              echo "Deleting old nightly release ${TAG} (created ${CREATED_AT})"
+              gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag
             fi
-          done < artifacts.tsv
+          done < releases.tsv

--- a/.github/workflows/nightly-lxc.yml
+++ b/.github/workflows/nightly-lxc.yml
@@ -119,7 +119,9 @@ jobs:
 
           # Re-runs on the same day (e.g. manual + scheduled) replace that day's
           # nightly release instead of failing on an existing tag.
-          gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag 2>/dev/null || true
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+  gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag
+fi
 
           gh release create "$TAG" \
             --repo "$REPO" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,7 @@ on:
   push:
     tags:
       - '*'
-    tags-ignore:
-      - 'nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
+      - '!nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: "Release"
 
 on:
-on:
   push:
     tags:
       - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: "Release"
 
 on:
+on:
   push:
     tags:
       - '*'
-      - '!nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
+    tags-ignore:
+      - 'nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+      - '!nightly-*'  # nightly-lxc.yml creates these; must not trigger a real release/build
 
 permissions: {}
 


### PR DESCRIPTION
The nightly LXC build only existed as ephemeral Actions artifacts, reachable solely through the Actions UI and gone after 14 days. Users had no stable, linkable way to download a specific nightly template.

Publish each nightly build as a date-tagged GitHub pre-release instead:

- nightly-lxc.yml: after the dispatched lxc-template build succeeds, download its artifacts and create a `nightly-YYYYMMDD` pre-release with the .tar.zst templates, app-bundle and .sha512 checksums. Same-day re-runs replace that day's release. Retention now prunes nightly pre-releases older than 14 days instead of pruning artifacts; add `contents: write`.
- release.yml / lxc-template.yml: exclude `nightly-*` tags from their `push: tags` triggers so a nightly tag can never fire a real release or a duplicate template build, independent of which token created it.

Nightly releases are marked --prerelease and tagged `nightly-*`, so the in-LXC `obs-update` picker (semver-only) ignores them.