### PR TITLE
Fix internal OBS datapoint writes

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 * none
 
 ### New features ✨
+* Backend/Admin GUI: OBS internal datapoints without adapter bindings can now be written through MQTT `dp/{uuid}/set` or the object detail view; the write is stored as the current value and propagated through the normal registry, retained MQTT value, history/ringbuffer, WebSocket, and logic event path. https://github.com/abeggled/openbridgeserver/issues/715
 * Backend: ETS hierarchy import logic is now available as a reusable backend service while keeping `POST /api/v1/hierarchy/import-from-ets` behavior unchanged. This prepares the KNX project import to create selected ETS hierarchies in the same import flow. https://github.com/abeggled/openbridgeserver/issues/727
 * Backend: `.knxproj` imports can now create selected ETS hierarchies in the same backend request, reporting per-hierarchy node/link counts and non-fatal failures for unavailable ETS data. https://github.com/abeggled/openbridgeserver/issues/728
 * Admin GUI: `.knxproj` imports now offer hierarchy creation for topology, buildings/rooms, and trades in the same import flow, including per-hierarchy result feedback and optional auto-linking to created objects. https://github.com/abeggled/openbridgeserver/issues/729

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -132,6 +132,7 @@
       "writeValue": "Wert schreiben",
       "write": "Schreiben",
       "invalidNumber": "Bitte eine gültige Zahl eingeben.",
+      "invalidTemporal": "Bitte ein gültiges Datum oder eine gültige Zeit eingeben.",
       "noWritableBinding": "Kein schreibbares Binding vorhanden.",
       "properties": "Eigenschaften",
       "datatype": "Datentyp",

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -148,6 +148,7 @@
       "noLogicBindings": "Objekt wird in keinem Logic-Sheet verwendet",
       "logicReads": "Logik liest im verlinkten Blatt dieses Objekt",
       "logicWrites": "Logik schreibt im verlinkten Blatt auf dieses Objekt",
+      "openLogicSheet": "Logic-Sheet öffnen",
       "writtenSuccess": "Wert geschrieben.",
       "writeError": "Wert konnte nicht geschrieben werden.",
       "bindingModalEdit": "Binding bearbeiten",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -132,6 +132,7 @@
       "writeValue": "Write value",
       "write": "Write",
       "invalidNumber": "Please enter a valid number.",
+      "invalidTemporal": "Please enter a valid date or time.",
       "noWritableBinding": "No writable binding available.",
       "properties": "Properties",
       "datatype": "Data type",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -148,6 +148,7 @@
       "noLogicBindings": "Data point is not used in any logic sheet",
       "logicReads": "Logic reads this data point in the linked sheet",
       "logicWrites": "Logic writes to this data point in the linked sheet",
+      "openLogicSheet": "Open logic sheet",
       "writtenSuccess": "Value written.",
       "writeError": "Value could not be written.",
       "bindingModalEdit": "Edit binding",

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -160,7 +160,7 @@
                 {{ u.node_type === 'datapoint_read' ? $t('datapoints.detail.logicReads') : $t('datapoints.detail.logicWrites') }}
               </div>
             </div>
-            <RouterLink :to="`/logic?graph=${u.graph_id}`" class="btn-icon shrink-0" title="Logic-Sheet öffnen">
+            <RouterLink :to="`/logic?graph=${u.graph_id}`" class="btn-icon shrink-0" :title="$t('datapoints.detail.openLogicSheet')">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
             </RouterLink>
           </div>

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -29,7 +29,8 @@
         <div v-if="dp.mqtt_alias" class="font-mono text-xs text-slate-600 break-all">{{ dp.mqtt_alias }}</div>
         <div class="border-t border-slate-200 dark:border-slate-700 pt-4 mt-1">
           <div class="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">{{ $t('datapoints.detail.writeValue') }}</div>
-          <div v-if="canWriteValue" class="flex flex-wrap items-center gap-2">
+          <div v-if="bindingsLoading" class="flex items-center py-1"><Spinner size="sm" /></div>
+          <div v-else-if="canWriteValue" class="flex flex-wrap items-center gap-2">
             <template v-if="dp.data_type === 'BOOLEAN'">
               <button
                 @click="writeDetailValue(true)"
@@ -212,6 +213,7 @@ const ws      = useWebSocketStore()
 const dp                  = ref(null)
 const bindings            = ref([])
 const bindingsLoading     = ref(false)
+const bindingsLoaded      = ref(false)
 const logicUsages         = ref([])
 const logicUsagesLoading  = ref(false)
 const showEdit            = ref(false)
