### PR TITLE
fix: handle invalid adapter bindings

### DIFF
--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -123,6 +123,9 @@
       "uncertain": "Unbekannt",
       "bad": "Schlecht"
     },
+    "diagnostics": {
+      "typeMismatch": "Typkonflikt: erwartet {expected}, erhalten {got} von {source} ({count}x)"
+    },
     "detail": {
       "backToList": "← Objekte",
       "currentValue": "Aktueller Wert",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -123,6 +123,9 @@
       "uncertain": "Unknown",
       "bad": "Bad"
     },
+    "diagnostics": {
+      "typeMismatch": "Type mismatch: expected {expected}, got {got} from {source} ({count}x)"
+    },
     "detail": {
       "backToList": "← Data points",
       "currentValue": "Current value",

--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -339,9 +339,20 @@
               </td>
 
               <td>
-                <Badge :variant="qualityVariant(liveQuality(dp))" dot size="xs">
-                  {{ qualityLabel(liveQuality(dp)) ?? '—' }}
-                </Badge>
+                <div class="flex items-center gap-1">
+                  <Badge :variant="qualityVariant(liveQuality(dp))" dot size="xs">
+                    {{ qualityLabel(liveQuality(dp)) ?? '—' }}
+                  </Badge>
+                  <Badge
+                    v-if="typeMismatchDiagnostic(dp)"
+                    variant="warning"
+                    size="xs"
+                    v-bind="typeMismatchAttrs(typeMismatchDiagnostic(dp))"
+                    :data-testid="`dp-type-mismatch-${dp.id}`"
+                  >
+                    !
+                  </Badge>
+                </div>
               </td>
 
               <td>
@@ -767,5 +778,18 @@ function qualityVariant(q) {
 }
 function qualityLabel(q) {
   return q === 'good' ? t('datapoints.quality.good') : q === 'bad' ? t('datapoints.quality.bad') : q === 'uncertain' ? t('datapoints.quality.uncertain') : q
+}
+function typeMismatchDiagnostic(dp) {
+  return dp.diagnostics?.find(d => d.type === 'type_mismatch') ?? null
+}
+function typeMismatchAttrs(diagnostic) {
+  return {
+    title: t('datapoints.diagnostics.typeMismatch', {
+    expected: diagnostic.expected ?? '—',
+    got: diagnostic.got ?? '—',
+    source: diagnostic.source_adapter ?? '—',
+    count: diagnostic.count ?? 1,
+    }),
+  }
 }
 </script>

--- a/gui/tests/views/DataPointsView.hierarchy.spec.js
+++ b/gui/tests/views/DataPointsView.hierarchy.spec.js
@@ -203,4 +203,33 @@ describe('DataPointsView hierarchy rendering', () => {
     expect(wrapper.findAll('[title="Haus › Gebäude A › EG › Küche"]').length).toBeGreaterThanOrEqual(1)
     expect(wrapper.findAll('[title="Haus › Gebäude B › EG › Küche"]').length).toBeGreaterThanOrEqual(1)
   })
+
+  it('shows a warning badge when a datapoint has a type mismatch diagnostic', async () => {
+    const { wrapper } = await mountDataPointsView({
+      items: [
+        {
+          id: 'dp-mismatch',
+          name: 'Deye/Micro/Status',
+          data_type: 'FLOAT',
+          tags: [],
+          value: 'online',
+          quality: 'good',
+          diagnostics: [
+            {
+              type: 'type_mismatch',
+              expected: 'float',
+              got: 'str',
+              source_adapter: 'MQTT',
+              count: 3,
+            },
+          ],
+        },
+      ],
+    })
+
+    const badge = wrapper.find('[data-testid="dp-type-mismatch-dp-mismatch"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.attributes('title')).toContain('float')
+    expect(badge.attributes('title')).toContain('str')
+  })
 })

--- a/gui/tests/views/DataPointsView.hierarchy.spec.js
+++ b/gui/tests/views/DataPointsView.hierarchy.spec.js
@@ -232,4 +232,34 @@ describe('DataPointsView hierarchy rendering', () => {
     expect(badge.attributes('title')).toContain('float')
     expect(badge.attributes('title')).toContain('str')
   })
