### PR TITLE
Fix ZSU binding filtering in visu widget

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,7 +11,7 @@
 * Backend/Admin GUI: Repeated `.knxproj` imports now replace automatically generated ETS hierarchies per selected mode by default, while manual hierarchy trees remain untouched; the import dialog also offers an opt-out to keep a separate tree for each import run. https://github.com/abeggled/openbridgeserver/issues/730
 
 ### Fixes 🐞
-* none
+* Visu: Zeitschaltuhr widgets now only show and manage Schaltpunkte for the configured scheduler instance, preventing unrelated KNX or other adapter bindings on the same object from being listed or deleted. https://github.com/abeggled/openbridgeserver/issues/782
 
 ### Known Issues 🔔
 * none

--- a/frontend/src/components/ZeitschaltuhrAddRemoveModal.test.ts
+++ b/frontend/src/components/ZeitschaltuhrAddRemoveModal.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { datapoints } from '@/api/client'
+import ZeitschaltuhrAddRemoveModal from './ZeitschaltuhrAddRemoveModal.vue'
+
+const apiMocks = vi.hoisted(() => ({
+  listBindings: vi.fn(),
+  updateBinding: vi.fn(),
+  deleteBinding: vi.fn(),
+  createBinding: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  datapoints: apiMocks,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (key === 'common.yes') return 'Yes'
+      if (key === 'common.no') return 'No'
+      if (key === 'zst.deleteConfirm') return `Delete ${params?.label}?`
+      return key
+    },
+  }),
+}))
+
+const listBindingsMock = vi.mocked(datapoints.listBindings)
+const deleteBindingMock = vi.mocked(datapoints.deleteBinding)
+
+let wrapper: VueWrapper | null = null
+
+function binding(id: string, adapterInstanceId: string, adapterType: string, value: string) {
+  return {
+    id,
+    datapoint_id: 'dp-1',
+    adapter_type: adapterType,
+    adapter_instance_id: adapterInstanceId,
+    instance_name: adapterType,
+    direction: 'SOURCE',
+    config: {
+      timer_type: 'daily',
+      time_ref: 'absolute',
+      hour: 8,
+      minute: 15,
+      value,
+    },
+    enabled: true,
+    created_at: '2026-06-11T00:00:00Z',
+    updated_at: '2026-06-11T00:00:00Z',
+  }
+}
+
+async function mountModal() {
+  wrapper = mount(ZeitschaltuhrAddRemoveModal, {
+    props: {
+      datapointId: 'dp-1',
+      instanceId: 'zsu-instance',
+      mode: 'full',
+    },
+    global: {
+      mocks: {
+        $t: (key: string, params?: Record<string, unknown>) => {
+          if (key === 'common.yes') return 'Yes'
+          if (key === 'common.no') return 'No'
+          if (key === 'zst.deleteConfirm') return `Delete ${params?.label}?`
+          return key
+        },
+      },
+      stubs: {
+        Teleport: true,
+        ZeitschaltuhrBindingModal: true,
+      },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+  vi.clearAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('ZeitschaltuhrAddRemoveModal binding filtering', () => {
+  it('only exposes bindings for the configured scheduler instance', async () => {
+    listBindingsMock.mockResolvedValue([
+      binding('zsu-binding', 'zsu-instance', 'ZEITSCHALTUHR', 'zsu-value'),
+      binding('knx-binding', 'knx-instance', 'KNX', 'knx-value'),
+    ])
+    deleteBindingMock.mockResolvedValue(undefined)
+
+    await mountModal()
+
+    expect(wrapper!.findAll('[data-testid="zsu-binding-row"]')).toHaveLength(1)
+    expect(wrapper!.text()).toContain('zsu-value')
+    expect(wrapper!.text()).not.toContain('knx-value')
+
+    await wrapper!.get('[data-testid="zsu-delete-btn"]').trigger('click')
+    await wrapper!.get('[data-testid="zsu-confirm-delete"]').trigger('click')
+
+    expect(deleteBindingMock).toHaveBeenCalledTimes(1)
+    expect(deleteBindingMock).toHaveBeenCalledWith('dp-1', 'zsu-binding')
+  })
+})

--- a/frontend/src/components/ZeitschaltuhrAddRemoveModal.vue
+++ b/frontend/src/components/ZeitschaltuhrAddRemoveModal.vue
@@ -6,7 +6,7 @@
  * mode="restricted"  — Bearbeiten + Aktivieren/Deaktivieren (kein Hinzufügen/Löschen)
  * mode="minimal"     — nur Aktivieren/Deaktivieren
  */
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { datapoints as dpApi } from '@/api/client'
 import type { BindingOut } from '@/api/client'
@@ -33,6 +33,10 @@ const bindings  = ref<BindingOut[]>([])
 
 const editingBinding   = ref<BindingOut | null>(null)
 const pendingDeleteId  = ref<string | null>(null)
+
+const zsuBindings = computed(() =>
+  bindings.value.filter((b) => b.adapter_instance_id === props.instanceId)
+)
 
 // ── Load ──────────────────────────────────────────────────────────────────────
 
@@ -184,7 +188,7 @@ const btnBase = 'px-2 py-1 rounded text-xs font-medium transition-colors disable
         <template v-else>
 
           <div
-            v-if="bindings.length === 0"
+            v-if="zsuBindings.length === 0"
             class="text-sm text-gray-400 dark:text-gray-500 text-center py-4"
           >
             {{ $t('zst.noBindings') }}
@@ -192,8 +196,9 @@ const btnBase = 'px-2 py-1 rounded text-xs font-medium transition-colors disable
 
           <!-- Binding-Liste -->
           <div
-            v-for="b in bindings"
+            v-for="b in zsuBindings"
             :key="String(b.id)"
+            data-testid="zsu-binding-row"
             class="rounded-lg border transition-colors"
             :class="pendingDeleteId === String(b.id)
               ? 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20'
@@ -228,7 +233,7 @@ const btnBase = 'px-2 py-1 rounded text-xs font-medium transition-colors disable
               <button
                 v-if="mode !== 'minimal'"
                 type="button"
-                title="Bearbeiten"
+                :title="$t('common.edit')"
                 :class="[btnBase, 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 hover:text-blue-600 dark:hover:text-blue-400 border border-gray-200 dark:border-gray-600']"
                 :disabled="saving"
                 @click="openEdit(b)"
@@ -238,7 +243,8 @@ const btnBase = 'px-2 py-1 rounded text-xs font-medium transition-colors disable
               <button
                 v-if="mode === 'full'"
                 type="button"
-                title="Löschen"
+                :title="$t('common.delete')"
+                data-testid="zsu-delete-btn"
                 :class="[btnBase, 'bg-red-50 dark:bg-red-900/20 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40 border border-red-200 dark:border-red-800']"
                 :disabled="saving"
                 @click="requestDelete(b)"
@@ -257,6 +263,7 @@ const btnBase = 'px-2 py-1 rounded text-xs font-medium transition-colors disable
               >{{ $t('common.no') }}</button>
               <button
                 type="button"
+                data-testid="zsu-confirm-delete"
                 :class="[btnBase, 'bg-red-600 hover:bg-red-500 text-white border border-red-600']"
                 :disabled="saving"
                 @click="confirmDelete(b)"
@@ -296,6 +303,7 @@ const btnBase = 'px-2 py-1 rounded text-xs font-medium transition-colors disable
     <ZeitschaltuhrBindingModal
       v-if="editingBinding"
       :datapoint-id="props.datapointId"
+      :instance-id="props.instanceId"
       :binding-id="String(editingBinding.id)"
       @close="editingBinding = null"
       @saved="onEditSaved"

--- a/frontend/src/components/ZeitschaltuhrBindingModal.vue
+++ b/frontend/src/components/ZeitschaltuhrBindingModal.vue
@@ -9,6 +9,7 @@ import type { HolidayEntry } from '@/api/client'
 
 const props = defineProps<{
   datapointId: string
+  instanceId: string
   bindingId: string
 }>()
 
@@ -219,7 +220,7 @@ async function loadBinding() {
   errorMsg.value = ''
   try {
     const bindings = await dpApi.listBindings(props.datapointId)
-    const b = bindings.find((b) => b.id === props.bindingId)
+    const b = bindings.find((b) => b.id === props.bindingId && b.adapter_instance_id === props.instanceId)
     if (!b) { errorMsg.value = t('zst.bindingNotFound'); return }
     bindingEnabled.value = b.enabled
     instanceId.value     = b.adapter_instance_id ?? ''


### PR DESCRIPTION
## Summary
- filter the VISU Zeitschaltuhr management dialog to the configured scheduler adapter instance
- guard the nested scheduler binding editor against opening bindings from another adapter instance
- add a regression test for a datapoint with both ZSU and KNX bindings
- add release notes under `2026.7.0` → `Fixes` with `Visu:` prefix

Fixes https://github.com/abeggled/openbridgeserver/issues/782

## Verification
- `npm run test -- src/components/ZeitschaltuhrAddRemoveModal.test.ts`
- `npm run test`
- `npm run build`
- `./scripts/check-i18n-hardcoded-strings.sh frontend/src/components/ZeitschaltuhrAddRemoveModal.vue frontend/src/components/ZeitschaltuhrBindingModal.vue frontend/src/components/ZeitschaltuhrAddRemoveModal.test.ts`
- `git diff --check`