@@ -233,7 +235,7 @@ const displayVal = computed(() => {
 })
 const activeBindings = computed(() => bindings.value.filter(b => b.enabled))
 const canWriteValue = computed(() =>
-  activeBindings.value.length === 0 || activeBindings.value.some(b => ['DEST', 'BOTH'].includes(b.direction))
+  bindingsLoaded.value && (activeBindings.value.length === 0 || activeBindings.value.some(b => ['DEST', 'BOTH'].includes(b.direction)))
 )
 watch(currentRawValue, (value) => {
   if (!writeBusy.value && value !== undefined && value !== null) writeDraft.value = String(value)
@@ -254,7 +256,12 @@ onUnmounted(() => unsubWs?.())
 
 async function loadBindings() {
   bindingsLoading.value = true
-  try { const { data } = await dpApi.listBindings(props.id); bindings.value = data }
+  bindingsLoaded.value = false
+  try {
+    const { data } = await dpApi.listBindings(props.id)
+    bindings.value = data
+    bindingsLoaded.value = true
+  }
   finally { bindingsLoading.value = false }
 }
 
@@ -283,7 +290,35 @@ function coerceWriteValue(raw) {
   if (dp.value?.data_type === 'BOOLEAN') return raw === true || raw === 'true' || raw === '1' || raw === 1
   if (dp.value?.data_type === 'INTEGER') return Number.parseInt(raw, 10)
   if (dp.value?.data_type === 'FLOAT') return Number.parseFloat(raw)
+  if (dp.value?.data_type === 'DATE') return coerceDate(raw)
+  if (dp.value?.data_type === 'TIME') return coerceTime(raw)
+  if (dp.value?.data_type === 'DATETIME') return coerceDateTime(raw)
   return raw
+}
+
+function coerceDate(raw) {
+  const value = String(raw).trim()
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) throw new Error(t('datapoints.detail.invalidTemporal'))
+  const [, year, month, day] = match.map(Number)
+  const dt = new Date(Date.UTC(year, month - 1, day))
+  if (dt.getUTCFullYear() !== year || dt.getUTCMonth() !== month - 1 || dt.getUTCDate() !== day) {
+    throw new Error(t('datapoints.detail.invalidTemporal'))
+  }
+  return value
+}
+
+function coerceTime(raw) {
+  const value = String(raw).trim()
+  const match = value.match(/^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d)(?:\.\d{1,6})?)?$/)
+  if (!match) throw new Error(t('datapoints.detail.invalidTemporal'))
+  return value
+}
+
+function coerceDateTime(raw) {
+  const value = String(raw).trim()
+  if (!value || Number.isNaN(Date.parse(value))) throw new Error(t('datapoints.detail.invalidTemporal'))
+  return value
 }
 
 async function writeDetailValue(raw) {

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -29,7 +29,7 @@
         <div v-if="dp.mqtt_alias" class="font-mono text-xs text-slate-600 break-all">{{ dp.mqtt_alias }}</div>
         <div class="border-t border-slate-200 dark:border-slate-700 pt-4 mt-1">
           <div class="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">{{ $t('datapoints.detail.writeValue') }}</div>
-          <div v-if="hasWritableBinding" class="flex flex-wrap items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
             <template v-if="dp.data_type === 'BOOLEAN'">
               <button
                 @click="writeDetailValue(true)"
@@ -59,9 +59,6 @@
                 {{ $t('datapoints.detail.write') }}
               </button>
             </template>
-          </div>
-          <div v-else class="text-xs text-slate-500">
-            {{ $t('datapoints.detail.noWritableBinding') }}
           </div>
           <div v-if="writeFeedback" class="text-xs mt-2" :class="writeFeedback.type === 'error' ? 'text-red-500' : 'text-green-600'">
             {{ writeFeedback.text }}
@@ -231,10 +228,6 @@ const displayVal = computed(() => {
   if (v === null || v === undefined) return '—'
   return dp.value?.unit ? `${v} ${dp.value.unit}` : String(v)
 })
-const hasWritableBinding = computed(() =>
-  bindings.value.some(b => b.enabled && ['DEST', 'BOTH'].includes(b.direction))
-)
-
 watch(currentRawValue, (value) => {
   if (!writeBusy.value && value !== undefined && value !== null) writeDraft.value = String(value)
 })

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -29,7 +29,7 @@
         <div v-if="dp.mqtt_alias" class="font-mono text-xs text-slate-600 break-all">{{ dp.mqtt_alias }}</div>
         <div class="border-t border-slate-200 dark:border-slate-700 pt-4 mt-1">
           <div class="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">{{ $t('datapoints.detail.writeValue') }}</div>
-          <div class="flex flex-wrap items-center gap-2">
+          <div v-if="canWriteValue" class="flex flex-wrap items-center gap-2">
             <template v-if="dp.data_type === 'BOOLEAN'">
               <button
                 @click="writeDetailValue(true)"
@@ -59,6 +59,9 @@
                 {{ $t('datapoints.detail.write') }}
               </button>
             </template>
+          </div>
+          <div v-else class="text-xs text-slate-500">
+            {{ $t('datapoints.detail.noWritableBinding') }}
           </div>
           <div v-if="writeFeedback" class="text-xs mt-2" :class="writeFeedback.type === 'error' ? 'text-red-500' : 'text-green-600'">
             {{ writeFeedback.text }}
@@ -228,6 +231,10 @@ const displayVal = computed(() => {
   if (v === null || v === undefined) return '—'
   return dp.value?.unit ? `${v} ${dp.value.unit}` : String(v)
 })
+const activeBindings = computed(() => bindings.value.filter(b => b.enabled))
+const canWriteValue = computed(() =>
+  activeBindings.value.length === 0 || activeBindings.value.some(b => ['DEST', 'BOTH'].includes(b.direction))
+)
 watch(currentRawValue, (value) => {
   if (!writeBusy.value && value !== undefined && value !== null) writeDraft.value = String(value)
 })

--- a/gui/tests/views/DataPointDetailView.spec.js
+++ b/gui/tests/views/DataPointDetailView.spec.js
@@ -89,4 +89,52 @@ describe('DataPointDetailView', () => {
     expect(wrapper.find('input[type="text"]').exists()).toBe(false)
     expect(wrapper.findAll('button').some(button => button.text() === 'Schreiben')).toBe(false)
   })
+
+  it('does not expose the write form while bindings are still loading', async () => {
+    let resolveBindings
+    apiMocks.dpApi.listBindings.mockReturnValue(new Promise(resolve => { resolveBindings = resolve }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('input[type="text"]').exists()).toBe(false)
+    expect(wrapper.findAll('button').some(button => button.text() === 'Schreiben')).toBe(false)
+
+    resolveBindings({ data: [] })
+    await flushPromises()
+
+    expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+  })
+
+  it('rejects invalid temporal write values before posting', async () => {
+    apiMocks.dpApi.get.mockResolvedValue({
+      data: {
+        id: 'dp-internal',
+        name: 'Internal Date',
+        data_type: 'DATE',
+        unit: null,
+        tags: [],
+        mqtt_topic: 'dp/dp-internal/value',
+        mqtt_alias: null,
+        persist_value: true,
+        record_history: true,
+        value: null,
+        quality: 'uncertain',
+        created_at: '2026-06-11T10:00:00+00:00',
+        updated_at: '2026-06-11T10:00:00+00:00',
+      },
+    })
+    const wrapper = mountView()
+    await flushPromises()
+
+    const input = wrapper.find('input[type="text"]')
+    await input.setValue('2026-02-31')
+
+    const writeButton = wrapper.findAll('button').find(button => button.text() === 'Schreiben')
+    await writeButton.trigger('click')
+    await flushPromises()
+
+    expect(apiMocks.dpApi.writeValue).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Bitte ein gültiges Datum oder eine gültige Zeit eingeben.')
+  })
 })