+
+  it('uses fallback text for incomplete type mismatch diagnostics', async () => {
+    const { wrapper } = await mountDataPointsView({
+      items: [
+        {
+          id: 'dp-without-diagnostic',
+          name: 'Normal',
+          data_type: 'FLOAT',
+          tags: [],
+          value: 21.5,
+          quality: 'good',
+        },
+        {
+          id: 'dp-incomplete-diagnostic',
+          name: 'Incomplete',
+          data_type: 'FLOAT',
+          tags: [],
+          value: 'online',
+          quality: 'good',
+          diagnostics: [{ type: 'type_mismatch' }],
+        },
+      ],
+    })
+
+    expect(wrapper.find('[data-testid="dp-type-mismatch-dp-without-diagnostic"]').exists()).toBe(false)
+    const badge = wrapper.find('[data-testid="dp-type-mismatch-dp-incomplete-diagnostic"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.attributes('title')).toContain('—')
+    expect(badge.attributes('title')).toContain('1')
+  })
 })

--- a/obs/adapters/registry.py
+++ b/obs/adapters/registry.py
@@ -11,12 +11,21 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 _adapters: dict[str, type] = {}  # adapter_type → AdapterBase Klasse
 _instances: dict[str, Any] = {}  # instance_id (str) → laufende Instanz
+_BINDING_LOAD_DETAIL_PREFIX = "Invalid adapter bindings skipped"
+
+
+@dataclass(frozen=True)
+class BindingLoadIssue:
+    binding_id: str
+    adapter_instance_id: str | None
+    reason: str
 
 
 # ---------------------------------------------------------------------------
@@ -93,14 +102,14 @@ async def start_all(event_bus: Any, db: Any, value_getter: Any = None) -> None:
                 "SELECT * FROM adapter_bindings WHERE adapter_instance_id=? AND enabled=1",
                 (instance_id,),
             )
-            bindings = [_row_to_binding(r) for r in binding_rows]
-            await instance.reload_bindings(bindings)
+            bindings, issues = await reload_instance_from_rows(instance, binding_rows)
 
             logger.info(
-                "Adapter gestartet: %s '%s' (%d Bindings)",
+                "Adapter gestartet: %s '%s' (%d Bindings, %d invalid skipped)",
                 adapter_type,
                 row["name"],
                 len(bindings),
+                len(issues),
             )
         except Exception:
             logger.exception("Fehler beim Starten von Adapter %s '%s'", adapter_type, row["name"])
@@ -205,14 +214,14 @@ async def restart_instance(instance_id: str, event_bus: Any, db: Any, value_gett
             "SELECT * FROM adapter_bindings WHERE adapter_instance_id=? AND enabled=1",
             (instance_id,),
         )
-        bindings = [_row_to_binding(r) for r in binding_rows]
-        await instance.reload_bindings(bindings)
+        bindings, issues = await reload_instance_from_rows(instance, binding_rows)
 
         logger.info(
-            "Adapter neu gestartet: %s '%s' (%d Bindings)",
+            "Adapter neu gestartet: %s '%s' (%d Bindings, %d invalid skipped)",
             row["adapter_type"],
             row["name"],
             len(bindings),
+            len(issues),
         )
         return instance
     except Exception:
@@ -254,8 +263,7 @@ async def reload_instance_bindings(instance_id: str, db: Any) -> None:
         "SELECT * FROM adapter_bindings WHERE adapter_instance_id=? AND enabled=1",
         (instance_id,),
     )
-    bindings = [_row_to_binding(r) for r in binding_rows]
-    await instance.reload_bindings(bindings)
+    await reload_instance_from_rows(instance, binding_rows)
 
 
 # ---------------------------------------------------------------------------
@@ -291,3 +299,66 @@ def _row_to_binding(row: Any) -> Any:
         created_at=datetime.fromisoformat(row["created_at"]),
         updated_at=datetime.fromisoformat(row["updated_at"]),
     )
