### PR TITLE
Make adapter status & schema messages translatable (#779)

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -246,9 +246,9 @@ Both frontends use **vue-i18n v9** (Composition API mode, `legacy: false`).
 
 | File | Purpose |
 |---|---|
-| `gui/src/i18n.js` | i18n instance; locale auto-detected from `localStorage` → browser language → fallback `de` |
-| `gui/src/locales/de.json` | German source strings (authoritative) |
-| `gui/src/locales/en.json` | English translations |
+| `gui/src/i18n.js` | i18n instance; locale auto-detected from `localStorage` → browser language; `fallbackLocale: 'en'` |
+| `gui/src/locales/en.json` | English source strings (authoritative — Weblate source language; must be complete) |
+| `gui/src/locales/de.json` | German translation |
 | `gui/src/components/ui/LocaleSwitcher.vue` | Dropdown wired into Settings → Appearance |
 | `frontend/src/i18n.ts` | Same setup for the Visu SPA (TypeScript) |
 | `frontend/src/locales/{de,en}.json` | Visu locale files |
@@ -258,7 +258,7 @@ Both frontends use **vue-i18n v9** (Composition API mode, `legacy: false`).
 
 **No hardcoded user-facing strings.** Any text visible to the user — labels, button text, placeholders, tooltips, error messages, badge text, empty-state messages — must go through `$t()` / `t()`. This includes strings returned from utility functions (`utils/`, composables) that end up rendered in a template.
 
-**`de.json` is the source of truth.** Always add new keys to both `de.json` (German) and `en.json` (English) in the same commit. Use Python (`json.dumps(..., ensure_ascii=False)`) when writing locale files programmatically — never shell heredocs, which strip non-ASCII characters.
+**`en.json` is the source of truth.** English is the Weblate source language (volunteers translate *from* English) and is the i18n `fallbackLocale`, so it must be complete. Always add new keys to both `en.json` (English, authoritative) and `de.json` (German) in the same commit. Use Python (`json.dumps(..., ensure_ascii=False)`) when writing locale files programmatically — never shell heredocs, which strip non-ASCII characters.
 
 #### Key namespace conventions
 
@@ -355,12 +355,23 @@ When adding a new view, widget config, or significant UI component:
 
 #### Hard-Gate (local + CI)
 
-`./scripts/check-i18n-hardcoded-strings.sh` enforces two checks on the PR/push diff:
+`./scripts/check-i18n-hardcoded-strings.sh` runs two gates on the PR/push diff; both must pass.
+
+**Frontend** (`scripts/check_i18n_guard.py`):
 
 1. Changed files under `gui/src` and `frontend/src` with extension `.vue`, `.js`, `.ts` are scanned file-wide for hardcoded user-facing strings outside `$t()` / `t()`.
 2. If locale files changed, `de.json` and `en.json` are compared pairwise (`gui/src/locales/` and `frontend/src/locales/`); missing counterpart keys fail the gate.
 
 Allowlisted technical literals are maintained in `scripts/i18n-allowlist.txt`. Keep the list minimal and reviewable.
+
+**Backend adapter strings** (`scripts/check_adapter_i18n.py`, issue #779): changed files under `obs/adapters/**` and `obs/api/v1/adapters.py` are AST-scanned — any `_publish_status(...)` / `TestResult(...)` call (and the thin wrappers around them) whose `detail` is a non-empty **string literal** must also pass a stable `code=` / `detail_code=`, and every referenced code must exist in both `en.json` and `de.json`. Dynamic fallbacks (f-strings, variables, `str(exc)`) are allowed without a code.
+
+##### Backend adapter status / schema strings (issue #779)
+
+Adapter status details and config-schema labels are user-facing and must use locale keys, **not** German literals:
+
+- **Status details** — `_publish_status(connected, detail, *, code=..., params=...)` emits a stable `code` (key suffix under `adapters.statusDetail.*`) plus interpolation `params`; the frontend translates it via `adapterStatusDetailText()` in `gui/src/utils/adapterStatus.js`. `detail` stays as the non-localized fallback for genuinely dynamic text. `TestResult` works the same way via `detail_code` / `adapters.testResult.*`.
+- **Schema labels** — `gui/src/components/adapters/SchemaForm.vue` prefers `adapters.schema.<ADAPTER_TYPE>.<field>.{title,description}` over the backend Pydantic `Field(title/description=)`. Add keys for every field of any `SchemaForm`-rendered adapter (KNX & Anwesenheit use custom forms). `<ADAPTER_TYPE>` is the registry type string (e.g. `HOME_ASSISTANT`, `MODBUS_TCP`).
 
 ##### `gui/src/utils/hierarchyDepthOptions.js`
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -24,7 +24,7 @@ function detectLocale(): LocaleCode {
 const i18n = createI18n({
   legacy: false,
   locale: detectLocale(),
-  fallbackLocale: 'de',
+  fallbackLocale: 'en',  // en.json is the authoritative source; fall back to it for missing keys
   messages: { de, en },
 })
 

--- a/gui/src/i18n.js
+++ b/gui/src/i18n.js
@@ -5,8 +5,9 @@ import en from './locales/en.json'
 /**
  * Supported locales.
  * To add a new language: add its JSON file to src/locales/ and import it here.
- * The JSON files are the Weblate source/target resources — de.json is the
- * authoritative source; translations are managed via Weblate and pulled with `wlc pull`.
+ * The JSON files are the Weblate source/target resources — en.json is the
+ * authoritative source language (what Weblate volunteers translate from) and
+ * must be complete; other locales are managed via Weblate and pulled with `wlc pull`.
  */
 export const SUPPORTED_LOCALES = [
   { code: 'de', label: 'Deutsch' },
@@ -24,7 +25,7 @@ function detectLocale() {
 const i18n = createI18n({
   legacy: false,          // use Composition API mode
   locale: detectLocale(),
-  fallbackLocale: 'de',
+  fallbackLocale: 'en',  // en.json is the authoritative source; fall back to it for missing keys
   messages: { de, en },
 })
 

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -695,6 +695,18 @@
         "startup_jitter_s": {
           "title": "Startup-Jitter (s)",
           "description": "Maximale zufällige Verzögerung (Sekunden) vor dem ersten Poll jedes Bindings. Verhindert einen Request-Burst wenn alle Tasks gleichzeitig starten. 0 = deaktiviert."
+        },
+        "host": {
+          "title": "Host",
+          "description": "Hostname oder IP-Adresse des Modbus-TCP-Geräts"
+        },
+        "port": {
+          "title": "Port",
+          "description": "Modbus-TCP-Port (Standard: 502)"
+        },
+        "timeout": {
+          "title": "Timeout (s)",
+          "description": "Anfrage-Timeout in Sekunden"
         }
       },
       "SNMP": {
@@ -799,8 +811,189 @@
         "vacation_6_end": {
           "title": "Ferien 6 Ende",
           "description": "Ferienperiode 6 Ende (JJJJ-MM-TT)"
+        },
+        "custom_holidays": {
+          "title": "Benutzerdefinierte Feiertage",
+          "description": "Benutzerdefinierte Feiertage als Liste von Ausdrücken. Formate: 'MM-TT[:Name]' (fixes Datum, z.B. '12-26:Stephanstag'), 'easter+N[:Name]' / 'easter-N[:Name]' (relativ zu Ostersonntag), 'advent+N[:Name]' / 'advent-N[:Name]' (relativ zum 1. Advent), 'last_WT_MON[:Name]' (letzter Wochentag des Monats), 'N_WT_MON[:Name]' (n-ter Wochentag). Wochentags-Kürzel: MO DI MI DO FR SA SO. Monats-Kürzel: JAN FEB MAR APR MAI JUN JUL AUG SEP OKT NOV DEZ. Mehrere Einträge durch Komma oder Zeilenumbruch trennen."
+        }
+      },
+      "HOME_ASSISTANT": {
+        "host": {
+          "title": "Host",
+          "description": "Hostname oder IP-Adresse des Home-Assistant-Servers"
+        },
+        "port": {
+          "title": "Port",
+          "description": "TCP-Port des Home-Assistant-Servers"
+        },
+        "token": {
+          "title": "Zugriffstoken",
+          "description": "Langlebiges Zugriffstoken aus dem Home-Assistant-Profil"
+        },
+        "ssl": {
+          "title": "SSL/TLS verwenden",
+          "description": "Verbindung über HTTPS/WSS statt HTTP/WS"
+        }
+      },
+      "IOBROKER": {
+        "host": {
+          "title": "Host",
+          "description": "Hostname oder IP-Adresse des ioBroker-Servers"
+        },
+        "port": {
+          "title": "Port",
+          "description": "Port des ioBroker-Socket.IO-Adapters (web/socketio)"
+        },
+        "username": {
+          "title": "Benutzername",
+          "description": "ioBroker-Benutzername (optional, für authentifizierte Instanzen)"
+        },
+        "password": {
+          "title": "Passwort",
+          "description": "ioBroker-Passwort (optional)"
+        },
+        "ssl": {
+          "title": "SSL/TLS verwenden",
+          "description": "Verbindung über HTTPS statt HTTP"
+        },
+        "path": {
+          "title": "Socket.IO-Pfad",
+          "description": "Socket.IO-Endpunktpfad (Standard: socket.io)"
+        },
+        "access_token": {
+          "title": "Zugriffstoken",
+          "description": "OAuth2-Zugriffstoken (Alternative zu Benutzername/Passwort)"
+        },
+        "resubscribe_interval_seconds": {
+          "title": "Resubscribe-Intervall (s)",
+          "description": "Wie oft der Subscription-Watchdog States erneut abonniert"
+        },
+        "reconnect_interval_seconds": {
+          "title": "Reconnect-Intervall (s)",
+          "description": "Anfangsverzögerung zwischen Reconnect-Versuchen"
+        },
+        "reconnect_max_interval_seconds": {
+          "title": "Max. Reconnect-Intervall (s)",
+          "description": "Obergrenze für die Reconnect-Backoff-Verzögerung"
+        },
+        "socket_instability_threshold": {
+          "title": "Instabilitäts-Schwelle",
+          "description": "Anzahl Disconnects im Zeitfenster, bevor die Verbindung als instabil gilt"
+        },
+        "socket_instability_window_s": {
+          "title": "Instabilitäts-Fenster (s)",
+          "description": "Zeitfenster (Sekunden) zum Zählen der Disconnects"
+        }
+      },
+      "MODBUS_RTU": {
+        "port": {
+          "title": "Serieller Port",
+          "description": "Pfad zum seriellen Gerät (z.B. /dev/ttyUSB0 oder COM3)"
+        },
+        "baudrate": {
+          "title": "Baudrate",
+          "description": "Serielle Baudrate (z.B. 9600, 19200, 115200)"
+        },
+        "parity": {
+          "title": "Parität",
+          "description": "Paritätsbit: N (keine), E (gerade), O (ungerade)"
+        },
+        "stopbits": {
+          "title": "Stoppbits",
+          "description": "Anzahl Stoppbits (1 oder 2)"
+        },
+        "bytesize": {
+          "title": "Bytegröße",
+          "description": "Anzahl Datenbits (7 oder 8)"
+        },
+        "timeout": {
+          "title": "Timeout (s)",
+          "description": "Anfrage-Timeout in Sekunden"
+        }
+      },
+      "MQTT": {
+        "host": {
+          "title": "Host",
+          "description": "Hostname oder IP-Adresse des MQTT-Brokers"
+        },
+        "port": {
+          "title": "Port",
+          "description": "MQTT-Broker-Port (Standard: 1883, oder 8883 für TLS)"
+        },
+        "username": {
+          "title": "Benutzername",
+          "description": "MQTT-Benutzername (optional)"
+        },
+        "password": {
+          "title": "Passwort",
+          "description": "MQTT-Passwort (optional)"
+        },
+        "client_id": {
+          "title": "Client-ID",
+          "description": "MQTT-Client-Kennung (leer = automatisch generiert)"
+        },
+        "tls": {
+          "title": "TLS verwenden",
+          "description": "Broker-Verbindung mit TLS verschlüsseln"
+        },
+        "tls_insecure": {
+          "title": "TLS-Prüfung überspringen",
+          "description": "TLS-Zertifikat des Brokers nicht prüfen (unsicher)"
+        }
+      },
+      "ONEWIRE": {
+        "poll_interval": {
+          "title": "Abfrageintervall (s)",
+          "description": "Wie oft Sensoren gelesen werden, in Sekunden"
+        },
+        "w1_path": {
+          "title": "1-Wire-Pfad",
+          "description": "Sysfs-Pfad zum 1-Wire-Bus (Standard: /sys/bus/w1/devices)"
         }
       }
+    },
+    "statusDetail": {
+      "connected": "Verbunden",
+      "connectedTo": "Verbunden mit {host}:{port}",
+      "connectedHa": "Verbunden mit HA {version}",
+      "knxConnectedRouting": "Verbunden (Routing {group}:{port})",
+      "connecting": "Verbinde mit {host}:{port}…",
+      "reconnecting": "Neuverbindung mit {host}:{port}…",
+      "disconnected": "Getrennt",
+      "started": "Gestartet",
+      "stopped": "Gestoppt",
+      "libNotInstalled": "{lib} nicht installiert",
+      "noToken": "Kein Token konfiguriert",
+      "tokenInvalid": "Token ungültig",
+      "wsErrorReconnecting": "WebSocket-Fehler — Neuverbindung",
+      "couldNotConnectTo": "Verbindung zu {host}:{port} nicht möglich",
+      "couldNotReconnectTo": "Neuverbindung zu {host}:{port} nicht möglich",
+      "couldNotOpenPort": "{port} konnte nicht geöffnet werden",
+      "modbusSerialConnected": "Verbunden ({port} @ {baudrate} Baud)",
+      "modbusReconnectBackoff": "Modbus-TCP-Neuverbindung pausiert (Backoff aktiv)",
+      "pathNotFound": "{path} nicht gefunden",
+      "onewireBusAt": "1-Wire-Bus an {path}",
+      "socketConnectFailed": "Socket.IO-Verbindung fehlgeschlagen",
+      "socketDisconnected": "Socket.IO getrennt",
+      "socketUnstable": "ioBroker Socket.IO-Verbindung instabil: mehrere Disconnects in kurzer Zeit.",
+      "socketStable": "ioBroker Socket.IO-Verbindung stabil.",
+      "subscribeFailed": "Abonnement fehlgeschlagen",
+      "watchdogSubscribeFailed": "ioBroker Subscription-Watchdog konnte States nicht erneut abonnieren.",
+      "knxRoutingSecureRequiresKey": "routing_secure erfordert backbone_key oder knxkeys_file_path",
+      "knxBackboneKeyInvalid": "KNX-Backbone-Key ungültig (kein Hex-String): {error}",
+      "knxIpSecureConfigError": "KNX-IP-Secure-Konfigurationsfehler: {error}",
+      "knxNoBackboneKeyInKeyfile": "Kein Backbone-Key im Keyfile — das Keyfile enthält keinen Backbone-Eintrag für Routing Secure.",
+      "knxNoTunnelingInterfaces": "Keine Tunneling-Interfaces im Keyfile gefunden — bitte Individual Address im Keyfile prüfen.",
+      "knxTunnelOverload": "KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet.",
+      "knxTunnelStable": "Tunnel-Pool wieder stabil.",
+      "invalidBindingsSkipped": "{count} ungültige Verknüpfung(en) übersprungen ({examples})"
+    },
+    "testResult": {
+      "typeNotRegistered": "Adapter-Typ '{type}' nicht registriert",
+      "configError": "Konfigurationsfehler: {error}",
+      "configValidationError": "Konfigurations-Validierungsfehler: {error}",
+      "connectOk": "Verbindung zu {type} erfolgreich",
+      "connectFailed": "Verbindungsversuch fehlgeschlagen"
     }
   },
   "history": {

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -695,6 +695,18 @@
         "startup_jitter_s": {
           "title": "Startup jitter (s)",
           "description": "Maximum random delay (seconds) before the first poll of each binding. Prevents a request burst when all tasks start simultaneously. 0 = disabled."
+        },
+        "host": {
+          "title": "Host",
+          "description": "Hostname or IP address of the Modbus TCP device"
+        },
+        "port": {
+          "title": "Port",
+          "description": "Modbus TCP port (default: 502)"
+        },
+        "timeout": {
+          "title": "Timeout (s)",
+          "description": "Request timeout in seconds"
         }
       },
       "SNMP": {
@@ -799,8 +811,189 @@
         "vacation_6_end": {
           "title": "Vacation 6 end",
           "description": "Vacation period 6 end (YYYY-MM-DD)"
+        },
+        "custom_holidays": {
+          "title": "Custom holidays",
+          "description": "User-defined holidays as a list of expressions. Formats: 'MM-DD[:Name]' (fixed date), 'easter+N[:Name]' / 'easter-N[:Name]' (relative to Easter Sunday), 'advent+N[:Name]' / 'advent-N[:Name]' (relative to the 1st Advent), 'last_WD_MON[:Name]' (last weekday of the month), 'N_WD_MON[:Name]' (n-th weekday). Weekday codes: MO TU WE TH FR SA SU. Month codes: JAN FEB MAR APR MAY JUN JUL AUG SEP OCT NOV DEC. Separate multiple entries with a comma or newline."
+        }
+      },
+      "HOME_ASSISTANT": {
+        "host": {
+          "title": "Host",
+          "description": "Hostname or IP address of the Home Assistant server"
+        },
+        "port": {
+          "title": "Port",
+          "description": "TCP port of the Home Assistant server"
+        },
+        "token": {
+          "title": "Access token",
+          "description": "Long-lived access token from your Home Assistant profile"
+        },
+        "ssl": {
+          "title": "Use SSL/TLS",
+          "description": "Connect via HTTPS/WSS instead of HTTP/WS"
+        }
+      },
+      "IOBROKER": {
+        "host": {
+          "title": "Host",
+          "description": "Hostname or IP address of the ioBroker server"
+        },
+        "port": {
+          "title": "Port",
+          "description": "Port of the ioBroker Socket.IO adapter (web/socketio)"
+        },
+        "username": {
+          "title": "Username",
+          "description": "ioBroker username (optional, for authenticated instances)"
+        },
+        "password": {
+          "title": "Password",
+          "description": "ioBroker password (optional)"
+        },
+        "ssl": {
+          "title": "Use SSL/TLS",
+          "description": "Connect via HTTPS instead of HTTP"
+        },
+        "path": {
+          "title": "Socket.IO path",
+          "description": "Socket.IO endpoint path (default: socket.io)"
+        },
+        "access_token": {
+          "title": "Access token",
+          "description": "OAuth2 access token (alternative to username/password)"
+        },
+        "resubscribe_interval_seconds": {
+          "title": "Resubscribe interval (s)",
+          "description": "How often the subscription watchdog re-subscribes to states"
+        },
+        "reconnect_interval_seconds": {
+          "title": "Reconnect interval (s)",
+          "description": "Initial delay between reconnect attempts"
+        },
+        "reconnect_max_interval_seconds": {
+          "title": "Max reconnect interval (s)",
+          "description": "Upper bound for the reconnect backoff delay"
+        },
+        "socket_instability_threshold": {
+          "title": "Instability threshold",
+          "description": "Number of disconnects within the window before the connection is flagged unstable"
+        },
+        "socket_instability_window_s": {
+          "title": "Instability window (s)",
+          "description": "Time window (seconds) for counting disconnects"
+        }
+      },
+      "MODBUS_RTU": {
+        "port": {
+          "title": "Serial port",
+          "description": "Serial device path (e.g. /dev/ttyUSB0 or COM3)"
+        },
+        "baudrate": {
+          "title": "Baud rate",
+          "description": "Serial baud rate (e.g. 9600, 19200, 115200)"
+        },
+        "parity": {
+          "title": "Parity",
+          "description": "Parity bit: N (none), E (even), O (odd)"
+        },
+        "stopbits": {
+          "title": "Stop bits",
+          "description": "Number of stop bits (1 or 2)"
+        },
+        "bytesize": {
+          "title": "Byte size",
+          "description": "Number of data bits (7 or 8)"
+        },
+        "timeout": {
+          "title": "Timeout (s)",
+          "description": "Request timeout in seconds"
+        }
+      },
+      "MQTT": {
+        "host": {
+          "title": "Host",
+          "description": "Hostname or IP address of the MQTT broker"
+        },
+        "port": {
+          "title": "Port",
+          "description": "MQTT broker port (default: 1883, or 8883 for TLS)"
+        },
+        "username": {
+          "title": "Username",
+          "description": "MQTT username (optional)"
+        },
+        "password": {
+          "title": "Password",
+          "description": "MQTT password (optional)"
+        },
+        "client_id": {
+          "title": "Client ID",
+          "description": "MQTT client identifier (empty = auto-generated)"
+        },
+        "tls": {
+          "title": "Use TLS",
+          "description": "Encrypt the broker connection with TLS"
+        },
+        "tls_insecure": {
+          "title": "Skip TLS verification",
+          "description": "Do not verify the broker's TLS certificate (insecure)"
+        }
+      },
+      "ONEWIRE": {
+        "poll_interval": {
+          "title": "Poll interval (s)",
+          "description": "How often sensors are read, in seconds"
+        },
+        "w1_path": {
+          "title": "1-Wire path",
+          "description": "Sysfs path to the 1-Wire bus (default: /sys/bus/w1/devices)"
         }
       }
+    },
+    "statusDetail": {
+      "connected": "Connected",
+      "connectedTo": "Connected to {host}:{port}",
+      "connectedHa": "Connected to HA {version}",
+      "knxConnectedRouting": "Connected (routing {group}:{port})",
+      "connecting": "Connecting to {host}:{port}…",
+      "reconnecting": "Reconnecting to {host}:{port}…",
+      "disconnected": "Disconnected",
+      "started": "Started",
+      "stopped": "Stopped",
+      "libNotInstalled": "{lib} not installed",
+      "noToken": "No token configured",
+      "tokenInvalid": "Token invalid",
+      "wsErrorReconnecting": "WebSocket error — reconnecting",
+      "couldNotConnectTo": "Could not connect to {host}:{port}",
+      "couldNotReconnectTo": "Could not reconnect to {host}:{port}",
+      "couldNotOpenPort": "Could not open {port}",
+      "modbusSerialConnected": "Connected ({port} @ {baudrate} baud)",
+      "modbusReconnectBackoff": "Modbus TCP reconnect backoff active",
+      "pathNotFound": "{path} not found",
+      "onewireBusAt": "1-Wire bus at {path}",
+      "socketConnectFailed": "Socket.IO connection failed",
+      "socketDisconnected": "Socket.IO disconnected",
+      "socketUnstable": "ioBroker Socket.IO connection unstable: multiple disconnects in a short time.",
+      "socketStable": "ioBroker Socket.IO connection stable.",
+      "subscribeFailed": "Subscribe failed",
+      "watchdogSubscribeFailed": "ioBroker subscription watchdog could not re-subscribe states.",
+      "knxRoutingSecureRequiresKey": "routing_secure requires backbone_key or knxkeys_file_path",
+      "knxBackboneKeyInvalid": "KNX backbone key invalid (not a hex string): {error}",
+      "knxIpSecureConfigError": "KNX IP Secure configuration error: {error}",
+      "knxNoBackboneKeyInKeyfile": "No backbone key in keyfile — the keyfile contains no backbone entry for Routing Secure.",
+      "knxNoTunnelingInterfaces": "No tunneling interfaces found in keyfile — please check the individual address in the keyfile.",
+      "knxTunnelOverload": "KNX tunnel slot likely occupied by another client — gateway pool overloaded.",
+      "knxTunnelStable": "Tunnel pool stable again.",
+      "invalidBindingsSkipped": "{count} invalid binding(s) skipped ({examples})"
+    },
+    "testResult": {
+      "typeNotRegistered": "Adapter type '{type}' not registered",
+      "configError": "Configuration error: {error}",
+      "configValidationError": "Configuration validation error: {error}",
+      "connectOk": "Connection to {type} successful",
+      "connectFailed": "Connection attempt failed"
     }
   },
   "history": {

--- a/gui/src/stores/adapters.js
+++ b/gui/src/stores/adapters.js
@@ -18,6 +18,8 @@ export const useAdapterStore = defineStore('adapters', () => {
             existing.connected = updated.connected
             existing.severity = updated.severity ?? 'ok'
             existing.status_detail = updated.status_detail ?? ''
+            existing.status_detail_code = updated.status_detail_code ?? null
+            existing.status_detail_params = updated.status_detail_params ?? {}
           }
         }
       } else {

--- a/gui/src/utils/adapterStatus.js
+++ b/gui/src/utils/adapterStatus.js
@@ -26,3 +26,17 @@ export function adapterStatusLabel(a) {
   if (a.connected) return 'adapters.status.connected'
   return 'adapters.status.running'
 }
+
+// Issue #779: the backend emits a stable status-detail `code` (+ params) under
+// adapters.statusDetail.*; translate it here. Falls back to the non-localized
+// `status_detail` string (dynamic/technical text such as raw exception output).
+// `t`/`te` are passed in because this is a pure util without a Vue setup context;
+// call it from a computed() so it stays reactive on locale change.
+export function adapterStatusDetailText(a, t, te) {
+  const code = a?.status_detail_code
+  if (code) {
+    const key = `adapters.statusDetail.${code}`
+    if (te(key)) return t(key, a?.status_detail_params ?? {})
+  }
+  return a?.status_detail ?? ''
+}

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -122,7 +122,7 @@
 
         <!-- Status-Detail bei Warning/Error -->
         <div
-          v-if="a.severity && a.severity !== 'ok' && a.status_detail"
+          v-if="a.severity && a.severity !== 'ok' && (a.status_detail || a.status_detail_code)"
           :class="[
             'mx-5 mb-3 flex items-start gap-2 p-3 rounded-lg text-sm',
             a.severity === 'error'

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -135,7 +135,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
           </svg>
-          <span>{{ a.status_detail }}</span>
+          <span>{{ statusDetailText(a) }}</span>
         </div>
 
         <!-- Expanded Config Panel -->
@@ -204,7 +204,7 @@
               <path v-if="feedback[a.id].success" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
               <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
             </svg>
-            {{ feedback[a.id].detail }}
+            {{ feedbackText(feedback[a.id]) }}
           </div>
 
           <div v-if="!isDemo" class="flex gap-3 flex-wrap">
@@ -403,9 +403,21 @@ import AnwesenheitDatapointSelector from '@/components/adapters/AnwesenheitDatap
 import AnwesenheitConfigForm from '@/components/adapters/AnwesenheitConfigForm.vue'
 import KnxConfigForm        from '@/components/adapters/KnxConfigForm.vue'
 import Modal         from '@/components/ui/Modal.vue'
-import { adapterDotClass as dotClass, adapterBadgeVariant as statusBadgeVariant, adapterStatusLabel as statusLabel } from '@/utils/adapterStatus'
+import { adapterDotClass as dotClass, adapterBadgeVariant as statusBadgeVariant, adapterStatusLabel as statusLabel, adapterStatusDetailText } from '@/utils/adapterStatus'
 
-const { t } = useI18n()
+const { t, te } = useI18n()
+const statusDetailText = (a) => adapterStatusDetailText(a, t, te)
+// Issue #779: TestResult / action feedback may carry a backend detail_code
+// (adapters.testResult.*) with params; translate it, else show the raw detail.
+function feedbackText(fb) {
+  if (!fb) return ''
+  const code = fb.detail_code
+  if (code) {
+    const key = `adapters.testResult.${code}`
+    if (te(key)) return t(key, fb.detail_params ?? {})
+  }
+  return fb.detail ?? ''
+}
 const store          = useAdapterStore()
 const auth           = useAuthStore()
 const isDemo         = computed(() => auth.username === 'demo')

--- a/gui/src/views/DashboardView.vue
+++ b/gui/src/views/DashboardView.vue
@@ -53,8 +53,8 @@
                 {{ a.severity === 'error' ? $t('common.error') : $t('common.warning') }}
               </Badge>
             </div>
-            <div v-if="a.status_detail" class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-              {{ a.status_detail }}
+            <div v-if="a.status_detail || a.status_detail_code" class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+              {{ statusDetailText(a) }}
             </div>
           </div>
         </RouterLink>
@@ -121,7 +121,11 @@ import { useAdapterStore } from '@/stores/adapters'
 import Badge   from '@/components/ui/Badge.vue'
 import Spinner from '@/components/ui/Spinner.vue'
 import StatCard from '@/components/ui/StatCard.vue'
-import { adapterDotClass as adapterDot, adapterBadgeVariant, adapterStatusLabel } from '@/utils/adapterStatus'
+import { adapterDotClass as adapterDot, adapterBadgeVariant, adapterStatusLabel, adapterStatusDetailText } from '@/utils/adapterStatus'
+import { useI18n } from 'vue-i18n'
+
+const { t, te } = useI18n()
+const statusDetailText = (a) => adapterStatusDetailText(a, t, te)
 
 const dpStore  = useDatapointStore()
 const ws       = useWebSocketStore()

--- a/gui/tests/utils/adapterStatus.spec.js
+++ b/gui/tests/utils/adapterStatus.spec.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { adapterStatusDetailText, adapterStatusLabel } from '@/utils/adapterStatus'
+
+// Fake vue-i18n t/te: te() reports whether a key exists in `keys`; t() interpolates {params}.
+function makeI18n(keys) {
+  const te = key => key in keys
+  const t = (key, params = {}) => keys[key].replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? ''))
+  return { t, te }
+}
+
+describe('adapterStatusDetailText', () => {
+  const keys = {
+    'adapters.statusDetail.connectedTo': 'Connected to {host}:{port}',
+    'adapters.statusDetail.disconnected': 'Disconnected',
+  }
+
+  it('translates a known code with params', () => {
+    const { t, te } = makeI18n(keys)
+    const a = { status_detail_code: 'connectedTo', status_detail_params: { host: 'h', port: 502 }, status_detail: 'h:502' }
+    expect(adapterStatusDetailText(a, t, te)).toBe('Connected to h:502')
+  })
+
+  it('translates a code that takes no params', () => {
+    const { t, te } = makeI18n(keys)
+    const a = { status_detail_code: 'disconnected', status_detail_params: {}, status_detail: 'Disconnected (raw)' }
+    expect(adapterStatusDetailText(a, t, te)).toBe('Disconnected')
+  })
+
+  it('falls back to status_detail when the code key is unknown', () => {
+    const { t, te } = makeI18n(keys)
+    const a = { status_detail_code: 'somethingNew', status_detail: 'raw fallback text' }
+    expect(adapterStatusDetailText(a, t, te)).toBe('raw fallback text')
+  })
+
+  it('falls back to status_detail when no code is present (dynamic detail)', () => {
+    const { t, te } = makeI18n(keys)
+    const a = { status_detail_code: null, status_detail: 'ValueError: boom' }
+    expect(adapterStatusDetailText(a, t, te)).toBe('ValueError: boom')
+  })
+
+  it('returns empty string for an adapter with neither code nor detail', () => {
+    const { t, te } = makeI18n(keys)
+    expect(adapterStatusDetailText({}, t, te)).toBe('')
+    expect(adapterStatusDetailText(null, t, te)).toBe('')
+  })
+})
+
+describe('adapterStatusLabel', () => {
+  it('still maps severity/connected to locale keys (regression guard)', () => {
+    expect(adapterStatusLabel({ running: false })).toBe('adapters.status.inactive')
+    expect(adapterStatusLabel({ running: true, severity: 'error' })).toBe('common.error')
+    expect(adapterStatusLabel({ running: true, severity: 'warning' })).toBe('adapters.status.degraded')
+    expect(adapterStatusLabel({ running: true, connected: true })).toBe('adapters.status.connected')
+  })
+})