--- a/gui/tests/views/DataPointDetailView.spec.js
+++ b/gui/tests/views/DataPointDetailView.spec.js
@@ -1,0 +1,79 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import DataPointDetailView from '@/views/DataPointDetailView.vue'
+
+const apiMocks = vi.hoisted(() => ({
+  dpApi: {
+    get: vi.fn(),
+    listBindings: vi.fn(),
+    writeValue: vi.fn(),
+  },
+  logicApi: {
+    datapointUsages: vi.fn(),
+  },
+  systemApi: {
+    datatypes: vi.fn(),
+  },
+}))
+
+vi.mock('@/api/client', () => apiMocks)
+
+function mountView() {
+  return mount(DataPointDetailView, {
+    props: { id: 'dp-internal' },
+    global: {
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+        DataPointHierarchyCard: { template: '<div />' },
+        DataPointForm: { template: '<div />' },
+        BindingForm: { template: '<div />' },
+        Modal: { template: '<div v-if="modelValue"><slot /></div>', props: ['modelValue'] },
+        ConfirmDialog: { template: '<div />' },
+      },
+    },
+  })
+}
+
+describe('DataPointDetailView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMocks.systemApi.datatypes.mockResolvedValue({ data: [{ name: 'FLOAT' }] })
+    apiMocks.dpApi.get.mockResolvedValue({
+      data: {
+        id: 'dp-internal',
+        name: 'Internal Temperature',
+        data_type: 'FLOAT',
+        unit: '°C',
+        tags: [],
+        mqtt_topic: 'dp/dp-internal/value',
+        mqtt_alias: null,
+        persist_value: true,
+        record_history: true,
+        value: null,
+        quality: 'uncertain',
+        created_at: '2026-06-11T10:00:00+00:00',
+        updated_at: '2026-06-11T10:00:00+00:00',
+      },
+    })
+    apiMocks.dpApi.listBindings.mockResolvedValue({ data: [] })
+    apiMocks.logicApi.datapointUsages.mockResolvedValue({ data: [] })
+    apiMocks.dpApi.writeValue.mockResolvedValue({})
+  })
+
+  it('allows writing an internal datapoint without writable adapter bindings', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Kein schreibbares Binding vorhanden.')
+
+    const input = wrapper.find('input[type="text"]')
+    await input.setValue('21.5')
+
+    const writeButton = wrapper.findAll('button').find(button => button.text() === 'Schreiben')
+    expect(writeButton).toBeTruthy()
+    await writeButton.trigger('click')
+    await flushPromises()
+
+    expect(apiMocks.dpApi.writeValue).toHaveBeenCalledWith('dp-internal', 21.5)
+  })
+})

--- a/gui/tests/views/DataPointDetailView.spec.js
+++ b/gui/tests/views/DataPointDetailView.spec.js
@@ -76,4 +76,17 @@ describe('DataPointDetailView', () => {
 
     expect(apiMocks.dpApi.writeValue).toHaveBeenCalledWith('dp-internal', 21.5)
   })