+
+
+def load_valid_bindings(rows: list[Any]) -> tuple[list[Any], list[BindingLoadIssue]]:
+    """Convert DB rows to bindings, skipping malformed rows one-by-one."""
+    bindings: list[Any] = []
+    issues: list[BindingLoadIssue] = []
+    for row in rows:
+        try:
+            bindings.append(_row_to_binding(row))
+        except Exception as exc:
+            issue = BindingLoadIssue(
+                binding_id=_row_value(row, "id") or "<unknown>",
+                adapter_instance_id=_row_value(row, "adapter_instance_id"),
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+            issues.append(issue)
+            logger.error(
+                "Invalid adapter binding skipped: id=%s instance=%s reason=%s",
+                issue.binding_id,
+                issue.adapter_instance_id,
+                issue.reason,
+            )
+    return bindings, issues
+
+
+async def reload_instance_from_rows(instance: Any, rows: list[Any]) -> tuple[list[Any], list[BindingLoadIssue]]:
+    bindings, issues = load_valid_bindings(rows)
+    await instance.reload_bindings(bindings)
+    await _publish_binding_load_status(instance, issues)
+    return bindings, issues
+
+
+async def _publish_binding_load_status(instance: Any, issues: list[BindingLoadIssue]) -> None:
+    if not issues:
+        if getattr(instance, "last_detail", "").startswith(_BINDING_LOAD_DETAIL_PREFIX):
+            await _set_instance_status(instance, "ok", "")
+        return
+
+    detail = _format_binding_load_detail(issues)
+    await _set_instance_status(instance, "warning", detail)
+
+
+def _format_binding_load_detail(issues: list[BindingLoadIssue]) -> str:
+    examples = "; ".join(f"{i.binding_id}: {i.reason}" for i in issues[:3])
+    suffix = f"; +{len(issues) - 3} more" if len(issues) > 3 else ""
+    return f"{_BINDING_LOAD_DETAIL_PREFIX}: {len(issues)} invalid binding(s) skipped ({examples}{suffix})"
+
+
+async def _set_instance_status(instance: Any, severity: str, detail: str) -> None:
+    publish = getattr(instance, "_publish_status", None)
+    if publish is not None:
+        await publish(getattr(instance, "connected", False), detail=detail, severity=severity)
+        return
+    instance._last_severity = severity
+    instance._last_detail = detail
+
+
+def _row_value(row: Any, key: str) -> str | None:
+    try:
+        value = row[key]
+    except Exception:
+        return None
+    return str(value) if value is not None else None

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -76,17 +76,9 @@ async def _get_bindings_for_dp(db: Database, dp_id: uuid.UUID) -> list[BindingOu
 
 async def _reload_adapter_instance(instance_id: str, db: Database) -> None:
     """Laufende Adapter-Instanz über ihre Bindings aus DB informieren."""
-    from obs.adapters.registry import _row_to_binding, get_instance_by_id
+    from obs.adapters import registry as adapter_registry
 
-    instance = get_instance_by_id(instance_id)
-    if instance is None:
-        return
-    rows = await db.fetchall(
-        "SELECT * FROM adapter_bindings WHERE adapter_instance_id=? AND enabled=1",
-        (instance_id,),
-    )
-    bindings = [_row_to_binding(r) for r in rows]
-    await instance.reload_bindings(bindings)
+    await adapter_registry.reload_instance_bindings(instance_id, db)
 
 
 def _row_out(row: Any, name_map: dict[str, str] | None = None) -> BindingOut:

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -54,6 +54,16 @@ class HierarchyNodeRef(BaseModel):
     display_depth: int = 0
 
 
+class DataPointDiagnostic(BaseModel):
+    type: str
+    expected: str | None = None
+    got: str | None = None
+    source_adapter: str | None = None
+    count: int = 1
+    last_value: Any = None
+    updated_at: str | None = None
+
+
 class DataPointOut(BaseModel):
     id: uuid.UUID
     name: str
@@ -69,6 +79,7 @@ class DataPointOut(BaseModel):
     # Runtime
     value: Any = None
     quality: str | None = None
+    diagnostics: list[DataPointDiagnostic] = []
     # Hierarchy (populated by search endpoint, empty elsewhere)
     hierarchy_nodes: list[HierarchyNodeRef] = []
 
@@ -166,6 +177,7 @@ def _enrich(dp: Any) -> DataPointOut:
         updated_at=dp.updated_at.isoformat(),
         value=state.value if state else None,
         quality=state.quality if state else None,
+        diagnostics=list(state.diagnostics.values()) if state else [],
     )
 
 

--- a/obs/api/v1/knxproj.py
+++ b/obs/api/v1/knxproj.py
@@ -230,15 +230,9 @@ async def _bulk_import_datapoints(
 
     # --- Adapter-Instanz neu laden ---
     try:
-        from obs.adapters.registry import _row_to_binding, get_instance_by_id
+        from obs.adapters.registry import reload_instance_bindings
 
-        adapter_instance = get_instance_by_id(adapter_instance_id)
-        if adapter_instance:
-            binding_rows = await db.fetchall(
-                "SELECT * FROM adapter_bindings WHERE adapter_instance_id=? AND enabled=1",
-                (adapter_instance_id,),
-            )
-            await adapter_instance.reload_bindings([_row_to_binding(r) for r in binding_rows])
+        await reload_instance_bindings(adapter_instance_id, db)
     except Exception:
         pass  # Adapter nicht geladen — kein Fehler
 

--- a/obs/core/registry.py
+++ b/obs/core/registry.py
@@ -32,13 +32,14 @@ logger = logging.getLogger(__name__)
 
 
 class ValueState:
-    __slots__ = ("old_value", "quality", "ts", "value")
+    __slots__ = ("diagnostics", "old_value", "quality", "ts", "value")
 
     def __init__(self) -> None:
         self.value: Any = None
         self.quality: str = "uncertain"
         self.ts: datetime = datetime.now(UTC)
         self.old_value: Any = None
+        self.diagnostics: dict[str, dict[str, Any]] = {}
 
     def update(self, value: Any, quality: str) -> bool:
         """Update state. Returns True if value actually changed."""
@@ -291,6 +292,36 @@ class DataPointRegistry:
             mqtt_alias_topic=alias_topic,
             ts=event.ts,
         )
+
+    async def report_type_mismatch(
+        self,
+        dp_id: uuid.UUID,
+        *,
+        expected: str,
+        got: str,
+        source_adapter: str,
+        value: Any,
+    ) -> None:
+        state = self._values.get(dp_id)
+        if state is None:
+            return
+        current = state.diagnostics.get("type_mismatch")
+        count = int(current.get("count", 0)) + 1 if current else 1
+        state.diagnostics["type_mismatch"] = {
+            "type": "type_mismatch",
+            "expected": expected,
+            "got": got,
+            "source_adapter": source_adapter,
+            "count": count,
+            "last_value": value,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+
+    async def clear_diagnostic(self, dp_id: uuid.UUID, diagnostic_type: str) -> None:
+        state = self._values.get(dp_id)
+        if state is None:
+            return
+        state.diagnostics.pop(diagnostic_type, None)
 
 
 # ---------------------------------------------------------------------------

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -144,8 +144,10 @@ class WriteRouter:
                     dt.python_type.__name__,
                     type(value).__name__,
                 )
+                await self._report_type_mismatch(event, dt.python_type.__name__, type(value).__name__)
                 return
 
+        await self._clear_type_mismatch(event.datapoint_id)
         await self._write_to_dest_bindings(event.datapoint_id, value, skip_binding_id=event.binding_id)
 
     # ------------------------------------------------------------------
@@ -172,7 +174,16 @@ class WriteRouter:
 
         logger.info("WriteRouter: %d writable binding(s) for dp %s", len(rows), dp_id)
         for row in rows:
-            binding = _row_to_binding(row)
+            try:
+                binding = _row_to_binding(row)
+            except Exception as exc:
+                logger.error(
+                    "WriteRouter: invalid writable binding skipped for dp=%s binding=%s: %s",
+                    dp_id,
+                    _row_value(row, "id") or "<unknown>",
+                    exc,
+                )
+                continue
             if skip_binding_id and binding.id == skip_binding_id:
                 logger.debug("WriteRouter: skipping originating binding %s", binding.id)
                 continue
@@ -292,6 +303,32 @@ class WriteRouter:
                     binding.adapter_type,
                     binding.id,
                 )