--- a/obs/adapters/anwesenheit/adapter.py
+++ b/obs/adapters/anwesenheit/adapter.py
@@ -151,7 +151,7 @@ class AnwesenheitssimulationAdapter(AdapterBase):
             self._simulation_loop(),
             name=f"anwesenheitssimulation_{self._instance_id}",
         )
-        await self._publish_status(True, "Anwesenheitssimulation gestartet")
+        await self._publish_status(True, "Anwesenheitssimulation gestartet", code="started")
 
     async def disconnect(self) -> None:
         if self._task and not self._task.done():
@@ -163,7 +163,7 @@ class AnwesenheitssimulationAdapter(AdapterBase):
             self._task = None
         self._pending.clear()
         self._seq = 0
-        await self._publish_status(False, "Anwesenheitssimulation gestoppt")
+        await self._publish_status(False, "Anwesenheitssimulation gestoppt", code="stopped")
 
     async def read(self, binding: Any) -> None:  # noqa: ARG002
         return None

--- a/obs/adapters/base.py
+++ b/obs/adapters/base.py
@@ -50,6 +50,13 @@ class AdapterBase(ABC):
         # subscribing to the EventBus (GUI polls /adapters/instances).
         self._last_severity: str = "ok"
         self._last_detail: str = ""
+        # i18n (issue #779): status details are emitted as a stable key suffix
+        # (`detail_code`, under `adapters.statusDetail.*` in the locale files)
+        # plus interpolation `detail_params`. The frontend translates the code;
+        # `_last_detail` stays as a human-readable fallback for codeless/dynamic
+        # messages (e.g. raw exception text).
+        self._last_detail_code: str | None = None
+        self._last_detail_params: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -110,7 +117,30 @@ class AdapterBase(ABC):
     def last_detail(self) -> str:
         return self._last_detail
 
