### PR TITLE
Fix WebSocket initial values after subscribe

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -112,6 +112,7 @@
 * Test stability: Monitor/Ringbuffer E2E scenarios stabilized. https://github.com/abeggled/openbridgeserver/pull/494
 * Visu: Internal API base URL usage fixed for E2E/runtime alignment. https://github.com/abeggled/openbridgeserver/pull/484
 * Visu: History widget now updates automatically when new values arrive via WebSocket. https://github.com/abeggled/openbridgeserver/issues/408
+* Visu: WebSocket subscriptions now immediately receive the current registry values, so viewers show values again right after reconnects or page changes instead of waiting for the next adapter poll. https://github.com/abeggled/openbridgeserver/issues/749
 * Visu: History widget now uses aggregated history buckets for multi-day ranges, so periods up to "last 90 days" remain complete and render efficiently instead of only showing the newest 24 hours. https://github.com/abeggled/openbridgeserver/issues/692
 * Visu: RTR Widget now use correct values for room controller (heating) DPT 20.102 https://github.com/abeggled/openbridgeserver/issues/461
 * Visu: Floorplan Widget: positioning broken if floorplan is rotated https://github.com/abeggled/openbridgeserver/issues/440

--- a/obs/api/v1/websocket.py
+++ b/obs/api/v1/websocket.py
@@ -107,6 +107,43 @@ class WebSocketManager:
         if conn_id in self._connections:
             self._connections[conn_id][1].difference_update(dp_ids)
 