+
+    async def _report_type_mismatch(self, event: Any, expected: str, got: str) -> None:
+        reporter = getattr(self._registry, "report_type_mismatch", None)
+        if reporter is None:
+            return
+        await reporter(
+            event.datapoint_id,
+            expected=expected,
+            got=got,
+            source_adapter=getattr(event, "source_adapter", ""),
+            value=event.value,
+        )
+
+    async def _clear_type_mismatch(self, dp_id: uuid.UUID) -> None:
+        clear = getattr(self._registry, "clear_diagnostic", None)
+        if clear is None:
+            return
+        await clear(dp_id, "type_mismatch")
+
+
+def _row_value(row: Any, key: str) -> str | None:
+    try:
+        value = row[key]
+    except Exception:
+        return None
+    return str(value) if value is not None else None
 
 
 # ---------------------------------------------------------------------------

--- a/obs/db/database.py
+++ b/obs/db/database.py
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS adapter_bindings (
     datapoint_id    TEXT NOT NULL REFERENCES datapoints(id) ON DELETE CASCADE,
     adapter_type    TEXT NOT NULL,
     direction       TEXT NOT NULL CHECK (direction IN ('SOURCE', 'DEST', 'BOTH')),
-    config          TEXT NOT NULL DEFAULT '{}',
+    config          TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(config)),
     enabled         INTEGER NOT NULL DEFAULT 1,
     created_at      TEXT NOT NULL,
     updated_at      TEXT NOT NULL