-    async def _publish_status(self, connected: bool, detail: str = "", severity: str = "ok") -> None:
+    @property
+    def last_detail_code(self) -> str | None:
+        return self._last_detail_code
+
+    @property
+    def last_detail_params(self) -> dict[str, Any]:
+        return self._last_detail_params
+
+    async def _publish_status(
+        self,
+        connected: bool,
+        detail: str = "",
+        severity: str = "ok",
+        *,
+        code: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish an adapter status change.
+
+        For i18n (issue #779) prefer a stable `code` (key suffix under
+        `adapters.statusDetail.*`) plus `params` for interpolation; the frontend
+        translates it. `detail` is the human-readable fallback shown when no code
+        is given or the locale key is missing (e.g. raw exception text).
+        """
         from obs.core.event_bus import AdapterStatusEvent
 
         # severity="warning" signals degraded operation without changing the
@@ -119,6 +149,8 @@ class AdapterBase(ABC):
             self._connected = connected
         self._last_severity = severity
         self._last_detail = detail
+        self._last_detail_code = code
+        self._last_detail_params = params or {}
         await self._bus.publish(
             AdapterStatusEvent(
                 adapter_type=self.adapter_type,
@@ -127,5 +159,7 @@ class AdapterBase(ABC):
                 connected=self._connected,
                 detail=detail,
                 severity=severity,
+                detail_code=code,
+                detail_params=params or {},
             ),
         )

--- a/obs/adapters/homeassistant/adapter.py
+++ b/obs/adapters/homeassistant/adapter.py
@@ -139,13 +139,13 @@ class HomeAssistantAdapter(AdapterBase):
             import websockets  # noqa: F401
         except ImportError:
             logger.error("websockets not installed — Home Assistant adapter disabled")
-            await self._publish_status(False, "websockets not installed")
+            await self._publish_status(False, "websockets not installed", code="libNotInstalled", params={"lib": "websockets"})
             return
 
         self._cfg = HaAdapterConfig(**self._config)
         if not self._cfg.token:
             logger.error("Home Assistant adapter: no token configured")
-            await self._publish_status(False, "Kein Token konfiguriert")
+            await self._publish_status(False, "Kein Token konfiguriert", code="noToken")
             return
 
         scheme = "https" if self._cfg.ssl else "http"
@@ -156,7 +156,12 @@ class HomeAssistantAdapter(AdapterBase):
             timeout=10.0,
         )
 
-        await self._publish_status(True, f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
+        await self._publish_status(
+            True,
+            f"Verbunden mit {self._cfg.host}:{self._cfg.port}",
+            code="connectedTo",
+            params={"host": self._cfg.host, "port": self._cfg.port},
+        )
         logger.info(
             "Home Assistant adapter started → %s:%d ssl=%s",
             self._cfg.host,
@@ -178,7 +183,7 @@ class HomeAssistantAdapter(AdapterBase):
             self._http_client = None
 
         self._entity_map.clear()
-        await self._publish_status(False, "Getrennt")
+        await self._publish_status(False, "Getrennt", code="disconnected")
 
     # ------------------------------------------------------------------
     # Bindings
@@ -247,7 +252,7 @@ class HomeAssistantAdapter(AdapterBase):
                     msg = json.loads(await ws.recv())
                     if msg.get("type") == "auth_invalid":
                         logger.error("HA WebSocket: authentication failed — check token")
-                        await self._publish_status(False, "Token ungültig")
+                        await self._publish_status(False, "Token ungültig", code="tokenInvalid")
                         await asyncio.sleep(60)
                         continue
                     if msg.get("type") != "auth_ok":
@@ -259,7 +264,12 @@ class HomeAssistantAdapter(AdapterBase):
                         "HA WebSocket authenticated (ha_version=%s)",
                         msg.get("ha_version", "?"),
                     )
-                    await self._publish_status(True, f"Verbunden mit HA {msg.get('ha_version', '')}")
+                    await self._publish_status(
+                        True,
+                        f"Verbunden mit HA {msg.get('ha_version', '')}",
+                        code="connectedHa",
+                        params={"version": msg.get("ha_version", "")},
+                    )
 
                     # Step 3: subscribe to state_changed events
                     sub_id = _next_ws_id()
@@ -301,7 +311,7 @@ class HomeAssistantAdapter(AdapterBase):
                 raise
             except Exception:
                 logger.exception("HA adapter WebSocket error, reconnecting in 10 s")
-                await self._publish_status(False, "WebSocket Fehler — reconnecting")
+                await self._publish_status(False, "WebSocket Fehler — reconnecting", code="wsErrorReconnecting")
                 await asyncio.sleep(10)
 
     async def _on_state_changed(self, data: dict) -> None:

--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -188,7 +188,13 @@ class IoBrokerAdapter(AdapterBase):
             import socketio
         except ImportError:
             logger.error("python-socketio not installed — ioBroker adapter disabled")
-            await self._publish_status(False, "python-socketio nicht installiert", severity="error")
+            await self._publish_status(
+                False,
+                "python-socketio nicht installiert",
+                severity="error",
+                code="libNotInstalled",
+                params={"lib": "python-socketio"},
+            )
             return
         for noisy_logger in (
             "socketio",
@@ -229,7 +235,7 @@ class IoBrokerAdapter(AdapterBase):
 
         connected = await self._connect_socket()
         if not connected:
-            await self._publish_status(False, "Socket.IO Verbindung fehlgeschlagen", severity="error")
+            await self._publish_status(False, "Socket.IO Verbindung fehlgeschlagen", severity="error", code="socketConnectFailed")
             self._ensure_reconnect_task()
 
         logger.info(
@@ -257,7 +263,7 @@ class IoBrokerAdapter(AdapterBase):
         self._last_source_values.clear()
         self._source_filter_last_sent.clear()
         self._source_filter_last_values.clear()
-        await self._publish_status(False, "Getrennt")
+        await self._publish_status(False, "Getrennt", code="disconnected")
 
     async def _on_bindings_reloaded(self) -> None:
         if self._cfg is None:
@@ -318,13 +324,15 @@ class IoBrokerAdapter(AdapterBase):
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
-    async def _publish_warning_status(self, detail: str) -> None:
+    async def _publish_warning_status(self, detail: str, *, code: str | None = None, params: dict | None = None) -> None:
         if self.connected:
             self._connected = True
         await self._publish_status(
             self.connected,
             detail,
             severity="warning",
+            code=code,
+            params=params,
         )
 
     async def _close_socket(self, sio: Any | None) -> None:
@@ -351,7 +359,7 @@ class IoBrokerAdapter(AdapterBase):
                 raise
             except Exception:
                 logger.exception("ioBroker subscription watchdog failed")
-                await self._publish_warning_status(WATCHDOG_SUBSCRIBE_WARNING_DETAIL)
+                await self._publish_warning_status(WATCHDOG_SUBSCRIBE_WARNING_DETAIL, code="watchdogSubscribeFailed")
 
     def _build_socket(self) -> Any:
         assert self._socketio is not None
@@ -369,7 +377,11 @@ class IoBrokerAdapter(AdapterBase):
                 return
             logger.info("ioBroker Socket.IO connected → %s", self._connect_url)
             if self._cfg is not None:
-                await self._publish_connected_status(f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
+                await self._publish_connected_status(
+                    f"Verbunden mit {self._cfg.host}:{self._cfg.port}",
+                    code="connectedTo",
+                    params={"host": self._cfg.host, "port": self._cfg.port},
+                )
             await self._subscribe_bound_states(force_publish_initial=True, publish_connected_status=False)
 
         @sio.event
@@ -378,7 +390,7 @@ class IoBrokerAdapter(AdapterBase):
                 return
             logger.info("ioBroker Socket.IO disconnected")
             self._socket = None
-            await self._publish_status(False, "Socket.IO getrennt")
+            await self._publish_status(False, "Socket.IO getrennt", code="socketDisconnected")
             await self._record_disconnect()
             self._ensure_reconnect_task()
 
@@ -480,25 +492,25 @@ class IoBrokerAdapter(AdapterBase):
         if len(self._disconnect_times) < self._disconnect_threshold():
             return
         self._instability_warning_active = True
-        await self._publish_warning_status(SOCKET_INSTABILITY_DETAIL)
+        await self._publish_warning_status(SOCKET_INSTABILITY_DETAIL, code="socketUnstable")
         logger.warning(
             "ioBroker Socket.IO instability suspected: %d disconnects in last %ss",
             len(self._disconnect_times),
             self._cfg.socket_instability_window_s if self._cfg is not None else self._config.get("socket_instability_window_s", 300),
         )
 
-    async def _publish_connected_status(self, detail: str) -> None:
+    async def _publish_connected_status(self, detail: str, *, code: str | None = None, params: dict | None = None) -> None:
         now = self._now()
         self._prune_disconnects(now)
         if self._instability_warning_active and self._disconnect_times:
             self._connected = True
-            await self._publish_status(True, SOCKET_INSTABILITY_DETAIL, severity="warning")
+            await self._publish_status(True, SOCKET_INSTABILITY_DETAIL, severity="warning", code="socketUnstable")
             return
         if self._instability_warning_active:
             self._instability_warning_active = False
-            await self._publish_status(True, SOCKET_STABLE_DETAIL)
+            await self._publish_status(True, SOCKET_STABLE_DETAIL, code="socketStable")
             return
-        await self._publish_status(True, detail)
+        await self._publish_status(True, detail, code=code, params=params)
 
     async def _subscribe_bound_states(
         self,
@@ -515,13 +527,17 @@ class IoBrokerAdapter(AdapterBase):
                 await self._call_socket("subscribe", states)
                 logger.info("ioBroker Socket.IO subscribed: %s", states)
                 if publish_connected_status and self._cfg is not None:
-                    await self._publish_connected_status(f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
+                    await self._publish_connected_status(
+                        f"Verbunden mit {self._cfg.host}:{self._cfg.port}",
+                        code="connectedTo",
+                        params={"host": self._cfg.host, "port": self._cfg.port},
+                    )
             except Exception:
                 logger.exception("ioBroker Socket.IO subscribe failed")
                 if force_publish_initial:
-                    await self._publish_status(False, "Subscribe fehlgeschlagen", severity="error")
+                    await self._publish_status(False, "Subscribe fehlgeschlagen", severity="error", code="subscribeFailed")
                 else:
-                    await self._publish_warning_status(WATCHDOG_SUBSCRIBE_WARNING_DETAIL)
+                    await self._publish_warning_status(WATCHDOG_SUBSCRIBE_WARNING_DETAIL, code="watchdogSubscribeFailed")
                 return False
 
             # subscribe only reports future changes. After connect/reconnect we

--- a/obs/adapters/knx/adapter.py
+++ b/obs/adapters/knx/adapter.py
@@ -173,7 +173,7 @@ class KnxAdapter(AdapterBase):
             from xknx.telegram.address import IndividualAddress
         except ImportError:
             logger.error("xknx not installed — KNX adapter disabled")
-            await self._publish_status(False, "xknx not installed", severity="error")
+            await self._publish_status(False, "xknx not installed", severity="error", code="libNotInstalled", params={"lib": "xknx"})
             return
 
         # Clean up any previous xknx instance before creating a new one
@@ -217,9 +217,11 @@ class KnxAdapter(AdapterBase):
                     if keyfile_result is None:
                         if cfg.connection_type == "routing_secure":
                             detail = "Kein Backbone-Key im Keyfile — das Keyfile enthält keinen Backbone-Eintrag für Routing Secure."
+                            keyfile_code = "knxNoBackboneKeyInKeyfile"
                         else:
                             detail = "Keine Tunneling-Interfaces im Keyfile gefunden — bitte Individual Address im Keyfile prüfen."
-                        await self._publish_status(False, detail, severity="error")
+                            keyfile_code = "knxNoTunnelingInterfaces"
+                        await self._publish_status(False, detail, severity="error", code=keyfile_code)
                         return
                     secure_config, resolved_individual_address = keyfile_result
                     logger.info("KNX IP Secure: Keyfile-Modus (%s), Credentials direkt extrahiert", cfg.knxkeys_file_path)
@@ -238,6 +240,7 @@ class KnxAdapter(AdapterBase):
                             False,
                             "routing_secure erfordert backbone_key oder knxkeys_file_path",
                             severity="error",
+                            code="knxRoutingSecureRequiresKey",
                         )
                         logger.error("KNX IP Secure (Routing): backbone_key und knxkeys_file_path fehlen")
                         return
@@ -246,11 +249,23 @@ class KnxAdapter(AdapterBase):
                     secure_config = SecureConfig(backbone_key=backbone_hex)
                     logger.info("KNX IP Secure: Manueller Modus (Routing, backbone_key)")
             except ValueError as exc:
-                await self._publish_status(False, f"KNX Backbone-Key ungültig (kein Hex-String): {exc}", severity="error")
+                await self._publish_status(
+                    False,
+                    f"KNX Backbone-Key ungültig (kein Hex-String): {exc}",
+                    severity="error",
+                    code="knxBackboneKeyInvalid",
+                    params={"error": str(exc)},
+                )
                 logger.error("KNX IP Secure backbone_key Parse-Fehler: %s", exc)
                 return
             except Exception as exc:
-                await self._publish_status(False, f"KNX IP Secure Konfigurationsfehler: {exc}", severity="error")
+                await self._publish_status(
+                    False,
+                    f"KNX IP Secure Konfigurationsfehler: {exc}",
+                    severity="error",
+                    code="knxIpSecureConfigError",
+                    params={"error": str(exc)},
+                )
                 logger.error("KNX IP Secure Konfigurationsfehler: %s", exc)
                 return
 
@@ -283,10 +298,20 @@ class KnxAdapter(AdapterBase):
         try:
             await self._xknx.start()
             if is_routing:
-                await self._publish_status(True, f"Connected (routing {cfg.multicast_group}:{cfg.multicast_port})")
+                await self._publish_status(
+                    True,
+                    f"Connected (routing {cfg.multicast_group}:{cfg.multicast_port})",
+                    code="knxConnectedRouting",
+                    params={"group": cfg.multicast_group, "port": cfg.multicast_port},
+                )
                 logger.info("KNX adapter connected: routing %s:%d", cfg.multicast_group, cfg.multicast_port)
             else:
-                await self._publish_status(True, f"Connected to {cfg.host}:{cfg.port}")
+                await self._publish_status(
+                    True,
+                    f"Connected to {cfg.host}:{cfg.port}",
+                    code="connectedTo",
+                    params={"host": cfg.host, "port": cfg.port},
+                )
                 logger.info(
                     "KNX adapter connected: %s:%d (%s)",
                     cfg.host,
@@ -344,6 +369,7 @@ class KnxAdapter(AdapterBase):
                 connected=self._connected,
                 detail=TUNNEL_OVERLOAD_DETAIL,
                 severity="warning",
+                code="knxTunnelOverload",
             )
             logger.warning(
                 "KNX tunnel-pool overload suspected: %d disconnects in last %ss",
@@ -361,6 +387,7 @@ class KnxAdapter(AdapterBase):
                 connected=self._connected,
                 detail="Tunnel-Pool wieder stabil.",
                 severity="ok",
+                code="knxTunnelStable",
             )
             logger.info("KNX tunnel-pool warning cleared (quiet window).")
 
@@ -395,7 +422,7 @@ class KnxAdapter(AdapterBase):
                 await self._xknx.stop()
             except Exception:
                 logger.exception("KNX disconnect error")
-        await self._publish_status(False, "Disconnected")
+        await self._publish_status(False, "Disconnected", code="disconnected")
         self._xknx = None
 
     # ------------------------------------------------------------------

--- a/obs/adapters/modbus_rtu/adapter.py
+++ b/obs/adapters/modbus_rtu/adapter.py
@@ -75,7 +75,7 @@ class ModbusRtuAdapter(AdapterBase):
             from pymodbus.client import AsyncModbusSerialClient
         except ImportError:
             logger.error("pymodbus not installed — Modbus RTU disabled. Run: pip install pymodbus")
-            await self._publish_status(False, "pymodbus not installed")
+            await self._publish_status(False, "pymodbus not installed", code="libNotInstalled", params={"lib": "pymodbus"})
             return
 
         cfg = ModbusRtuAdapterConfig(**self._config)
@@ -90,10 +90,15 @@ class ModbusRtuAdapter(AdapterBase):
         try:
             await self._client.connect()
             if self._client.connected:
-                await self._publish_status(True, f"{cfg.port}@{cfg.baudrate}")
+                await self._publish_status(
+                    True,
+                    f"{cfg.port}@{cfg.baudrate}",
+                    code="modbusSerialConnected",
+                    params={"port": cfg.port, "baudrate": cfg.baudrate},
+                )
                 logger.info("Modbus RTU connected: %s @ %d baud", cfg.port, cfg.baudrate)
             else:
-                await self._publish_status(False, f"Could not open {cfg.port}")
+                await self._publish_status(False, f"Could not open {cfg.port}", code="couldNotOpenPort", params={"port": cfg.port})
         except Exception as exc:
             await self._publish_status(False, str(exc))
             logger.exception("Modbus RTU connect failed")
@@ -104,7 +109,7 @@ class ModbusRtuAdapter(AdapterBase):
         self._poll_tasks.clear()
         if self._client:
             self._client.close()
-        await self._publish_status(False, "Disconnected")
+        await self._publish_status(False, "Disconnected", code="disconnected")
 
     # ------------------------------------------------------------------
     # Bindings

--- a/obs/adapters/modbus_tcp/adapter.py
+++ b/obs/adapters/modbus_tcp/adapter.py
@@ -119,7 +119,7 @@ class ModbusTcpAdapter(AdapterBase):
             from pymodbus.client import AsyncModbusTcpClient
         except ImportError:
             logger.error("pymodbus not installed — Modbus TCP disabled. Run: pip install pymodbus")
-            await self._publish_status(False, "pymodbus not installed")
+            await self._publish_status(False, "pymodbus not installed", code="libNotInstalled", params={"lib": "pymodbus"})
             return
         self._client_factory = AsyncModbusTcpClient
 
@@ -139,10 +139,20 @@ class ModbusTcpAdapter(AdapterBase):
         try:
             await self._client.connect()
             if self._client.connected:
-                await self._publish_status(True, f"{cfg.host}:{cfg.port}")
+                await self._publish_status(
+                    True,
+                    f"{cfg.host}:{cfg.port}",
+                    code="connectedTo",
+                    params={"host": cfg.host, "port": cfg.port},
+                )
                 logger.info("Modbus TCP connected: %s:%d", cfg.host, cfg.port)
             else:
-                await self._publish_status(False, f"Could not connect to {cfg.host}:{cfg.port}")
+                await self._publish_status(
+                    False,
+                    f"Could not connect to {cfg.host}:{cfg.port}",
+                    code="couldNotConnectTo",
+                    params={"host": cfg.host, "port": cfg.port},
+                )
         except Exception as exc:
             await self._publish_status(False, str(exc))
             logger.exception("Modbus TCP connect failed")
@@ -162,7 +172,7 @@ class ModbusTcpAdapter(AdapterBase):
             if self._client:
                 async with self._client_lifecycle():
                     self._client.close()
-            await self._publish_status(False, "Disconnected")
+            await self._publish_status(False, "Disconnected", code="disconnected")
 
     # ------------------------------------------------------------------
     # Bindings
@@ -199,12 +209,19 @@ class ModbusTcpAdapter(AdapterBase):
                         await self._client.connect()
                         if self._client.connected:
                             self._reconnect_ok_after = 0.0
-                            await self._publish_status(True, f"{self._adp_cfg.host}:{self._adp_cfg.port}")
+                            await self._publish_status(
+                                True,
+                                f"{self._adp_cfg.host}:{self._adp_cfg.port}",
+                                code="connectedTo",
+                                params={"host": self._adp_cfg.host, "port": self._adp_cfg.port},
+                            )
                             logger.info("Modbus TCP: reconnected after binding reload")
                         else:
                             await self._publish_status(
                                 False,
                                 f"Could not reconnect to {self._adp_cfg.host}:{self._adp_cfg.port}",
+                                code="couldNotReconnectTo",
+                                params={"host": self._adp_cfg.host, "port": self._adp_cfg.port},
                             )
                             logger.warning("Modbus TCP: reconnect after reload left client disconnected")
                     except Exception as exc:
@@ -259,7 +276,7 @@ class ModbusTcpAdapter(AdapterBase):
                     if self._client and not self._client.connected:
                         if time.monotonic() < self._reconnect_ok_after:
                             # Backoff active — skip this attempt, publish bad quality.
-                            await self._publish_disconnected_if_needed("Modbus TCP reconnect backoff active")
+                            await self._publish_disconnected_if_needed("Modbus TCP reconnect backoff active", code="modbusReconnectBackoff")
                             reconnect_failed = True
                         else:
                             try:
@@ -269,7 +286,7 @@ class ModbusTcpAdapter(AdapterBase):
                                     self._reconnect_ok_after = 0.0  # clear backoff on success
                                     host = self._adp_cfg.host
                                     port = self._adp_cfg.port
-                                    await self._publish_status(True, f"{host}:{port}")
+                                    await self._publish_status(True, f"{host}:{port}", code="connectedTo", params={"host": host, "port": port})
                                     logger.info(
                                         "Modbus TCP: reconnected in poll loop (binding %s)",
                                         binding.id,
@@ -281,6 +298,8 @@ class ModbusTcpAdapter(AdapterBase):
                                     )
                                     await self._publish_disconnected_if_needed(
                                         f"Could not reconnect to {self._adp_cfg.host}:{self._adp_cfg.port}",
+                                        code="couldNotReconnectTo",
+                                        params={"host": self._adp_cfg.host, "port": self._adp_cfg.port},
                                     )
                                     logger.warning(
                                         "Modbus TCP: connect() succeeded but client still disconnected (binding %s)",
@@ -440,9 +459,9 @@ class ModbusTcpAdapter(AdapterBase):
                 continue
         return max(0.0, min(intervals))
 
-    async def _publish_disconnected_if_needed(self, detail: str) -> None:
+    async def _publish_disconnected_if_needed(self, detail: str, *, code: str | None = None, params: dict | None = None) -> None:
         if self.connected:
-            await self._publish_status(False, detail)
+            await self._publish_status(False, detail, code=code, params=params)
 
     async def _modbus_call(self, fn, *pos_args, unit_id: int, **extra_kwargs) -> Any:
         """Version-safe pymodbus call across 2.x / 3.x / 3.12+.

--- a/obs/adapters/mqtt/adapter.py
+++ b/obs/adapters/mqtt/adapter.py
@@ -128,7 +128,7 @@ class MqttAdapter(AdapterBase):
             import aiomqtt  # noqa: F401
         except ImportError:
             logger.error("aiomqtt not installed — MQTT adapter disabled")
-            await self._publish_status(False, "aiomqtt not installed")
+            await self._publish_status(False, "aiomqtt not installed", code="libNotInstalled", params={"lib": "aiomqtt"})
             return
 
         self._cfg = MqttAdapterConfig(**self._config)
@@ -150,7 +150,12 @@ class MqttAdapter(AdapterBase):
             self._tls_context = ctx
 
         self._pub_task = asyncio.create_task(self._publisher_loop(), name="mqtt-adapter-pub")
-        await self._publish_status(False, f"Connecting to {self._cfg.host}:{self._cfg.port}...")
+        await self._publish_status(
+            False,
+            f"Connecting to {self._cfg.host}:{self._cfg.port}...",
+            code="connecting",
+            params={"host": self._cfg.host, "port": self._cfg.port},
+        )
         logger.info("MQTT adapter started → %s:%d", self._cfg.host, self._cfg.port)
 
     async def disconnect(self) -> None:
@@ -164,7 +169,7 @@ class MqttAdapter(AdapterBase):
         self._pub_task = None
         self._sub_task = None
         self._topic_map.clear()
-        await self._publish_status(False, "Disconnected")
+        await self._publish_status(False, "Disconnected", code="disconnected")
 
     # ------------------------------------------------------------------
     # Bindings
@@ -314,7 +319,12 @@ class MqttAdapter(AdapterBase):
                     identifier=self._pub_client_id,
                     tls_context=self._tls_context,
                 ) as client:
-                    await self._publish_status(True, f"Connected to {cfg.host}:{cfg.port}")
+                    await self._publish_status(
+                        True,
+                        f"Connected to {cfg.host}:{cfg.port}",
+                        code="connectedTo",
+                        params={"host": cfg.host, "port": cfg.port},
+                    )
                     logger.info("MQTT adapter publisher connected")
                     while True:
                         topic, payload, retain = await self._publish_queue.get()
@@ -324,7 +334,12 @@ class MqttAdapter(AdapterBase):
                 raise
             except Exception:
                 logger.exception("MQTT adapter publisher error, reconnecting in 5 s")
-                await self._publish_status(False, f"Reconnecting to {cfg.host}:{cfg.port}...")
+                await self._publish_status(
+                    False,
+                    f"Reconnecting to {cfg.host}:{cfg.port}...",
+                    code="reconnecting",
+                    params={"host": cfg.host, "port": cfg.port},
+                )
                 await asyncio.sleep(5)
 
     # ------------------------------------------------------------------

--- a/obs/adapters/onewire/adapter.py
+++ b/obs/adapters/onewire/adapter.py
@@ -78,18 +78,18 @@ class OneWireAdapter(AdapterBase):
                 "1-Wire path %s not found — adapter disabled (Linux only, needs w1-therm kernel module)",
                 w1_path,
             )