+
+  it('does not expose the write form for source-only adapter bindings', async () => {
+    apiMocks.dpApi.listBindings.mockResolvedValue({
+      data: [{ id: 'binding-source', enabled: true, direction: 'SOURCE', adapter_type: 'KNX', config: {} }],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Kein schreibbares Binding vorhanden.')
+    expect(wrapper.find('input[type="text"]').exists()).toBe(false)
+    expect(wrapper.findAll('button').some(button => button.text() === 'Schreiben')).toBe(false)
+  })
 })

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -406,7 +406,8 @@ async def write_value(
     - Kein Auth-Kontext → 401
     """
     reg = get_registry()
-    if reg.get(dp_id) is None:
+    dp = reg.get(dp_id)
+    if dp is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
 
     if user is None:
@@ -432,9 +433,14 @@ async def write_value(
         elif access not in ("public",):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
 
+    try:
+        value = _coerce_value_for_type(body.value, dp.data_type)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(exc))
+
     event = DataValueEvent(
         datapoint_id=dp_id,
-        value=body.value,
+        value=value,
         quality="good",
         source_adapter="api",
     )

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -62,6 +62,17 @@ def _cached_value_equals(current_value: Any, cached_value: Any) -> bool:
     return current_value == cached_value
 
 
+def _unwrap_mqtt_set_payload(raw_payload: str) -> tuple[Any, bool]:
+    try:
+        payload = json.loads(raw_payload)
+    except Exception:
+        return raw_payload, False
+
+    if isinstance(payload, dict) and "v" in payload:
+        return payload["v"], True
+    return payload, True
+
+
 class WriteRouter:
     def __init__(self, db: Any, registry: Any, event_bus: Any | None = None) -> None:
         from obs.core.registry import DataPointRegistry
@@ -107,14 +118,14 @@ class WriteRouter:
             return
 
         dt = DataTypeRegistry.get(dp.data_type)
+        payload_value, payload_was_json = _unwrap_mqtt_set_payload(raw_payload)
         if dt.name == "UNKNOWN":
-            try:
-                value = json.loads(raw_payload)
-            except Exception:
-                value = raw_payload
+            value = payload_value if payload_was_json else raw_payload
+        elif dt.name == "STRING" and not payload_was_json:
+            value = raw_payload
         else:
             try:
-                value = dt.mqtt_deserializer(raw_payload)
+                value = dt.mqtt_deserializer(json.dumps(payload_value) if payload_was_json else raw_payload)
             except Exception:
                 logger.warning(
                     "WriteRouter: invalid MQTT set payload for dp=%s data_type=%s payload=%r",

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -123,6 +123,8 @@ class WriteRouter:
             value = payload_value if payload_was_json else raw_payload
         elif dt.name == "STRING" and not payload_was_json:
             value = raw_payload
+        elif dt.name in {"DATE", "TIME", "DATETIME"} and not payload_was_json:
+            value = dt.mqtt_deserializer(json.dumps(raw_payload))
         else:
             try:
                 value = dt.mqtt_deserializer(json.dumps(payload_value) if payload_was_json else raw_payload)

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -89,15 +89,39 @@ def _coerce_mqtt_boolean(value: Any) -> bool:
     raise ValueError(f"Invalid boolean value: {value!r}")
 
 
+def _coerce_mqtt_integer(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float) and not isinstance(value, bool) and value == int(value):
+        return int(value)
+    raise ValueError(f"Invalid integer value: {value!r}")
+
+
+def _coerce_mqtt_float(value: Any) -> float:
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    raise ValueError(f"Invalid float value: {value!r}")
+
+
 def _deserialize_typed_mqtt_set_value(dt: Any, raw_payload: str, payload_value: Any, payload_was_json: bool) -> Any:
     if dt.name == "BOOLEAN":
-        value = payload_value if payload_was_json else json.loads(raw_payload)
+        value = payload_value if payload_was_json else raw_payload
         return _coerce_mqtt_boolean(value)
+    if dt.name == "INTEGER":
+        value = payload_value if payload_was_json else json.loads(raw_payload)
+        return _coerce_mqtt_integer(value)
+    if dt.name == "FLOAT":
+        value = payload_value if payload_was_json else json.loads(raw_payload)
+        return _coerce_mqtt_float(value)
     if dt.name == "STRING" and not payload_was_json:
         return raw_payload
     if dt.name in {"DATE", "TIME", "DATETIME"} and not payload_was_json:
         return dt.mqtt_deserializer(json.dumps(raw_payload))
     return dt.mqtt_deserializer(json.dumps(payload_value) if payload_was_json else raw_payload)
+
+
+def _row_is_enabled(row: Any) -> bool:
+    return _row_value(row, "enabled") in {1, True, "1"}
 
 
 class WriteRouter:
@@ -134,14 +158,15 @@ class WriteRouter:
             return
 
         rows = await self._db.fetchall(
-            """SELECT direction FROM adapter_bindings
-               WHERE datapoint_id=? AND enabled=1""",
+            """SELECT direction, enabled FROM adapter_bindings
+               WHERE datapoint_id=?""",
             (str(dp_id),),
         )
         has_bindings = bool(rows)
-        has_writable_bindings = any(_row_value(row, "direction") in {"DEST", "BOTH"} for row in rows)
+        active_rows = [row for row in rows if _row_is_enabled(row)]
+        has_writable_bindings = any(_row_value(row, "direction") in {"DEST", "BOTH"} for row in active_rows)
         if has_bindings and not has_writable_bindings:
-            logger.warning("Write request for source-only DataPoint %s — ignored", dp_id)
+            logger.warning("Write request for non-writable DataPoint %s — ignored", dp_id)
             return
 
         dt = DataTypeRegistry.get(dp.data_type)

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -63,12 +63,13 @@ def _cached_value_equals(current_value: Any, cached_value: Any) -> bool:
 
 
 class WriteRouter:
-    def __init__(self, db: Any, registry: Any) -> None:
+    def __init__(self, db: Any, registry: Any, event_bus: Any | None = None) -> None:
         from obs.core.registry import DataPointRegistry
         from obs.db.database import Database
 
         self._db: Database = db
         self._registry: DataPointRegistry = registry
+        self._bus = event_bus
         # binding_id → timestamp of last successful send (monotonic seconds)
         self._last_sent: dict[uuid.UUID, float] = {}
         # binding_id → last successfully sent value (for on-change / delta checks)
@@ -98,7 +99,17 @@ class WriteRouter:
                 value = raw_payload
         logger.info("WriteRouter: dp=%s value=%r (type=%s)", dp.name, value, dp.data_type)
 
-        await self._write_to_dest_bindings(dp_id, value, skip_binding_id=None)
+        from obs.core.event_bus import DataValueEvent, get_event_bus
+
+        bus = getattr(self, "_bus", None) or get_event_bus()
+        await bus.publish(
+            DataValueEvent(
+                datapoint_id=dp_id,
+                value=value,
+                quality="good",
+                source_adapter="mqtt_set",
+            )
+        )
 
     # ------------------------------------------------------------------
     # Path 2 — internal DataValueEvent propagation
@@ -350,7 +361,7 @@ def reset_write_router() -> None:
     _write_router = None
 
 
-def init_write_router(db: Any, registry: Any) -> WriteRouter:
+def init_write_router(db: Any, registry: Any, event_bus: Any | None = None) -> WriteRouter:
     global _write_router
-    _write_router = WriteRouter(db, registry)
+    _write_router = WriteRouter(db, registry, event_bus=event_bus)
     return _write_router

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -80,7 +80,13 @@ class WriteRouter:
     # ------------------------------------------------------------------
 
     async def handle(self, dp_id: uuid.UUID, raw_payload: str) -> None:
-        """Deserialize payload and write to all DEST/BOTH bindings."""
+        """Deserialize an inbound MQTT set payload.
+
+        Bound datapoints keep the adapter write semantics: only DEST/BOTH
+        bindings receive commands, and registry state changes only when an
+        adapter later publishes a value event. Bindingless datapoints are OBS
+        internal objects, so their validated set payload becomes the value event.
+        """
         from obs.models.types import DataTypeRegistry
 
         logger.info("WriteRouter.handle: dp_id=%s payload=%r", dp_id, raw_payload)
@@ -89,15 +95,39 @@ class WriteRouter:
             logger.warning("Write request for unknown DataPoint %s — ignored", dp_id)
             return
 
+        rows = await self._db.fetchall(
+            """SELECT direction FROM adapter_bindings
+               WHERE datapoint_id=? AND enabled=1""",
+            (str(dp_id),),
+        )
+        has_bindings = bool(rows)
+        has_writable_bindings = any(_row_value(row, "direction") in {"DEST", "BOTH"} for row in rows)
+        if has_bindings and not has_writable_bindings:
+            logger.warning("Write request for source-only DataPoint %s — ignored", dp_id)
+            return
+
         dt = DataTypeRegistry.get(dp.data_type)
-        try:
-            value = dt.mqtt_deserializer(raw_payload)
-        except Exception:
+        if dt.name == "UNKNOWN":
             try:
                 value = json.loads(raw_payload)
             except Exception:
                 value = raw_payload
+        else:
+            try:
+                value = dt.mqtt_deserializer(raw_payload)
+            except Exception:
+                logger.warning(
+                    "WriteRouter: invalid MQTT set payload for dp=%s data_type=%s payload=%r",
+                    dp_id,
+                    dp.data_type,
+                    raw_payload,
+                )
+                return
         logger.info("WriteRouter: dp=%s value=%r (type=%s)", dp.name, value, dp.data_type)
+
+        if has_writable_bindings:
+            await self._write_to_dest_bindings(dp_id, value, skip_binding_id=None)
+            return
 
         from obs.core.event_bus import DataValueEvent, get_event_bus
 

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -73,6 +73,33 @@ def _unwrap_mqtt_set_payload(raw_payload: str) -> tuple[Any, bool]:
     return payload, True
 
 
+def _coerce_mqtt_boolean(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value in {0, 1}:
+            return bool(value)
+        raise ValueError(f"Invalid boolean numeric value: {value!r}")
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    raise ValueError(f"Invalid boolean value: {value!r}")
+
+
+def _deserialize_typed_mqtt_set_value(dt: Any, raw_payload: str, payload_value: Any, payload_was_json: bool) -> Any:
+    if dt.name == "BOOLEAN":
+        value = payload_value if payload_was_json else json.loads(raw_payload)
+        return _coerce_mqtt_boolean(value)
+    if dt.name == "STRING" and not payload_was_json:
+        return raw_payload
+    if dt.name in {"DATE", "TIME", "DATETIME"} and not payload_was_json:
+        return dt.mqtt_deserializer(json.dumps(raw_payload))
+    return dt.mqtt_deserializer(json.dumps(payload_value) if payload_was_json else raw_payload)
+
+
 class WriteRouter:
     def __init__(self, db: Any, registry: Any, event_bus: Any | None = None) -> None:
         from obs.core.registry import DataPointRegistry
@@ -121,13 +148,9 @@ class WriteRouter:
         payload_value, payload_was_json = _unwrap_mqtt_set_payload(raw_payload)
         if dt.name == "UNKNOWN":
             value = payload_value if payload_was_json else raw_payload
-        elif dt.name == "STRING" and not payload_was_json:
-            value = raw_payload
-        elif dt.name in {"DATE", "TIME", "DATETIME"} and not payload_was_json:
-            value = dt.mqtt_deserializer(json.dumps(raw_payload))
         else:
             try:
-                value = dt.mqtt_deserializer(json.dumps(payload_value) if payload_was_json else raw_payload)
+                value = _deserialize_typed_mqtt_set_value(dt, raw_payload, payload_value, payload_was_json)
             except Exception:
                 logger.warning(
                     "WriteRouter: invalid MQTT set payload for dp=%s data_type=%s payload=%r",

--- a/obs/main.py
+++ b/obs/main.py
@@ -111,7 +111,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # 6. Write Router
     #    Path A: MQTT dp/{uuid}/set → adapters (external commands)
     #    Path B: DataValueEvent → DEST/BOTH bindings (cross-protocol propagation)
-    write_router = init_write_router(db, registry)
+    write_router = init_write_router(db, registry, event_bus=bus)
     mqtt.on_write_request(write_router.handle)
     bus.subscribe(DataValueEvent, write_router.handle_value_event)
 

--- a/tests/unit/test_coverage_api_auth_icons_dp.py
+++ b/tests/unit/test_coverage_api_auth_icons_dp.py
@@ -1518,6 +1518,28 @@ class TestWriteValue:
         bus_mock.publish.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_write_value_coerces_temporal_value_before_publish(self, monkeypatch):
+        from datetime import time
+
+        from obs.api.v1.datapoints import WriteValueIn
+
+        dp = _DpStub(data_type="TIME")
+        reg = _RegistryStub(dps=[dp])
+        monkeypatch.setattr(dp_api, "get_registry", lambda: reg)
+
+        bus_mock = MagicMock()
+        bus_mock.publish = AsyncMock()
+        monkeypatch.setattr(dp_api, "get_event_bus", lambda: bus_mock)
+
+        request = MagicMock()
+        db = _DbStub()
+        body = WriteValueIn(value="10:30:00")
+        await dp_api.write_value(dp_id=dp.id, body=body, request=request, user="admin", db=db)
+
+        event = bus_mock.publish.await_args.args[0]
+        assert event.value == time(10, 30, 0)
+
+    @pytest.mark.asyncio
     async def test_write_value_not_found_raises_404(self, monkeypatch):
         from obs.api.v1.datapoints import WriteValueIn
 

--- a/tests/unit/test_coverage_system_core.py
+++ b/tests/unit/test_coverage_system_core.py
@@ -1050,22 +1050,29 @@ class TestWriteRouterHandle:
         router._write_to_dest_bindings.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_handle_calls_write_to_dest_bindings(self):
+    async def test_handle_publishes_value_event(self):
+        from obs.core.event_bus import DataValueEvent
         from obs.core.write_router import WriteRouter
 
         dp = SimpleNamespace(name="dp", data_type="FLOAT")
         router = WriteRouter.__new__(WriteRouter)
         router._db = _DbStub()
         router._registry = SimpleNamespace(get=lambda _: dp)
+        router._bus = SimpleNamespace(publish=AsyncMock())
         router._last_sent = {}
         router._last_value = {}
         router._write_to_dest_bindings = AsyncMock()
 
         dp_id = uuid.uuid4()
         await router.handle(dp_id, "42.0")
-        router._write_to_dest_bindings.assert_awaited_once()
-        assert router._write_to_dest_bindings.call_args[0][0] == dp_id
-        assert router._write_to_dest_bindings.call_args[1]["skip_binding_id"] is None
+        router._bus.publish.assert_awaited_once()
+        event = router._bus.publish.await_args.args[0]
+        assert isinstance(event, DataValueEvent)
+        assert event.datapoint_id == dp_id
+        assert event.value == pytest.approx(42.0)
+        assert event.quality == "good"
+        assert event.source_adapter == "mqtt_set"
+        router._write_to_dest_bindings.assert_not_awaited()
 
 
 class TestWriteRouterHandleValueEvent:

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -357,6 +357,46 @@ async def test_handle_preserves_raw_string_payload_for_writable_binding():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("data_type", "raw_payload", "expected"),
+    [
+        ("DATE", "2026-06-12", datetime.date(2026, 6, 12)),
+        ("TIME", "10:30:00", datetime.time(10, 30, 0)),
+        ("DATETIME", "2026-06-12T10:30:00+00:00", datetime.datetime(2026, 6, 12, 10, 30, 0, tzinfo=datetime.UTC)),
+    ],
+)
+async def test_handle_preserves_raw_temporal_payload_for_bindingless_datapoint(data_type, raw_payload, expected):
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type=data_type))
+
+    await router.handle(dp_id, raw_payload)
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == expected
+    assert event.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_handle_preserves_raw_temporal_payload_for_writable_binding():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([_row(datapoint_id=str(dp_id), direction="DEST")])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Clock", data_type="TIME"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "10:30:00")
+
+    router._write_to_dest_bindings.assert_awaited_once_with(dp_id, datetime.time(10, 30, 0), skip_binding_id=None)
+    bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_time_value_event_routes_to_mqtt_raw_payload_without_template(monkeypatch):
     dp_id = uuid.uuid4()
     binding = make_binding({"topic": "clock/time"}, direction="DEST")

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -308,6 +308,55 @@ async def test_handle_publishes_value_event_for_bindingless_datapoint():
 
 
 @pytest.mark.asyncio
+async def test_handle_unwraps_documented_value_payload_for_bindingless_datapoint():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="BOOLEAN"))
+
+    await router.handle(dp_id, '{"v": false, "q": "good"}')
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value is False
+    assert event.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_handle_preserves_raw_string_payload_for_bindingless_datapoint():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="STRING"))
+
+    await router.handle(dp_id, "hello")
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == "hello"
+    assert event.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_handle_preserves_raw_string_payload_for_writable_binding():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([_row(datapoint_id=str(dp_id), direction="DEST")])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Actuator", data_type="STRING"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "hello")
+
+    router._write_to_dest_bindings.assert_awaited_once_with(dp_id, "hello", skip_binding_id=None)
+    bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_time_value_event_routes_to_mqtt_raw_payload_without_template(monkeypatch):
     dp_id = uuid.uuid4()
     binding = make_binding({"topic": "clock/time"}, direction="DEST")

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -325,6 +325,53 @@ async def test_handle_unwraps_documented_value_payload_for_bindingless_datapoint
 
 
 @pytest.mark.asyncio
+async def test_handle_parses_wrapped_boolean_string_before_publishing():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="BOOLEAN"))
+
+    await router.handle(dp_id, '{"v": "false"}')
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value is False
+    assert event.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_handle_rejects_invalid_boolean_payload_without_publishing_event():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="BOOLEAN"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, '{"v": "not-bool"}')
+
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_rejects_boolean_object_payload_without_truthiness_coercion():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="BOOLEAN"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, '{"unexpected": true}')
+
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_handle_preserves_raw_string_payload_for_bindingless_datapoint():
     dp_id = uuid.uuid4()
     bus = SimpleNamespace(publish=AsyncMock())
@@ -394,6 +441,21 @@ async def test_handle_preserves_raw_temporal_payload_for_writable_binding():
 
     router._write_to_dest_bindings.assert_awaited_once_with(dp_id, datetime.time(10, 30, 0), skip_binding_id=None)
     bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_rejects_invalid_raw_temporal_payload_without_raising():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Clock", data_type="TIME"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "not-a-time")
+
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -211,18 +211,27 @@ async def test_handle_value_event_forwards_skip_binding_id(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_uses_json_fallback_when_deserializer_fails(monkeypatch):
+async def test_handle_rejects_invalid_typed_payload_without_publishing_event():
     dp_id = uuid.uuid4()
     router = _make_router([])
-    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="dummy"))
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="FLOAT"))
     bus = SimpleNamespace(publish=AsyncMock())
     router._bus = bus
+    router._write_to_dest_bindings = AsyncMock()
 
-    def _failing_deserializer(_raw):
-        raise ValueError("boom")
+    await router.handle(dp_id, "not json")
 
-    fake_dt = SimpleNamespace(mqtt_deserializer=_failing_deserializer)
-    monkeypatch.setattr("obs.models.types.DataTypeRegistry.get", lambda _dt: fake_dt)
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_publishes_unknown_json_payload_for_bindingless_datapoint():
+    dp_id = uuid.uuid4()
+    router = _make_router([])
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="UNKNOWN"))
+    bus = SimpleNamespace(publish=AsyncMock())
+    router._bus = bus
 
     await router.handle(dp_id, '{"n": 7}')
     bus.publish.assert_awaited_once()
@@ -235,18 +244,12 @@ async def test_handle_uses_json_fallback_when_deserializer_fails(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_uses_raw_payload_when_deserializer_and_json_fallback_fail(monkeypatch):
+async def test_handle_publishes_unknown_raw_payload_for_bindingless_datapoint():
     dp_id = uuid.uuid4()
     router = _make_router([])
-    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="dummy"))
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="UNKNOWN"))
     bus = SimpleNamespace(publish=AsyncMock())
     router._bus = bus
-
-    def _failing_deserializer(_raw):
-        raise ValueError("boom")
-
-    fake_dt = SimpleNamespace(mqtt_deserializer=_failing_deserializer)
-    monkeypatch.setattr("obs.models.types.DataTypeRegistry.get", lambda _dt: fake_dt)
 
     await router.handle(dp_id, "not json")
     bus.publish.assert_awaited_once()
@@ -254,6 +257,36 @@ async def test_handle_uses_raw_payload_when_deserializer_and_json_fallback_fail(
     assert event.datapoint_id == dp_id
     assert event.value == "not json"
     assert event.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_handle_ignores_source_only_datapoint_without_publishing_state():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([_row(datapoint_id=str(dp_id), direction="SOURCE")])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Sensor", data_type="FLOAT"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "21.5")
+
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_with_writable_binding_writes_adapter_without_publishing_state():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([_row(datapoint_id=str(dp_id), direction="DEST")])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Actuator", data_type="FLOAT"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "21.5")
+
+    router._write_to_dest_bindings.assert_awaited_once_with(dp_id, pytest.approx(21.5), skip_binding_id=None)
+    bus.publish.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -74,6 +74,7 @@ def _make_router(db_rows: list[dict]) -> WriteRouter:
     router = WriteRouter.__new__(WriteRouter)
     router._db = _FakeDb(db_rows)
     router._registry = None
+    router._bus = None
     router._last_sent = {}
     router._last_value = {}
     return router
@@ -214,7 +215,8 @@ async def test_handle_uses_json_fallback_when_deserializer_fails(monkeypatch):
     dp_id = uuid.uuid4()
     router = _make_router([])
     router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="dummy"))
-    router._write_to_dest_bindings = AsyncMock()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router._bus = bus
 
     def _failing_deserializer(_raw):
         raise ValueError("boom")
@@ -223,7 +225,13 @@ async def test_handle_uses_json_fallback_when_deserializer_fails(monkeypatch):
     monkeypatch.setattr("obs.models.types.DataTypeRegistry.get", lambda _dt: fake_dt)
 
     await router.handle(dp_id, '{"n": 7}')
-    router._write_to_dest_bindings.assert_awaited_once_with(dp_id, {"n": 7}, skip_binding_id=None)
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert isinstance(event, DataValueEvent)
+    assert event.datapoint_id == dp_id
+    assert event.value == {"n": 7}
+    assert event.quality == "good"
+    assert event.source_adapter == "mqtt_set"
 
 
 @pytest.mark.asyncio
@@ -231,7 +239,8 @@ async def test_handle_uses_raw_payload_when_deserializer_and_json_fallback_fail(
     dp_id = uuid.uuid4()
     router = _make_router([])
     router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="dp", data_type="dummy"))
-    router._write_to_dest_bindings = AsyncMock()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router._bus = bus
 
     def _failing_deserializer(_raw):
         raise ValueError("boom")
@@ -240,7 +249,29 @@ async def test_handle_uses_raw_payload_when_deserializer_and_json_fallback_fail(
     monkeypatch.setattr("obs.models.types.DataTypeRegistry.get", lambda _dt: fake_dt)
 
     await router.handle(dp_id, "not json")
-    router._write_to_dest_bindings.assert_awaited_once_with(dp_id, "not json", skip_binding_id=None)
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == "not json"
+    assert event.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_handle_publishes_value_event_for_bindingless_datapoint():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="FLOAT"))
+
+    await router.handle(dp_id, "21.5")
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == pytest.approx(21.5)
+    assert event.quality == "good"
+    assert event.source_adapter == "mqtt_set"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -275,6 +275,21 @@ async def test_handle_ignores_source_only_datapoint_without_publishing_state():
 
 
 @pytest.mark.asyncio
+async def test_handle_ignores_disabled_bindings_without_publishing_internal_state():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([_row(datapoint_id=str(dp_id), direction="DEST", enabled=0)])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Disabled", data_type="FLOAT"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "21.5")
+
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_handle_with_writable_binding_writes_adapter_without_publishing_state():
     dp_id = uuid.uuid4()
     bus = SimpleNamespace(publish=AsyncMock())
@@ -342,6 +357,24 @@ async def test_handle_parses_wrapped_boolean_string_before_publishing():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(("raw_payload", "expected"), [("on", True), ("off", False), ("yes", True), ("no", False)])
+async def test_handle_accepts_raw_boolean_word_payloads(raw_payload, expected):
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type="BOOLEAN"))
+
+    await router.handle(dp_id, raw_payload)
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value is expected
+    assert event.quality == "good"
+
+
+@pytest.mark.asyncio
 async def test_handle_rejects_invalid_boolean_payload_without_publishing_event():
     dp_id = uuid.uuid4()
     bus = SimpleNamespace(publish=AsyncMock())
@@ -366,6 +399,31 @@ async def test_handle_rejects_boolean_object_payload_without_truthiness_coercion
     router._write_to_dest_bindings = AsyncMock()
 
     await router.handle(dp_id, '{"unexpected": true}')
+
+    bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("data_type", "raw_payload"),
+    [
+        ("INTEGER", "1.9"),
+        ("INTEGER", '{"v": 1.9}'),
+        ("INTEGER", "true"),
+        ("FLOAT", "true"),
+        ("FLOAT", '{"v": "1.5"}'),
+    ],
+)
+async def test_handle_rejects_lossy_numeric_payloads_without_publishing_event(data_type, raw_payload):
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal", data_type=data_type))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, raw_payload)
 
     bus.publish.assert_not_awaited()
     router._write_to_dest_bindings.assert_not_awaited()


### PR DESCRIPTION
## Summary
- route MQTT `dp/{uuid}/set` writes through the internal `DataValueEvent` pipeline so binding-less OBS datapoints get state, retained MQTT values, history/ringbuffer, WebSocket, and logic propagation
- allow the Admin GUI object detail view to write datapoints without requiring writable adapter bindings
- add backend and GUI regression coverage

## Tests
- `npm run build`
- `npm run test`
- `npm run test:coverage`
- `npm run test -- DataPointDetailView.spec.js`
- `tools/with-venv pytest tests/unit/test_write_router.py tests/test_write_router_value_event.py tests/unit/test_coverage_system_core.py::TestWriteRouterHandle`
- `tools/with-venv ./tools/lint.sh --check`
- `./scripts/check-i18n-hardcoded-strings.sh`
- `git diff --check`
- `node tools/gui-coverage-summary.mjs --changed-only --threshold=70`

Fixes https://github.com/abeggled/openbridgeserver/issues/715