@@ -263,7 +263,7 @@ ALTER TABLE history_values ADD COLUMN source_adapter TEXT;
 """
 
 _MIGRATION_V20 = """
-ALTER TABLE adapter_bindings ADD COLUMN value_map TEXT;
+ALTER TABLE adapter_bindings ADD COLUMN value_map TEXT CHECK (value_map IS NULL OR json_valid(value_map));
 """
 
 _MIGRATION_V21 = """

--- a/tests/unit/test_issue_755_binding_diagnostics.py
+++ b/tests/unit/test_issue_755_binding_diagnostics.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import datetime
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from obs.adapters import registry as adapter_registry
+from obs.core.registry import DataPointRegistry, ValueState
+from obs.db import database
+
+
+class _Db:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def fetchall(self, _query, _params=()):
+        return list(self._rows)
+
+
+class _Instance:
+    connected = True
+
+    def __init__(self):
+        self.bindings = None
+        self.status_events = []
+        self.last_severity = "ok"
+        self.last_detail = ""
+
+    async def reload_bindings(self, bindings):
+        self.bindings = bindings
+
+    async def _publish_status(self, connected, detail="", severity="ok"):
+        self.status_events.append((connected, detail, severity))
+        self.last_severity = severity
+        self.last_detail = detail
+
+
+class _PlainInstance:
+    connected = False
+    last_detail = ""
+
+
+class _BadRow:
+    def __getitem__(self, _key):
+        raise KeyError("missing")
+
+
+def _binding_row(**overrides):
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    row = {
+        "id": str(uuid.uuid4()),
+        "datapoint_id": str(uuid.uuid4()),
+        "adapter_type": "MQTT",
+        "adapter_instance_id": str(uuid.uuid4()),
+        "direction": "SOURCE",
+        "config": "{}",
+        "enabled": 1,
+        "send_throttle_ms": None,
+        "send_on_change": 0,
+        "send_min_delta": None,
+        "send_min_delta_pct": None,
+        "value_formula": None,
+        "value_map": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_reload_instance_bindings_skips_invalid_rows_and_sets_warning(monkeypatch):
+    instance_id = str(uuid.uuid4())
+    instance = _Instance()
+    monkeypatch.setitem(adapter_registry._instances, instance_id, instance)
+    rows = [
+        _binding_row(adapter_instance_id=instance_id, datapoint_id="not-a-uuid"),
+        _binding_row(adapter_instance_id=instance_id, config="{unit_id: 10}"),
+        _binding_row(adapter_instance_id=instance_id, config=json.dumps({"topic": "ok"})),
+    ]
+
+    await adapter_registry.reload_instance_bindings(instance_id, _Db(rows))
+
+    assert len(instance.bindings) == 1
+    assert instance.bindings[0].config == {"topic": "ok"}
+    assert instance.last_severity == "warning"
+    assert "2 invalid binding" in instance.last_detail
+
+
+@pytest.mark.asyncio
+async def test_datapoint_registry_exposes_type_mismatch_diagnostic(monkeypatch):
+    from obs.api.v1 import datapoints as dp_api
+
+    dp_id = uuid.uuid4()
+    registry = DataPointRegistry(db=SimpleNamespace(), mqtt_client=SimpleNamespace(), event_bus=SimpleNamespace())
+    state = ValueState()
+    registry._values[dp_id] = state
+    monkeypatch.setattr(dp_api, "get_registry", lambda: registry)
+
+    await registry.report_type_mismatch(
+        dp_id,
+        expected="float",
+        got="str",
+        source_adapter="MQTT",
+        value="online",
+    )
+
+    result = dp_api._enrich(
+        SimpleNamespace(
+            id=dp_id,
+            name="Deye/Micro/Status",
+            data_type="FLOAT",
+            unit=None,
+            tags=[],
+            mqtt_topic="dp/status/value",
+            mqtt_alias=None,
+            persist_value=True,
+            record_history=True,
+            created_at=datetime.datetime.now(datetime.UTC),
+            updated_at=datetime.datetime.now(datetime.UTC),
+        )
+    )
+
+    assert result.diagnostics[0].type == "type_mismatch"
+    assert result.diagnostics[0].expected == "float"
+    assert result.diagnostics[0].got == "str"
+    assert result.diagnostics[0].count == 1
+
+
+def test_new_adapter_binding_schema_requires_valid_json_config():
+    assert "config          TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(config))" in database._MIGRATION_V1
+    assert "value_map TEXT CHECK (value_map IS NULL OR json_valid(value_map))" in database._MIGRATION_V20
+
+
+@pytest.mark.asyncio
+async def test_bindings_api_reload_adapter_instance_delegates_to_registry(monkeypatch):
+    from obs.api.v1 import bindings as bindings_api
+
+    calls = []
+
+    async def _reload(instance_id, db):
+        calls.append((instance_id, db))
+
+    db = _Db([])
+    monkeypatch.setattr(adapter_registry, "reload_instance_bindings", _reload)
+
+    await bindings_api._reload_adapter_instance("instance-1", db)
+
+    assert calls == [("instance-1", db)]
+
+
+def test_load_valid_bindings_reports_unknown_row_when_id_cannot_be_read():
+    bindings, issues = adapter_registry.load_valid_bindings([_BadRow()])
+
+    assert bindings == []
+    assert issues[0].binding_id == "<unknown>"
+    assert issues[0].adapter_instance_id is None
+    assert "KeyError" in issues[0].reason
+
+
+@pytest.mark.asyncio
+async def test_binding_load_status_clears_previous_binding_warning():
+    instance = _Instance()
+    instance.last_detail = "Invalid adapter bindings skipped: old"
+
+    await adapter_registry._publish_binding_load_status(instance, [])
+
+    assert instance.last_severity == "ok"
+    assert instance.last_detail == ""
+    assert instance.status_events[-1] == (True, "", "ok")
+
+
+@pytest.mark.asyncio
+async def test_binding_load_status_does_not_clear_unrelated_warning():
+    instance = _Instance()
+    instance.last_detail = "Transport warning"
+
+    await adapter_registry._publish_binding_load_status(instance, [])
+
+    assert instance.status_events == []
+    assert instance.last_detail == "Transport warning"
+
+
+@pytest.mark.asyncio
+async def test_binding_load_status_supports_instances_without_publish_status():
+    instance = _PlainInstance()
+    issue = adapter_registry.BindingLoadIssue(
+        binding_id="b1",
+        adapter_instance_id="i1",
+        reason="ValueError: bad",
+    )
+
+    await adapter_registry._publish_binding_load_status(instance, [issue])
+
+    assert instance._last_severity == "warning"
+    assert "b1" in instance._last_detail
+
+
+def test_binding_load_detail_shows_more_suffix():
+    issues = [adapter_registry.BindingLoadIssue(f"b{i}", "i1", "ValueError: bad") for i in range(5)]
+
+    detail = adapter_registry._format_binding_load_detail(issues)
+
+    assert "+2 more" in detail
+
+
+@pytest.mark.asyncio
+async def test_datapoint_registry_type_mismatch_count_increments_and_clears():
+    dp_id = uuid.uuid4()
+    registry = DataPointRegistry(db=SimpleNamespace(), mqtt_client=SimpleNamespace(), event_bus=SimpleNamespace())
+    registry._values[dp_id] = ValueState()
+
+    await registry.report_type_mismatch(dp_id, expected="float", got="str", source_adapter="MQTT", value="online")
+    await registry.report_type_mismatch(dp_id, expected="float", got="str", source_adapter="MQTT", value="offline")
+
+    diagnostic = registry._values[dp_id].diagnostics["type_mismatch"]
+    assert diagnostic["count"] == 2
+    assert diagnostic["last_value"] == "offline"
+
+    await registry.clear_diagnostic(dp_id, "type_mismatch")
+    assert registry._values[dp_id].diagnostics == {}
+
+
+@pytest.mark.asyncio
+async def test_datapoint_registry_diagnostic_methods_ignore_unknown_datapoint():
+    registry = DataPointRegistry(db=SimpleNamespace(), mqtt_client=SimpleNamespace(), event_bus=SimpleNamespace())
+
+    await registry.report_type_mismatch(
+        uuid.uuid4(),
+        expected="float",
+        got="str",
+        source_adapter="MQTT",
+        value="online",
+    )
+    await registry.clear_diagnostic(uuid.uuid4(), "type_mismatch")
+
+    assert registry._values == {}

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -11,7 +11,7 @@ from obs.adapters import registry as adapter_registry
 from obs.adapters.mqtt.adapter import MqttAdapter
 from obs.core.event_bus import DataValueEvent
 from obs.core import write_router
-from obs.core.write_router import WriteRouter
+from obs.core.write_router import WriteRouter, _cached_value_equals, _row_value, _to_cached_value
 from tests.adapters.conftest import make_binding
 
 
@@ -100,6 +100,14 @@ async def test_send_on_change_skips_duplicate_large_string(monkeypatch):
     await router._write_to_dest_bindings(dp_id, large_value, skip_binding_id=None)
 
     assert len(instance.writes) == 1
+
+
+def test_cached_value_helpers_cover_short_strings_and_digest_type_mismatch():
+    cached = _to_cached_value("short")
+
+    assert cached == "short"
+    assert _cached_value_equals("short", cached) is True
+    assert _cached_value_equals(42, ("__str_digest__", 5, "unused")) is False
 
 
 @pytest.mark.asyncio
@@ -219,6 +227,23 @@ async def test_handle_uses_json_fallback_when_deserializer_fails(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_handle_uses_raw_payload_when_deserializer_and_json_fallback_fail(monkeypatch):
+    dp_id = uuid.uuid4()
+    router = _make_router([])
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="dummy"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    def _failing_deserializer(_raw):
+        raise ValueError("boom")
+
+    fake_dt = SimpleNamespace(mqtt_deserializer=_failing_deserializer)
+    monkeypatch.setattr("obs.models.types.DataTypeRegistry.get", lambda _dt: fake_dt)
+
+    await router.handle(dp_id, "not json")
+    router._write_to_dest_bindings.assert_awaited_once_with(dp_id, "not json", skip_binding_id=None)
+
+
+@pytest.mark.asyncio
 async def test_time_value_event_routes_to_mqtt_raw_payload_without_template(monkeypatch):
     dp_id = uuid.uuid4()
     binding = make_binding({"topic": "clock/time"}, direction="DEST")
@@ -260,6 +285,27 @@ async def test_write_router_skips_invalid_binding_row_and_writes_valid_row(monke
     await router._write_to_dest_bindings(dp_id, "value", skip_binding_id=None)
 
     assert instance.writes == ["value"]
+
+
+@pytest.mark.asyncio
+async def test_send_min_delta_ignores_non_numeric_values(monkeypatch):
+    binding = _binding(send_min_delta=1.0)
+    instance = _FakeInstance()
+    router = _make_router([{"id": str(binding.id)}])
+    _patch_registry(monkeypatch, binding, instance)
+
+    await router._write_to_dest_bindings(uuid.uuid4(), "old", skip_binding_id=None)
+    await router._write_to_dest_bindings(uuid.uuid4(), "new", skip_binding_id=None)
+
+    assert instance.writes == ["old", "new"]
+
+
+def test_row_value_returns_none_for_rows_that_do_not_support_lookup():
+    class BadRow:
+        def __getitem__(self, _key):
+            raise TypeError("unsupported")
+
+    assert _row_value(BadRow(), "id") is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -31,6 +31,29 @@ class _FakeInstance:
         self.writes.append(value)
 
 
+def _row(**overrides):
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    row = {
+        "id": str(uuid.uuid4()),
+        "datapoint_id": str(uuid.uuid4()),
+        "adapter_type": "MQTT",
+        "adapter_instance_id": str(uuid.uuid4()),
+        "direction": "DEST",
+        "config": "{}",
+        "enabled": 1,
+        "send_throttle_ms": None,
+        "send_on_change": 0,
+        "send_min_delta": None,
+        "send_min_delta_pct": None,
+        "value_formula": None,
+        "value_map": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    row.update(overrides)
+    return row
+
+
 def _binding(**kwargs):
     defaults = {
         "id": uuid.uuid4(),
@@ -220,3 +243,95 @@ async def test_time_value_event_routes_to_mqtt_raw_payload_without_template(monk
     assert topic == "clock/time"
     assert payload == "10:30:00"
     assert retain is False
+
+
+@pytest.mark.asyncio
+async def test_write_router_skips_invalid_binding_row_and_writes_valid_row(monkeypatch):
+    dp_id = uuid.uuid4()
+    valid_binding_id = uuid.uuid4()
+    rows = [
+        _row(id=str(uuid.uuid4()), datapoint_id="not-a-uuid"),
+        _row(id=str(valid_binding_id), datapoint_id=str(dp_id), adapter_instance_id=None),
+    ]
+    instance = _FakeInstance()
+    router = _make_router(rows)
+    monkeypatch.setattr(adapter_registry, "get_instance", lambda _adapter_type: instance)
+
+    await router._write_to_dest_bindings(dp_id, "value", skip_binding_id=None)
+
+    assert instance.writes == ["value"]
+
+
+@pytest.mark.asyncio
+async def test_handle_value_event_records_type_mismatch_diagnostic():
+    dp_id = uuid.uuid4()
+    registry = SimpleNamespace(
+        get=lambda _dp_id: SimpleNamespace(name="Status", data_type="FLOAT"),
+        report_type_mismatch=AsyncMock(),
+        clear_diagnostic=AsyncMock(),
+    )
+    router = _make_router([])
+    router._registry = registry
+    router._write_to_dest_bindings = AsyncMock()
+
+    event = SimpleNamespace(
+        datapoint_id=dp_id,
+        value="online",
+        binding_id=uuid.uuid4(),
+        quality="good",
+        source_adapter="MQTT",
+    )
+    await router.handle_value_event(event)
+
+    registry.report_type_mismatch.assert_awaited_once_with(
+        dp_id,
+        expected="float",
+        got="str",
+        source_adapter="MQTT",
+        value="online",
+    )
+    registry.clear_diagnostic.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_value_event_clears_type_mismatch_after_valid_value():
+    dp_id = uuid.uuid4()
+    registry = SimpleNamespace(
+        get=lambda _dp_id: SimpleNamespace(name="Temperature", data_type="FLOAT"),
+        report_type_mismatch=AsyncMock(),
+        clear_diagnostic=AsyncMock(),
+    )
+    router = _make_router([])
+    router._registry = registry
+    router._write_to_dest_bindings = AsyncMock()
+
+    event = SimpleNamespace(
+        datapoint_id=dp_id,
+        value=21.5,
+        binding_id=uuid.uuid4(),
+        quality="good",
+        source_adapter="MQTT",
+    )
+    await router.handle_value_event(event)
+
+    registry.clear_diagnostic.assert_awaited_once_with(dp_id, "type_mismatch")
+    registry.report_type_mismatch.assert_not_awaited()
+    router._write_to_dest_bindings.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_report_type_mismatch_noops_when_registry_has_no_reporter():
+    router = _make_router([])
+    router._registry = SimpleNamespace()
+    event = SimpleNamespace(datapoint_id=uuid.uuid4(), value="online", source_adapter="MQTT")
+
+    await router._report_type_mismatch(event, "float", "str")
+
+
+@pytest.mark.asyncio
+async def test_clear_type_mismatch_noops_when_registry_has_no_clearer():
+    router = _make_router([])
+    router._registry = SimpleNamespace()
+
+    await router._clear_type_mismatch(uuid.uuid4())


### PR DESCRIPTION
## Summary
- skip invalid adapter binding rows during adapter startup/reload instead of aborting the whole instance
- surface adapter binding load warnings and datapoint type mismatch diagnostics
- add focused backend and GUI regression coverage for issue #755

## Validation
- `tools/with-venv pytest tests/unit/test_issue_755_binding_diagnostics.py tests/unit/test_write_router.py tests/unit/test_coverage_adapters_hierarchy_logic.py -q`
- `tools/with-venv ./tools/lint.sh --check`
- `tools/with-venv pytest tests/unit tests/adapters tests/contracts -q`
- `tools/with-venv pytest tests/unit tests/adapters tests/contracts --cov=obs --cov-report=term -q`
- `cd gui && npm run test -- DataPointsView.hierarchy.spec.js`
- `cd gui && npm run test`
- `cd gui && npm run test:coverage`
- `cd gui && npm run build`
- pre-push full CI parity hook passed before pushing the branch

Closes #755