+    async def send_initial_values(self, conn_id: str, dp_ids: list[str]) -> None:
+        """Send current registry values for subscribed datapoints."""
+        from obs.core.registry import get_registry
+
+        try:
+            reg = get_registry()
+        except RuntimeError:
+            return
+
+        dead = False
+        for dp_id in dp_ids:
+            try:
+                dp_uuid = uuid.UUID(dp_id)
+            except (TypeError, ValueError):
+                continue
+
+            dp = reg.get(dp_uuid)
+            state = reg.get_value(dp_uuid)
+            if dp is None or state is None:
+                continue
+
+            ts = state.ts
+            ts_str = ts.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+            msg = {
+                "id": str(dp_uuid),
+                "v": jsonable(state.value),
+                "u": dp.unit,
+                "t": ts_str,
+                "q": state.quality,
+            }
+            if not await self._send(conn_id, msg):
+                dead = True
+                break
+
+        if dead:
+            await self.disconnect(conn_id)
+
     async def _send(self, conn_id: str, msg: dict) -> bool:
         """Send *msg* to one connection, serialised via its per-connection lock.
 
@@ -196,7 +233,7 @@ class WebSocketManager:
             "unit": dp.unit if dp else None,
         }
         metadata: dict[str, Any] | None = None
-        if any(allowed_ids is None for _, _, _, allowed_ids in self._connections.values()):
+        if any(allowed_ids is None for _, _, _, allowed_ids, _, _ in self._connections.values()):
             from obs.ringbuffer.ringbuffer import build_ringbuffer_metadata_snapshot
 
             metadata = await build_ringbuffer_metadata_snapshot(
@@ -627,7 +664,9 @@ async def websocket_endpoint(
                 manager.subscribe(conn_id, ids)
                 after = manager.subscriptions(conn_id)
                 added = [i for i in ids if i in after and i not in before]
+                subscribed = [i for i in ids if i in after]
                 await ws.send_json({"action": "subscribed", "ids": added})
+                await manager.send_initial_values(conn_id, subscribed)
 
             elif action == "unsubscribe":
                 ids = [str(i) for i in data.get("ids", [])]

--- a/tests/unit/test_websocket_auth.py
+++ b/tests/unit/test_websocket_auth.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
 import pytest
 from fastapi import HTTPException, WebSocketDisconnect
 
@@ -14,6 +18,7 @@ class _FakeWebSocket:
         headers: dict[str, str] | None = None,
         query_params: dict[str, str] | None = None,
         subprotocols: list[str] | None = None,
+        received: list[dict] | None = None,
     ) -> None:
         self.headers = headers or {}
         self.query_params = query_params or {}
@@ -21,6 +26,8 @@ class _FakeWebSocket:
         self.accepted = False
         self.accepted_subprotocol: str | None = None
         self.close_calls: list[tuple[int | None, str | None]] = []
+        self.received = received or []
+        self.sent: list[dict] = []
 
     async def accept(self, subprotocol: str | None = None) -> None:
         self.accepted = True
@@ -30,10 +37,12 @@ class _FakeWebSocket:
         self.close_calls.append((code, reason))
 
     async def receive_json(self) -> dict:
+        if self.received:
+            return self.received.pop(0)
         raise WebSocketDisconnect()
 
-    async def send_json(self, _msg: dict) -> None:
-        return None
+    async def send_json(self, msg: dict) -> None:
+        self.sent.append(msg)
 
 
 class _DbStub:
@@ -128,6 +137,51 @@ async def test_websocket_endpoint_accepts_api_key(monkeypatch):
 
     assert ws.accepted is True
     assert db.updated is True
+
+
+@pytest.mark.asyncio
+async def test_websocket_endpoint_subscribe_sends_initial_registry_value(monkeypatch):
+    dp_id = uuid4()
+    monkeypatch.setattr(auth_api, "hash_api_key", lambda key: f"hash:{key}")
+    monkeypatch.setattr(ws_api, "get_db", lambda: _DbStub(has_key=True))
+
+    class _RegistryStub:
+        def get(self, dp_uuid):
+            if dp_uuid == dp_id:
+                return SimpleNamespace(unit="W")
+            return None
+
+        def get_value(self, dp_uuid):
+            if dp_uuid == dp_id:
+                return SimpleNamespace(
+                    value=17.25,
+                    quality="good",
+                    ts=datetime(2026, 6, 8, 9, 10, 11, 456000, tzinfo=UTC),
+                )
+            return None
+
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _RegistryStub())
+
+    ws = _FakeWebSocket(
+        headers={"x-api-key": "obs_valid"},
+        received=[{"action": "subscribe", "ids": [str(dp_id)]}],
+    )
+    ws_api.init_ws_manager()
+    try:
+        await ws_api.websocket_endpoint(ws)
+    finally:
+        ws_api.reset_ws_manager()
+
+    assert ws.sent == [
+        {"action": "subscribed", "ids": [str(dp_id)]},
+        {
+            "id": str(dp_id),
+            "v": 17.25,
+            "u": "W",
+            "t": "2026-06-08T09:10:11.456Z",
+            "q": "good",
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_websocket_ringbuffer_contract.py
+++ b/tests/unit/test_websocket_ringbuffer_contract.py
@@ -199,6 +199,81 @@ async def test_subscribe_filters_datapoints_for_page_scoped_connection():
 
 
 @pytest.mark.asyncio
+async def test_subscribe_initial_values_sends_current_registry_snapshot(monkeypatch):
+    dp_id = uuid4()
+    other_dp_id = uuid4()
+    ws = _FakeWebSocket()
+    manager = WebSocketManager()
+    conn_id = await manager.connect(ws)
+
+    class _RegistryStub:
+        def get(self, dp_uuid):
+            if dp_uuid == dp_id:
+                return SimpleNamespace(unit="W")
+            return None
+
+        def get_value(self, dp_uuid):
+            if dp_uuid == dp_id:
+                return SimpleNamespace(
+                    value=42.5,
+                    quality="good",
+                    ts=datetime(2026, 6, 8, 9, 10, 11, 123000, tzinfo=UTC),
+                )
+            return None
+
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _RegistryStub())
+
+    manager.subscribe(conn_id, [str(dp_id), str(other_dp_id), "not-a-uuid"])
+    await manager.send_initial_values(conn_id, [str(dp_id), str(other_dp_id), "not-a-uuid"])
+
+    assert ws.messages == [
+        {
+            "id": str(dp_id),
+            "v": 42.5,
+            "u": "W",
+            "t": "2026-06-08T09:10:11.123Z",
+            "q": "good",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_initial_values_respects_page_scope(monkeypatch):
+    allowed_uuid = uuid4()
+    blocked_uuid = uuid4()
+    allowed_id = str(allowed_uuid)
+    blocked_id = str(blocked_uuid)
+    ws = _FakeWebSocket()
+    manager = WebSocketManager()
+    conn_id = await manager.connect(ws, allowed_dp_ids={allowed_id})
+
+    class _RegistryStub:
+        def get(self, dp_uuid):
+            if dp_uuid in {allowed_uuid, blocked_uuid}:
+                return SimpleNamespace(unit="W")
+            return None
+
+        def get_value(self, dp_uuid):
+            if dp_uuid in {allowed_uuid, blocked_uuid}:
+                return SimpleNamespace(
+                    value=str(dp_uuid),
+                    quality="good",
+                    ts=datetime(2026, 6, 8, 9, 10, 11, 123000, tzinfo=UTC),
+                )
+            return None
+
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _RegistryStub())
+
+    before = manager.subscriptions(conn_id)
+    manager.subscribe(conn_id, [allowed_id, blocked_id])
+    after = manager.subscriptions(conn_id)
+    added = [dp_id for dp_id in [allowed_id, blocked_id] if dp_id in after and dp_id not in before]
+    await manager.send_initial_values(conn_id, added)
+
+    assert [msg["id"] for msg in ws.messages] == [allowed_id]
+
+
+@pytest.mark.asyncio
 async def test_ringbuffer_push_is_scoped_for_anonymous_page_connections(monkeypatch):
     allowed_uuid = uuid4()
     blocked_uuid = uuid4()


### PR DESCRIPTION
## Summary
- send current registry values immediately after accepted WebSocket subscriptions
- keep page-scoped WebSocket subscriptions restricted to allowed datapoints
- add release note for issue #749

Closes #749

## Tests
- `.venv/bin/pytest tests/unit/test_websocket_ringbuffer_contract.py tests/unit/test_websocket_auth.py`
- `git diff --check`