-            await self._publish_status(False, f"{w1_path} not found")
+            await self._publish_status(False, f"{w1_path} not found", code="pathNotFound", params={"path": w1_path})
             return
 
         self._available = True
-        await self._publish_status(True, f"1-Wire bus at {w1_path}")
+        await self._publish_status(True, f"1-Wire bus at {w1_path}", code="onewireBusAt", params={"path": w1_path})
         logger.info("1-Wire adapter connected: %s", w1_path)
 
     async def disconnect(self) -> None:
         for t in self._poll_tasks:
             t.cancel()
         self._poll_tasks.clear()
-        await self._publish_status(False, "Disconnected")
+        await self._publish_status(False, "Disconnected", code="disconnected")
 
     # ------------------------------------------------------------------
     # Bindings

--- a/obs/adapters/registry.py
+++ b/obs/adapters/registry.py
@@ -333,27 +333,54 @@ async def reload_instance_from_rows(instance: Any, rows: list[Any]) -> tuple[lis
 
 async def _publish_binding_load_status(instance: Any, issues: list[BindingLoadIssue]) -> None:
     if not issues:
-        if getattr(instance, "last_detail", "").startswith(_BINDING_LOAD_DETAIL_PREFIX):
+        # Clear a previously raised binding-load warning. Match on the i18n code
+        # (issue #779) and fall back to the legacy detail prefix for safety.
+        is_binding_warning = getattr(instance, "last_detail_code", None) == "invalidBindingsSkipped" or getattr(
+            instance,
+            "last_detail",
+            "",
+        ).startswith(_BINDING_LOAD_DETAIL_PREFIX)
+        if is_binding_warning:
             await _set_instance_status(instance, "ok", "")
         return
 
-    detail = _format_binding_load_detail(issues)
-    await _set_instance_status(instance, "warning", detail)
+    examples = _format_binding_load_examples(issues)
+    detail = f"{_BINDING_LOAD_DETAIL_PREFIX}: {len(issues)} invalid binding(s) skipped ({examples})"
+    await _set_instance_status(
+        instance,
+        "warning",
+        detail,
+        code="invalidBindingsSkipped",
+        params={"count": len(issues), "examples": examples},
+    )
+
+
+def _format_binding_load_examples(issues: list[BindingLoadIssue]) -> str:
+    examples = "; ".join(f"{i.binding_id}: {i.reason}" for i in issues[:3])
+    suffix = f"; +{len(issues) - 3} more" if len(issues) > 3 else ""
+    return f"{examples}{suffix}"
 
 
 def _format_binding_load_detail(issues: list[BindingLoadIssue]) -> str:
-    examples = "; ".join(f"{i.binding_id}: {i.reason}" for i in issues[:3])
-    suffix = f"; +{len(issues) - 3} more" if len(issues) > 3 else ""
-    return f"{_BINDING_LOAD_DETAIL_PREFIX}: {len(issues)} invalid binding(s) skipped ({examples}{suffix})"
+    return f"{_BINDING_LOAD_DETAIL_PREFIX}: {len(issues)} invalid binding(s) skipped ({_format_binding_load_examples(issues)})"
 
 
-async def _set_instance_status(instance: Any, severity: str, detail: str) -> None:
+async def _set_instance_status(
+    instance: Any,
+    severity: str,
+    detail: str,
+    *,
+    code: str | None = None,
+    params: dict | None = None,
+) -> None:
     publish = getattr(instance, "_publish_status", None)
     if publish is not None:
-        await publish(getattr(instance, "connected", False), detail=detail, severity=severity)
+        await publish(getattr(instance, "connected", False), detail=detail, severity=severity, code=code, params=params)
         return
     instance._last_severity = severity
     instance._last_detail = detail
+    instance._last_detail_code = code
+    instance._last_detail_params = params or {}
 
 
 def _row_value(row: Any, key: str) -> str | None:

--- a/obs/adapters/snmp/adapter.py
+++ b/obs/adapters/snmp/adapter.py
@@ -310,7 +310,7 @@ class SnmpAdapter(AdapterBase):
         if not self._snmp:
             msg = "pysnmp nicht installiert — SNMP deaktiviert. Ausführen: pip install pysnmp"
             logger.error(msg)
-            await self._publish_status(False, msg)
+            await self._publish_status(False, msg, code="libNotInstalled", params={"lib": "pysnmp"})
             return
 
         self._engine = self._snmp["SnmpEngine"]()
@@ -329,7 +329,7 @@ class SnmpAdapter(AdapterBase):
             t.cancel()
         self._poll_tasks.clear()
         self._engine = None
-        await self._publish_status(False, "Getrennt")
+        await self._publish_status(False, "Getrennt", code="disconnected")
 
     # ------------------------------------------------------------------
     # Bindings

--- a/obs/adapters/zeitschaltuhr/adapter.py
+++ b/obs/adapters/zeitschaltuhr/adapter.py
@@ -387,7 +387,7 @@ class ZeitschaltuhrAdapter(AdapterBase):
         self._tz = await self._resolve_timezone()
         self._hol = self._build_holidays()
         self._connected = True
-        await self._publish_status(True, "Zeitschaltuhr gestartet")
+        await self._publish_status(True, "Zeitschaltuhr gestartet", code="started")
         self._task = asyncio.create_task(
             self._timer_loop(),
             name=f"zeitschaltuhr_{self._instance_id}",
@@ -409,7 +409,7 @@ class ZeitschaltuhrAdapter(AdapterBase):
                 pass
             self._task = None
         self._connected = False
-        await self._publish_status(False, "Zeitschaltuhr gestoppt")
+        await self._publish_status(False, "Zeitschaltuhr gestoppt", code="stopped")
 
     async def reload_bindings(self, bindings: list[Any]) -> None:
         """Überschreibt Base-Methode: filtert ungültige Richtungen vor dem Speichern."""

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -52,7 +52,9 @@ class AdapterInstanceOut(BaseModel):
     running: bool
     connected: bool
     severity: str = "ok"  # "ok" | "warning" | "error" — last AdapterStatusEvent
-    status_detail: str = ""
+    status_detail: str = ""  # non-localized fallback (issue #779)
+    status_detail_code: str | None = None  # key suffix under adapters.statusDetail.*
+    status_detail_params: dict = {}
     bindings: int
     created_at: str
     updated_at: str
@@ -112,7 +114,9 @@ class TestRequest(BaseModel):
 
 class TestResult(BaseModel):
     success: bool
-    detail: str
+    detail: str  # non-localized fallback (issue #779)
+    detail_code: str | None = None  # key suffix under adapters.testResult.*
+    detail_params: dict = {}
 
 
 class IoBrokerStateOut(BaseModel):
@@ -178,6 +182,8 @@ def _instance_out(row: Any, instance: Any | None) -> AdapterInstanceOut:
         connected=instance.connected if instance else False,
         severity=getattr(instance, "last_severity", "ok") if instance else "ok",
         status_detail=getattr(instance, "last_detail", "") if instance else "",
+        status_detail_code=getattr(instance, "last_detail_code", None) if instance else None,
+        status_detail_params=getattr(instance, "last_detail_params", {}) if instance else {},
         bindings=len(instance.get_bindings()) if instance else 0,
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -353,6 +359,8 @@ async def test_instance(
         return TestResult(
             success=False,
             detail=f"Adapter-Typ '{row['adapter_type']}' nicht registriert",
+            detail_code="typeNotRegistered",
+            detail_params={"type": row["adapter_type"]},
         )
 
     if body and body.config:
@@ -364,7 +372,7 @@ async def test_instance(
     try:
         cls.config_schema(**config_dict)
     except Exception as exc:
-        return TestResult(success=False, detail=f"Config-Fehler: {exc}")
+        return TestResult(success=False, detail=f"Config-Fehler: {exc}", detail_code="configError", detail_params={"error": str(exc)})
 
     from obs.core.event_bus import EventBus
 
@@ -380,8 +388,13 @@ async def test_instance(
         connected = test_instance.connected
         await test_instance.disconnect()
         if connected:
-            return TestResult(success=True, detail=f"Verbindung zu {row['adapter_type']} erfolgreich")
-        return TestResult(success=False, detail="Verbindungsversuch fehlgeschlagen")
+            return TestResult(
+                success=True,
+                detail=f"Verbindung zu {row['adapter_type']} erfolgreich",
+                detail_code="connectOk",
+                detail_params={"type": row["adapter_type"]},
+            )
+        return TestResult(success=False, detail="Verbindungsversuch fehlgeschlagen", detail_code="connectFailed")
     except Exception as exc:
         return TestResult(success=False, detail=str(exc))
 
@@ -1242,7 +1255,12 @@ async def test_adapter(
     try:
         cls.config_schema(**body.config)
     except Exception as exc:
-        return TestResult(success=False, detail=f"Config-Validierungsfehler: {exc}")
+        return TestResult(
+            success=False,
+            detail=f"Config-Validierungsfehler: {exc}",
+            detail_code="configValidationError",
+            detail_params={"error": str(exc)},
+        )
 
     from obs.core.event_bus import EventBus
 
@@ -1258,8 +1276,13 @@ async def test_adapter(
         connected = test_instance.connected
         await test_instance.disconnect()
         if connected:
-            return TestResult(success=True, detail=f"Verbindung zu {adapter_type} erfolgreich")
-        return TestResult(success=False, detail="Verbindungsversuch fehlgeschlagen")
+            return TestResult(
+                success=True,
+                detail=f"Verbindung zu {adapter_type} erfolgreich",
+                detail_code="connectOk",
+                detail_params={"type": adapter_type},
+            )
+        return TestResult(success=False, detail="Verbindungsversuch fehlgeschlagen", detail_code="connectFailed")
     except Exception as exc:
         return TestResult(success=False, detail=str(exc))
 

--- a/obs/core/event_bus.py
+++ b/obs/core/event_bus.py
@@ -57,6 +57,10 @@ class AdapterStatusEvent:
     instance_id: uuid.UUID | None = None
     instance_name: str = ""
     severity: Severity = "ok"
+    # i18n (issue #779): stable key suffix under `adapters.statusDetail.*` plus
+    # interpolation params. `detail` remains the non-localized fallback.
+    detail_code: str | None = None
+    detail_params: dict[str, Any] = field(default_factory=dict)
     ts: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/scripts/check-i18n-hardcoded-strings.sh
+++ b/scripts/check-i18n-hardcoded-strings.sh
@@ -9,8 +9,15 @@ cd "$REPO_ROOT"
 BASE_REF="${I18N_DIFF_BASE:-}"
 HEAD_REF="${I18N_DIFF_HEAD:-}"
 
+# Two diff-scoped gates run back-to-back; both must pass:
+#   - check_i18n_guard.py:    frontend (gui/src, frontend/src) hardcoded strings + locale parity
+#   - check_adapter_i18n.py:  backend adapter status/test strings must use locale codes (issue #779)
+declare -a diff_args=()
 if [[ -n "$BASE_REF" && -n "$HEAD_REF" ]]; then
-  exec python3 "$SCRIPT_DIR/check_i18n_guard.py" --base "$BASE_REF" --head "$HEAD_REF" "$@"
+  diff_args=(--base "$BASE_REF" --head "$HEAD_REF")
 fi
 
-exec python3 "$SCRIPT_DIR/check_i18n_guard.py" "$@"
+status=0
+python3 "$SCRIPT_DIR/check_i18n_guard.py" "${diff_args[@]}" "$@" || status=1
+python3 "$SCRIPT_DIR/check_adapter_i18n.py" "${diff_args[@]}" "$@" || status=1
+exit "$status"

--- a/scripts/check_adapter_i18n.py
+++ b/scripts/check_adapter_i18n.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Diff-scoped i18n hard gate for backend adapter status/test strings (issue #779).
+
+The frontend guard (``check_i18n_guard.py``) only scans ``gui/src`` + ``frontend/src``,
+so user-facing German that originates in backend adapter code escapes detection. This
+gate closes that gap with two structural checks on the changed backend files:
+
+1. **Status/test calls must use a code.** Any call to ``_publish_status`` /
+   ``TestResult`` (and the thin adapter/registry wrappers around them) whose ``detail``
+   argument is a non-empty *string literal* must also pass a stable ``code=`` /
+   ``detail_code=`` key (under ``adapters.statusDetail.*`` / ``adapters.testResult.*``).
+   Dynamic fallbacks (f-strings, variables, ``str(exc)``) are allowed without a code —
+   they are the agreed non-localized technical fallback.
+
+2. **Referenced codes must exist with locale parity.** Every ``code`` / ``detail_code``
+   literal referenced in a changed file must exist in both ``gui/src/locales/en.json``
+   and ``de.json`` under the matching namespace.
+
+Scope: ``obs/adapters/**/*.py`` and ``obs/api/v1/adapters.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Functions that publish a user-facing status detail, mapped to the positional index
+# of their ``detail`` argument (``detail`` may also be passed by keyword).
+STATUS_FUNCS = {
+    "_publish_status": 1,  # (connected, detail, ...)
+    "_publish_disconnected_if_needed": 0,  # (detail, ...)
+    "_publish_warning_status": 0,
+    "_publish_connected_status": 0,
+    "_set_instance_status": 2,  # (instance, severity, detail, ...)
+}
+# Calls whose ``detail``/``detail_code`` live under adapters.testResult.* instead.
+TESTRESULT_FUNC = "TestResult"
+
+STATUS_NS = "adapters.statusDetail"
+TESTRESULT_NS = "adapters.testResult"
+
+LOCALES = ("gui/src/locales/en.json", "gui/src/locales/de.json")
+
+
+@dataclass
+class Violation:
+    path: str
+    line: int
+    message: str
+
+
+def run_git_diff(repo_root: Path, base: str | None, head: str | None) -> list[str]:
+    candidates: list[list[str]] = []
+    if base and head:
+        candidates.append(["git", "diff", "--name-only", f"{base}...{head}"])
+        candidates.append(["git", "diff", "--name-only", base, head])
+    candidates.extend(
+        [
+            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            ["git", "diff", "--name-only", "main...HEAD"],
+            ["git", "diff", "--name-only", "HEAD~1...HEAD"],
+        ],
+    )
+    for cmd in candidates:
+        proc = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)  # noqa: S603
+        if proc.returncode == 0:
+            files = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+            return sorted(set(files)) if files else []
+    tried = " | ".join(" ".join(c) for c in candidates)
+    raise RuntimeError(f"Could not determine changed files via git diff ({tried})")
+
+
+def is_target(rel_path: str) -> bool:
+    return (rel_path.startswith("obs/adapters/") and rel_path.endswith(".py")) or rel_path == "obs/api/v1/adapters.py"
+
+
+def _string_const(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _detail_node(call: ast.Call, positional_index: int) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == "detail":
+            return kw.value
+    if len(call.args) > positional_index:
+        return call.args[positional_index]
+    return None
+
+
+def _code_literal(call: ast.Call, code_kw: str) -> str | None | bool:
+    """Return the code string literal, None if absent, or False if present but non-literal."""
+    for kw in call.keywords:
+        if kw.arg == code_kw:
+            lit = _string_const(kw.value)
+            return lit if lit is not None else False
+    return None
+
+
+def _call_name(call: ast.Call) -> str | None:
+    fn = call.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    if isinstance(fn, ast.Name):
+        return fn.id
+    return None
+
+
+def scan_file(rel_path: str, source: str) -> tuple[list[Violation], list[tuple[int, str, str]]]:
+    """Return (violations, referenced_codes) where referenced_codes = [(line, namespace, code)]."""
+    violations: list[Violation] = []
+    referenced: list[tuple[int, str, str]] = []
+    tree = ast.parse(source, filename=rel_path)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        if name in STATUS_FUNCS:
+            ns, code_kw, det_idx = STATUS_NS, "code", STATUS_FUNCS[name]
+        elif name == TESTRESULT_FUNC:
+            ns, code_kw, det_idx = TESTRESULT_NS, "detail_code", -1
+            # TestResult always passes detail by keyword; no positional detail slot.
+        else:
+            continue
+
+        detail_literal = _string_const(_detail_node(node, det_idx))
+        code = _code_literal(node, code_kw)
+
+        if detail_literal and (code is None):
+            violations.append(
+                Violation(
+                    rel_path,
+                    node.lineno,
+                    f"{name}(...) has a hardcoded detail {detail_literal!r} but no {code_kw}= "
+                    f"(add a stable code under {ns}.* or pass dynamic text instead)",
+                ),
+            )
+        # A literal code is validated against the locale files; a variable/pass-through
+        # code (e.g. wrappers forwarding code=code) cannot be checked statically and is
+        # accepted as-is — its callers supply the literal codes that do get validated.
+        if isinstance(code, str):
+            referenced.append((node.lineno, ns, code))
+    return violations, referenced
+
+
+def load_locale(repo_root: Path, rel: str) -> dict:
+    return json.loads((repo_root / rel).read_text(encoding="utf-8"))
+
+
+def lookup(locale: dict, dotted: str) -> bool:
+    cur: object = locale
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False
+        cur = cur[part]
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Diff-scoped backend adapter i18n hard gate (issue #779)")
+    parser.add_argument("--base", default=None)
+    parser.add_argument("--head", default=None)
+    parser.add_argument("files", nargs="*", help="Explicit files to scan instead of deriving from git diff")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+
+    changed = sorted(set(args.files)) if args.files else run_git_diff(repo_root, args.base, args.head)
+    targets = [p for p in changed if is_target(p)]
+    if not targets:
+        print("adapter i18n guard: no changed backend adapter files in diff; nothing to do.")
+        return 0
+
+    violations: list[Violation] = []
+    referenced: list[tuple[str, int, str, str]] = []
+    for rel in targets:
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        file_violations, file_refs = scan_file(rel, path.read_text(encoding="utf-8"))
+        violations.extend(file_violations)
+        referenced.extend((rel, line, ns, code) for line, ns, code in file_refs)
+
+    locales = {rel: load_locale(repo_root, rel) for rel in LOCALES}
+    for rel, line, ns, code in referenced:
+        dotted = f"{ns}.{code}"
+        for loc_rel, data in locales.items():
+            if not lookup(data, dotted):
+                violations.append(Violation(rel, line, f"code {dotted!r} is missing from {loc_rel}"))
+
+    if violations:
+        print("adapter i18n guard: violations detected:")
+        for v in sorted(violations, key=lambda x: (x.path, x.line)):
+            print(f"  {v.path}:{v.line}: {v.message}")
+        print("adapter i18n guard: FAILED")
+        return 1
+
+    print(f"adapter i18n guard: OK (scanned {len(targets)} backend file(s), {len(referenced)} code reference(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/adapters/test_adapter_base.py
+++ b/tests/adapters/test_adapter_base.py
@@ -67,6 +67,8 @@ class TestAdapterBaseInit:
         assert a.connected is False
         assert a.last_severity == "ok"
         assert a.last_detail == ""
+        assert a.last_detail_code is None
+        assert a.last_detail_params == {}
 
     def test_custom_instance_id_preserved(self, mock_bus):
         iid = uuid.uuid4()
@@ -135,6 +137,29 @@ class TestPublishStatus:
         await a._publish_status(False, severity="warning")
         assert a.connected is True  # warning never flips connected
         assert a.last_severity == "warning"
+
+    @pytest.mark.asyncio
+    async def test_code_and_params_cached_and_published(self, mock_bus):
+        a = _MinimalAdapter(event_bus=mock_bus)
+        await a._publish_status(True, detail="Connected to h:1", code="connectedTo", params={"host": "h", "port": 1})
+        assert a.last_detail_code == "connectedTo"
+        assert a.last_detail_params == {"host": "h", "port": 1}
+        event = mock_bus.publish.call_args.args[0]
+        assert event.detail_code == "connectedTo"
+        assert event.detail_params == {"host": "h", "port": 1}
+        assert event.detail == "Connected to h:1"
+
+    @pytest.mark.asyncio
+    async def test_code_defaults_to_none_and_params_to_empty_dict(self, mock_bus):
+        a = _MinimalAdapter(event_bus=mock_bus)
+        a._last_detail_code = "stale"
+        a._last_detail_params = {"x": 1}
+        await a._publish_status(False, detail="raw error text")
+        assert a.last_detail_code is None
+        assert a.last_detail_params == {}
+        event = mock_bus.publish.call_args.args[0]
+        assert event.detail_code is None
+        assert event.detail_params == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_homeassistant.py
+++ b/tests/adapters/test_homeassistant.py
@@ -607,3 +607,89 @@ class TestHaBindingConfig:
         assert bc.service_domain == "light"
         assert bc.service_name == "turn_on"
         assert bc.service_data_key == "brightness"
+
+
+# ---------------------------------------------------------------------------
+# _ws_loop — auth / connect / error status codes (issue #779)
+# ---------------------------------------------------------------------------
+
+
+class _FakeWS:
+    """Minimal async-context-manager websocket that replays scripted messages."""
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def recv(self):
+        import asyncio as _asyncio
+
+        if not self._messages:
+            raise _asyncio.CancelledError
+        item = self._messages.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+async def _run_ws_loop(adapter, messages, monkeypatch):
+    import asyncio
+    import contextlib
+    import sys
+
+    async def _cancel_sleep(*_a, **_k):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", _cancel_sleep)
+    fake_ws = _FakeWS(messages)
+    fake_websockets = MagicMock()
+    fake_websockets.connect = MagicMock(return_value=fake_ws)
+    monkeypatch.setitem(sys.modules, "websockets", fake_websockets)
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await adapter._ws_loop()
+    return fake_ws
+
+
+@pytest.mark.asyncio
+async def test_ws_loop_auth_invalid_emits_token_invalid(adapter, monkeypatch):
+    import json
+
+    messages = [json.dumps({"type": "auth_required"}), json.dumps({"type": "auth_invalid"})]
+    await _run_ws_loop(adapter, messages, monkeypatch)
+    assert adapter.last_detail_code == "tokenInvalid"
+
+
+@pytest.mark.asyncio
+async def test_ws_loop_auth_ok_emits_connected_ha(adapter, monkeypatch):
+    import json
+
+    messages = [
+        json.dumps({"type": "auth_required"}),
+        json.dumps({"type": "auth_ok", "ha_version": "2025.1"}),
+        json.dumps({"success": True}),
+    ]
+    await _run_ws_loop(adapter, messages, monkeypatch)
+    assert adapter.last_detail_code == "connectedHa"
+    assert adapter.last_detail_params == {"version": "2025.1"}
+
+
+@pytest.mark.asyncio
+async def test_ws_loop_exception_emits_ws_error(adapter, monkeypatch):
+    await _run_ws_loop(adapter, [RuntimeError("boom")], monkeypatch)
+    assert adapter.last_detail_code == "wsErrorReconnecting"

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -6,6 +6,8 @@ Keine echte ioBroker-Instanz erforderlich — Socket.IO-Client wird gemockt.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from datetime import UTC, datetime, time, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -13,7 +15,13 @@ import pytest
 
 from obs.core.event_bus import AdapterStatusEvent, DataValueEvent
 from tests.adapters.conftest import make_binding
-from obs.adapters.iobroker.adapter import IoBrokerAdapter, IoBrokerAdapterConfig, _EngineIOQueueFilter, _coerce_iobroker_value
+from obs.adapters.iobroker.adapter import (
+    WATCHDOG_SUBSCRIBE_WARNING_DETAIL,
+    IoBrokerAdapter,
+    IoBrokerAdapterConfig,
+    _EngineIOQueueFilter,
+    _coerce_iobroker_value,
+)
 
 
 @pytest.fixture
@@ -800,3 +808,26 @@ class TestWrite:
             ("0_userdata.0.time", {"val": "10:30:00", "ack": False}),
             timeout=10.0,
         )
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_publishes_warning_on_failure(adapter):
+    """The watchdog loop emits the watchdogSubscribeFailed code when a resync raises."""
+    adapter._cfg = adapter.config_schema(**{**adapter._config, "resubscribe_interval_seconds": 0})
+    adapter._publish_warning_status = AsyncMock()
+
+    async def _boom(**_kwargs):
+        raise RuntimeError("subscribe failed")
+
+    adapter._subscribe_bound_states = _boom
+
+    task = asyncio.create_task(adapter._subscription_watchdog())
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if adapter._publish_warning_status.await_count:
+            break
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    adapter._publish_warning_status.assert_awaited_with(WATCHDOG_SUBSCRIBE_WARNING_DETAIL, code="watchdogSubscribeFailed")

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -364,7 +364,7 @@ class TestReconnect:
         await socket.disconnect()
 
         assert adapter._socket is None
-        adapter._publish_status.assert_awaited_once_with(False, "Socket.IO getrennt")
+        adapter._publish_status.assert_awaited_once_with(False, "Socket.IO getrennt", code="socketDisconnected")
         adapter._ensure_reconnect_task.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/adapters/test_knx.py
+++ b/tests/adapters/test_knx.py
@@ -161,6 +161,27 @@ class TestDoConnectSecure:
         assert "backbone_key" in event.detail.lower() or "backbone" in event.detail.lower()
 
     @pytest.mark.asyncio
+    async def test_routing_secure_keyfile_without_backbone_publishes_error(self, mock_bus, monkeypatch):
+        """Keyfile yields no backbone entry → knxNoBackboneKeyInKeyfile code (issue #779)."""
+        import obs.adapters.knx.adapter as knx_mod
+
+        monkeypatch.setattr(knx_mod, "_secure_config_from_keyfile", lambda *a, **k: None)
+        adapter = KnxAdapter(
+            event_bus=mock_bus,
+            config={
+                "connection_type": "routing_secure",
+                "host": "239.0.0.1",
+                "knxkeys_file_path": "/tmp/does-not-matter.knxkeys",
+                "knxkeys_password": "pw",
+            },
+        )
+        await adapter._do_connect()
+
+        event = mock_bus.publish.call_args[0][0]
+        assert event.connected is False
+        assert event.detail_code == "knxNoBackboneKeyInKeyfile"
+
+    @pytest.mark.asyncio
     async def test_routing_secure_invalid_backbone_key_publishes_error(self, mock_bus):
         """routing_secure mit ungültigem Hex → Status-Fehler, kein Absturz."""
         adapter = KnxAdapter(

--- a/tests/adapters/test_modbus_adapters.py
+++ b/tests/adapters/test_modbus_adapters.py
@@ -204,6 +204,31 @@ class TestModbusTcpConnect:
         assert t.cancelled()
         client.close.assert_called_once()
 
+    async def test_connect_success_emits_connected_code(self):
+        adapter, bus = _make_tcp()
+        client = _make_client(connected=True)
+        fake_mod = MagicMock()
+        fake_mod.AsyncModbusTcpClient = MagicMock(return_value=client)
+        with patch.dict("sys.modules", {"pymodbus.client": fake_mod}):
+            await adapter.connect()
+        event = bus.publish.call_args_list[-1].args[0]
+        assert event.detail_code == "connectedTo"
+        assert event.detail_params == {"host": adapter._adp_cfg.host, "port": adapter._adp_cfg.port}
+
+    async def test_publish_disconnected_if_needed_forwards_code(self):
+        adapter, bus = _make_tcp()
+        adapter._connected = True
+        await adapter._publish_disconnected_if_needed("backoff", code="modbusReconnectBackoff")
+        event = bus.publish.call_args_list[-1].args[0]
+        assert event.connected is False
+        assert event.detail_code == "modbusReconnectBackoff"
+
+    async def test_publish_disconnected_if_needed_noop_when_disconnected(self):
+        adapter, bus = _make_tcp()
+        adapter._connected = False
+        await adapter._publish_disconnected_if_needed("ignored", code="modbusReconnectBackoff")
+        bus.publish.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # connect / disconnect — RTU

--- a/tests/adapters/test_mqtt_adapter.py
+++ b/tests/adapters/test_mqtt_adapter.py
@@ -738,10 +738,10 @@ class TestPublisherLoop:
         connected_event = asyncio.Event()
         original_publish_status = adapter._publish_status
 
-        async def track_status(connected, detail="", severity="ok"):
+        async def track_status(connected, detail="", severity="ok", *, code=None, params=None):
             if connected:
                 connected_event.set()
-            await original_publish_status(connected, detail, severity)
+            await original_publish_status(connected, detail, severity, code=code, params=params)
 
         adapter._publish_status = track_status
 

--- a/tests/adapters/test_zeitschaltuhr.py
+++ b/tests/adapters/test_zeitschaltuhr.py
@@ -7,7 +7,9 @@ are all pure / near-pure methods that can be tested without asyncio.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from obs.adapters.zeitschaltuhr.adapter import (
     HolidayMode,
@@ -50,6 +52,33 @@ def _now(hour: int = 8, minute: int = 0, weekday_offset: int = 0) -> datetime:
 
     base = datetime(2026, 4, 6, hour, minute, 0, tzinfo=UTC)  # a Monday
     return base + timedelta(days=weekday_offset)
+
+
+# ---------------------------------------------------------------------------
+# connect / disconnect — i18n status codes (issue #779)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectDisconnect:
+    @pytest.mark.asyncio
+    async def test_connect_emits_started_code(self):
+        adapter = _make_adapter()
+        adapter._bus.publish = AsyncMock()
+        await adapter.connect()
+        try:
+            assert adapter.last_detail_code == "started"
+            assert adapter.connected is True
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_emits_stopped_code(self):
+        adapter = _make_adapter()
+        adapter._bus.publish = AsyncMock()
+        await adapter.connect()
+        await adapter.disconnect()
+        assert adapter.last_detail_code == "stopped"
+        assert adapter.connected is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_adapters_instances.py
+++ b/tests/integration/test_adapters_instances.py
@@ -265,6 +265,52 @@ async def test_test_instance_returns_result(client, auth_headers):
     body = resp.json()
     assert "success" in body
     assert "detail" in body
+    # issue #779: response carries a translatable code + params alongside the raw detail
+    assert "detail_code" in body
+    assert "detail_params" in body
+    if body["success"]:
+        assert body["detail_code"] == "connectOk"
+        assert body["detail_params"] == {"type": _ADAPTER_TYPE}
+
+
+# ---------------------------------------------------------------------------
+# POST /{adapter_type}/test  (type-level, ephemeral)
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_type_test_requires_auth(client):
+    resp = await client.post(f"/api/v1/adapters/{_ADAPTER_TYPE}/test", json={"config": {}})
+    assert resp.status_code == 401
+
+
+async def test_adapter_type_test_unregistered_returns_404(client, auth_headers):
+    resp = await client.post("/api/v1/adapters/NOPE/test", json={"config": {}}, headers=auth_headers)
+    assert resp.status_code == 404
+
+
+async def test_adapter_type_test_returns_result_with_code(client, auth_headers):
+    resp = await client.post(f"/api/v1/adapters/{_ADAPTER_TYPE}/test", json={"config": {}}, headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body["success"], bool)
+    assert "detail_code" in body
+    if body["success"]:
+        assert body["detail_code"] == "connectOk"
+        assert body["detail_params"] == {"type": _ADAPTER_TYPE}
+
+
+async def test_adapter_type_test_invalid_config_returns_validation_code(client, auth_headers):
+    # offset_days expects an int; a list cannot be coerced → config validation error.
+    resp = await client.post(
+        f"/api/v1/adapters/{_ADAPTER_TYPE}/test",
+        json={"config": {"offset_days": [1, 2]}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is False
+    assert body["detail_code"] == "configValidationError"
+    assert "error" in body["detail_params"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_check_adapter_i18n.py
+++ b/tests/unit/test_check_adapter_i18n.py
@@ -1,0 +1,102 @@
+"""Tests for scripts/check_adapter_i18n.py — the backend adapter i18n hard gate (issue #779)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "check_adapter_i18n.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_adapter_i18n", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the @dataclass in the module can resolve its own module.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module()
+
+
+REL = "obs/adapters/sample/adapter.py"
+
+
+def test_string_literal_detail_without_code_is_flagged():
+    src = 'async def f(self):\n    await self._publish_status(False, "Hardcoded German")\n'
+    violations, referenced = gate.scan_file(REL, src)
+    assert referenced == []
+    assert len(violations) == 1
+    assert "no code=" in violations[0].message
+
+
+def test_literal_detail_with_code_passes_and_is_referenced():
+    src = 'async def f(self):\n    await self._publish_status(False, "Disconnected", code="disconnected")\n'
+    violations, referenced = gate.scan_file(REL, src)
+    assert violations == []
+    assert referenced == [(2, gate.STATUS_NS, "disconnected")]
+
+
+def test_fstring_and_str_exc_details_need_no_code():
+    src = (
+        "async def f(self, exc, host, port):\n"
+        "    await self._publish_status(False, str(exc))\n"
+        '    await self._publish_status(True, f"{host}:{port}")\n'
+    )
+    violations, referenced = gate.scan_file(REL, src)
+    assert violations == []
+    assert referenced == []
+
+
+def test_testresult_uses_testresult_namespace():
+    src = 'def f():\n    return TestResult(success=False, detail="x", detail_code="connectFailed")\n'
+    violations, referenced = gate.scan_file(REL, src)
+    assert violations == []
+    assert referenced == [(2, gate.TESTRESULT_NS, "connectFailed")]
+
+
+def test_testresult_literal_detail_without_code_is_flagged():
+    src = 'def f():\n    return TestResult(success=True, detail="Verbindung erfolgreich")\n'
+    violations, _ = gate.scan_file(REL, src)
+    assert len(violations) == 1
+    assert "detail_code=" in violations[0].message
+
+
+def test_passthrough_variable_code_is_not_flagged_or_referenced():
+    # Wrapper forwarding a variable code (e.g. code=code) cannot be validated statically.
+    src = "async def f(self, detail, code):\n    await self._publish_status(False, detail, code=code)\n"
+    violations, referenced = gate.scan_file(REL, src)
+    assert violations == []
+    assert referenced == []
+
+
+def test_is_target_matches_adapters_and_adapter_api_only():
+    assert gate.is_target("obs/adapters/mqtt/adapter.py")
+    assert gate.is_target("obs/api/v1/adapters.py")
+    assert not gate.is_target("obs/core/event_bus.py")
+    assert not gate.is_target("obs/adapters/registry.md")
+
+
+def test_lookup_resolves_nested_keys():
+    data = {"adapters": {"statusDetail": {"disconnected": "Disconnected"}}}
+    assert gate.lookup(data, "adapters.statusDetail.disconnected")
+    assert not gate.lookup(data, "adapters.statusDetail.missing")
+    assert not gate.lookup(data, "adapters.testResult.connectOk")
+
+
+@pytest.mark.parametrize("rel", ["obs/adapters/mqtt/adapter.py", "obs/api/v1/adapters.py"])
+def test_real_files_reference_only_existing_codes(rel):
+    """Every code referenced by the shipped backend files must exist in both locales."""
+    source = (REPO_ROOT / rel).read_text(encoding="utf-8")
+    _, referenced = gate.scan_file(rel, source)
+    en = gate.load_locale(REPO_ROOT, "gui/src/locales/en.json")
+    de = gate.load_locale(REPO_ROOT, "gui/src/locales/de.json")
+    for _line, ns, code in referenced:
+        dotted = f"{ns}.{code}"
+        assert gate.lookup(en, dotted), f"{dotted} missing from en.json"
+        assert gate.lookup(de, dotted), f"{dotted} missing from de.json"

--- a/tests/unit/test_coverage_adapters_hierarchy_logic.py
+++ b/tests/unit/test_coverage_adapters_hierarchy_logic.py
@@ -147,6 +147,55 @@ class TestInstanceOut:
         assert result == []
 
 
+def _fake_adapter_cls(*, connect_raises=False, connected=False):
+    """A minimal adapter class for driving the connection-test endpoints (issue #779)."""
+
+    class _Fake:
+        config_schema = staticmethod(lambda **_kw: None)
+
+        def __init__(self, event_bus=None, config=None):
+            self.connected = connected
+
+        async def connect(self):
+            if connect_raises:
+                raise RuntimeError("boom")
+
+        async def disconnect(self):
+            return None
+
+    return _Fake
+
+
+class TestConnectionTestEndpoints:
+    """Cover the TestResult code paths of the two connection-test endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_instance_connect_failed_emits_code(self, monkeypatch):
+        from obs.api.v1 import adapters as adp_api
+
+        monkeypatch.setattr(adp_api.adapter_registry, "get_class", lambda t: _fake_adapter_cls(connected=False))
+        # Skip the 5 s poll: deadline=0+5, first check returns 999 → loop exits immediately.
+        loop = MagicMock()
+        loop.time = MagicMock(side_effect=[0.0, 999.0, 999.0])
+        monkeypatch.setattr(adp_api.asyncio, "get_event_loop", lambda: loop)
+
+        db = _DbStub(one=_inst_row(adapter_type="MQTT"))
+        result = await adp_api.test_instance(instance_id=uuid.uuid4(), body=None, _user="admin", db=db)
+        assert result.success is False
+        assert result.detail_code == "connectFailed"
+
+    @pytest.mark.asyncio
+    async def test_adapter_type_connect_exception_keeps_raw_detail(self, monkeypatch):
+        from obs.api.v1 import adapters as adp_api
+
+        monkeypatch.setattr(adp_api.adapter_registry, "get_class", lambda t: _fake_adapter_cls(connect_raises=True))
+        body = adp_api.TestRequest(config={})
+        result = await adp_api.test_adapter(adapter_type="MQTT", body=body, _user="admin")
+        assert result.success is False
+        assert result.detail_code is None  # dynamic exception text → no code
+        assert "boom" in result.detail
+
+
 class TestCreateInstance:
     @pytest.mark.asyncio
     async def test_create_instance_unknown_type(self, monkeypatch):

--- a/tests/unit/test_coverage_adapters_hierarchy_logic.py
+++ b/tests/unit/test_coverage_adapters_hierarchy_logic.py
@@ -112,6 +112,8 @@ class TestInstanceOut:
         inst.connected = True
         inst.last_severity = "warning"
         inst.last_detail = "some detail"
+        inst.last_detail_code = "knxTunnelOverload"
+        inst.last_detail_params = {}
         inst.get_bindings.return_value = [1, 2, 3]
         row = _inst_row()
         result = adp_api._instance_out(row, inst)
@@ -119,6 +121,7 @@ class TestInstanceOut:
         assert result.connected is True
         assert result.severity == "warning"
         assert result.status_detail == "some detail"
+        assert result.status_detail_code == "knxTunnelOverload"
         assert result.bindings == 3
 
     @pytest.mark.asyncio

--- a/tests/unit/test_issue_755_binding_diagnostics.py
+++ b/tests/unit/test_issue_755_binding_diagnostics.py
@@ -28,14 +28,18 @@ class _Instance:
         self.status_events = []
         self.last_severity = "ok"
         self.last_detail = ""
+        self.last_detail_code = None
+        self.last_detail_params = {}
 
     async def reload_bindings(self, bindings):
         self.bindings = bindings
 
-    async def _publish_status(self, connected, detail="", severity="ok"):
+    async def _publish_status(self, connected, detail="", severity="ok", *, code=None, params=None):
         self.status_events.append((connected, detail, severity))
         self.last_severity = severity
         self.last_detail = detail
+        self.last_detail_code = code
+        self.last_detail_params = params or {}
 
 
 class _PlainInstance:
@@ -197,6 +201,33 @@ async def test_binding_load_status_supports_instances_without_publish_status():
 
     assert instance._last_severity == "warning"
     assert "b1" in instance._last_detail
+    assert instance._last_detail_code == "invalidBindingsSkipped"
+    assert instance._last_detail_params == {"count": 1, "examples": "b1: ValueError: bad"}
+
+
+@pytest.mark.asyncio
+async def test_binding_load_status_emits_i18n_code_and_params():
+    instance = _Instance()
+    issue = adapter_registry.BindingLoadIssue(binding_id="b1", adapter_instance_id="i1", reason="ValueError: bad")
+
+    await adapter_registry._publish_binding_load_status(instance, [issue])
+
+    assert instance.last_severity == "warning"
+    assert instance.last_detail_code == "invalidBindingsSkipped"
+    assert instance.last_detail_params == {"count": 1, "examples": "b1: ValueError: bad"}
+
+
+@pytest.mark.asyncio
+async def test_binding_load_status_clears_warning_via_i18n_code():
+    instance = _Instance()
+    instance.last_detail = ""
+    instance.last_detail_code = "invalidBindingsSkipped"
+
+    await adapter_registry._publish_binding_load_status(instance, [])
+
+    assert instance.last_severity == "ok"
+    assert instance.last_detail == ""
+    assert instance.last_detail_code is None
 
 
 def test_binding_load_detail_shows_more_suffix():


### PR DESCRIPTION
# Summary
  
  German string literals in backend adapter code reached the GUI untranslated, bypassing the i18n/Weblate pipeline. This PR closes that gap for adapter status details, connection-test results, and
  config-schema labels, and adds a CI gate so new backend strings can't regress.

  Closes #779.
  
# Approach

  Adapters no longer push user-facing strings. Instead they emit a stable code + params, which the frontend translates via locale keys; genuinely dynamic/technical text (str(exc), version banners)
  passes through as a non-localized fallback. Schema labels reuse the existing SchemaForm.vue mechanism (adapters.schema.<TYPE>.<field>), which was already in place but lacked keys.

# What changed (by commit)

  1. feat(adapters) — _publish_status(..., *, code=None, params=None) + last_detail_code/last_detail_params; AdapterStatusEvent gains detail_code/detail_params. Fully backward compatible.
  2. refactor(adapters) — all ~57 _publish_status call sites across the 10 adapters + the registry binding-load warning now emit codes.
  3. feat(api) — AdapterInstanceOut exposes status_detail_code/status_detail_params; TestResult gains detail_code/detail_params for the connection-test endpoints.
  4. feat(gui) — adapterStatusDetailText() / feedbackText() translate codes (falling back to raw detail); locale keys (EN authoritative + DE) for status details, test results, and every field of all
  SchemaForm-rendered adapters.
  5. fix(i18n) — fallbackLocale: 'de' → 'en' in both frontends. English is the Weblate source language and must be complete, so missing keys should fall back to English.
  6. ci(i18n) — new scripts/check_adapter_i18n.py (AST-based, diff-scoped): a string-literal detail/TestResult.detail in changed obs/adapters/** or obs/api/v1/adapters.py must carry a code=, and
  referenced codes must exist in both locales. Wired into the i18n-guard workflow; AGENTS.MD updated (English-as-source + the new conventions).

# Out of scope

  - KNX & Anwesenheit config forms (custom, already $t()'d) and binding-config UI in BindingForm.vue (already i18n'd).
  - HTTPException error strings in adapters.py (e.g. "Instanz nicht gefunden") — a broader API-wide i18n concern for a follow-up.

# Testing

  - tools/lint.sh --check ✅
  - Backend: 3467 unit/adapter/contract + 699 integration tests pass; coverage held at 89% (changed adapters 96–100%).
  - GUI: npm run build ✅,  371 vitest pass (incl. new adapterStatus.spec.js); both i18n gates pass with EN/DE parity clean.
  - ⚠️ The Visu (frontend/) production build couldn't be validated locally — its linked node_modules is missing @vue/test-utils (pre-existing worktree gap, unrelated to the one-line fallbackLocale
  change). Worth a build from the main worktree before merge.

  🤖 Generated with Claude Code
