### PR TITLE
[authz][P2] scope KNX project device reads

### DIFF
--- a/obs/api/authz_service.py
+++ b/obs/api/authz_service.py
@@ -1,0 +1,192 @@
+"""Shared AuthZ runtime helpers for route-level policy wiring."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from obs.api.auth import Principal
+from obs.api.authz import AuthzAction, AuthzTarget, RoleGrant, authorize
+from obs.db.database import Database
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _placeholders(values: Sequence[str]) -> str:
+    return ",".join("?" for _ in values)
+
+
+def _principal_ids(principal: Principal) -> list[str]:
+    if principal.type == "api_key" and principal.subject.startswith("api_key:"):
+        return _unique([principal.subject.removeprefix("api_key:"), principal.subject])
+    return [principal.subject]
+
+
+async def load_role_grants(
+    db: Database,
+    principal: Principal,
+    *,
+    node_type: str | None = None,
+) -> list[RoleGrant]:
+    """Load persisted grants for *principal* and materialize hierarchy paths."""
+    principal_ids = _principal_ids(principal)
+    params: list[Any] = [principal.type, *principal_ids]
+    node_filter = ""
+    if node_type is not None:
+        node_filter = " AND node_type=?"
+        params.append(node_type)
+
+    rows = await db.fetchall(
+        f"""
+        SELECT principal_type, principal_id, node_type, node_id, role, effect
+        FROM authz_node_roles
+        WHERE principal_type=? AND principal_id IN ({_placeholders(principal_ids)}){node_filter}
+        ORDER BY node_type, node_id, role
+        """,
+        params,
+    )
+
+    hierarchy_ids = [row["node_id"] for row in rows if row["node_type"] == "hierarchy"]
+    hierarchy_targets = {target.node_id: target for target in await resolve_hierarchy_targets(db, hierarchy_ids)}
+
+    grants: list[RoleGrant] = []
+    for row in rows:
+        ancestors: tuple[str, ...] = ()
+        if row["node_type"] == "hierarchy":
+            target = hierarchy_targets.get(row["node_id"])
+            ancestors = target.ancestors if target else ()
+        grants.append(
+            RoleGrant(
+                principal_type=row["principal_type"],
+                principal_id=row["principal_id"],
+                node_type=row["node_type"],
+                node_id=row["node_id"],
+                role=row["role"],
+                effect=row["effect"],
+                ancestors=ancestors,
+            )
+        )
+    return grants
+
+
+async def resolve_hierarchy_targets(db: Database, node_ids: Iterable[str]) -> list[AuthzTarget]:
+    """Resolve hierarchy nodes into AuthZ targets with root-to-parent ancestors."""
+    ordered_ids = _unique(node_ids)
+    if not ordered_ids:
+        return []
+
+    rows = await db.fetchall(
+        f"""
+        WITH RECURSIVE anc(leaf_id, cur_id, cur_parent, depth, seen) AS (
+            SELECT id, id, parent_id, 0, '|' || id || '|'
+            FROM hierarchy_nodes
+            WHERE id IN ({_placeholders(ordered_ids)})
+            UNION ALL
+            SELECT anc.leaf_id, hn.id, hn.parent_id, anc.depth + 1, anc.seen || hn.id || '|'
+            FROM anc
+            JOIN hierarchy_nodes hn ON hn.id = anc.cur_parent
+            WHERE anc.cur_parent IS NOT NULL
+              AND anc.depth < 63
+              AND instr(anc.seen, '|' || hn.id || '|') = 0
+        )
+        SELECT leaf_id, cur_id, depth
+        FROM anc
+        ORDER BY leaf_id, depth DESC
+        """,
+        ordered_ids,
+    )
+
+    ancestors_by_leaf: dict[str, list[str]] = {}
+    found_leaf_ids: set[str] = set()
+    for row in rows:
+        leaf_id = row["leaf_id"]
+        found_leaf_ids.add(leaf_id)
+        if row["depth"] > 0:
+            ancestors_by_leaf.setdefault(leaf_id, []).append(row["cur_id"])
+
+    return [
+        AuthzTarget(
+            node_type="hierarchy",
+            node_id=node_id,
+            ancestors=tuple(ancestors_by_leaf.get(node_id, [])),
+        )
+        for node_id in ordered_ids
+        if node_id in found_leaf_ids
+    ]
+
+
+async def resolve_datapoint_targets(db: Database, dp_ids: Iterable[str]) -> dict[str, list[AuthzTarget]]:
+    """Resolve datapoints to hierarchy targets.
+
+    Linked datapoints evaluate all linked hierarchy nodes. Existing datapoints
+    without hierarchy links receive a direct ``datapoint`` target: that keeps
+    the admin bridge effective while ungranted non-admin access still denies.
+    """
+    ordered_ids = _unique(dp_ids)
+    if not ordered_ids:
+        return {}
+
+    existing_rows = await db.fetchall(
+        f"SELECT id FROM datapoints WHERE id IN ({_placeholders(ordered_ids)})",
+        ordered_ids,
+    )
+    existing_ids = {row["id"] for row in existing_rows}
+
+    link_rows = await db.fetchall(
+        f"""
+        SELECT datapoint_id, node_id
+        FROM hierarchy_datapoint_links
+        WHERE datapoint_id IN ({_placeholders(ordered_ids)})
+        ORDER BY datapoint_id, node_id
+        """,
+        ordered_ids,
+    )
+    node_targets = {target.node_id: target for target in await resolve_hierarchy_targets(db, [row["node_id"] for row in link_rows])}
+
+    targets_by_dp: dict[str, list[AuthzTarget]] = {dp_id: [] for dp_id in ordered_ids}
+    for row in link_rows:
+        target = node_targets.get(row["node_id"])
+        if target is not None:
+            targets_by_dp[row["datapoint_id"]].append(target)
+
+    for dp_id in ordered_ids:
+        if dp_id in existing_ids and not targets_by_dp[dp_id]:
+            targets_by_dp[dp_id].append(AuthzTarget(node_type="datapoint", node_id=dp_id))
+
+    return targets_by_dp
+
+
+async def filter_authorized_datapoints(
+    db: Database,
+    principal: Principal,
+    dp_ids: Iterable[str],
+    *,
+    action: AuthzAction | str = AuthzAction.READ,
+    grants: Sequence[RoleGrant] | None = None,
+) -> list[str]:
+    """Return datapoint IDs from *dp_ids* authorized for *principal*."""
+    ordered_ids = _unique(dp_ids)
+    if not ordered_ids:
+        return []
+
+    resolved_grants = list(grants) if grants is not None else await load_role_grants(db, principal)
+    targets_by_dp = await resolve_datapoint_targets(db, ordered_ids)
+    allowed: list[str] = []
+    for dp_id in ordered_ids:
+        decision = authorize(
+            principal=principal,
+            action=action,
+            targets=targets_by_dp.get(dp_id, []),
+            grants=resolved_grants,
+        )
+        if decision.allowed:
+            allowed.append(dp_id)
+    return allowed

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -16,9 +16,12 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, field_serializer
 
-from obs.api.auth import get_admin_user, get_current_user, optional_current_user
+from obs.api.auth import Principal, get_admin_user, get_current_principal, get_current_user, optional_current_user
+from obs.api.authz import AuthzAction
+from obs.api.authz_service import filter_authorized_datapoints
 from obs.api.v1.datapoint_config import collect_datapoint_ids_from_config
 from obs.api.v1.sessions import validate_session
 from obs.core.event_bus import DataValueEvent, get_event_bus
@@ -181,6 +184,67 @@ def _enrich(dp: Any) -> DataPointOut:
     )
 
 
+def _principal_from_dependency(value: Principal | str) -> Principal:
+    if isinstance(value, Principal):
+        return value
+    return Principal(
+        subject=value,
+        type="api_key" if value.startswith("api_key:") else "user",
+        is_admin=value == "admin",
+    )
+
+
+async def _optional_current_principal(
+    request: Request,
+    db: Database = Depends(get_db),
+) -> Principal | None:
+    auth_header = request.headers.get("Authorization")
+    api_key = request.headers.get("X-API-Key")
+    credentials: HTTPAuthorizationCredentials | None = None
+    if auth_header:
+        scheme, _, token = auth_header.partition(" ")
+        if scheme.lower() == "bearer" and token:
+            credentials = HTTPAuthorizationCredentials(scheme=scheme, credentials=token)
+
+    if credentials is None and not api_key:
+        return None
+
+    try:
+        return await get_current_principal(credentials=credentials, api_key=api_key, db=db)
+    except HTTPException:
+        return None
+
+
+async def _readable_datapoint_ids(db: Database, principal: Principal, dps: list[Any]) -> list[str]:
+    ordered_ids = [str(dp.id) for dp in dps]
+    if principal.type == "user" and principal.is_admin:
+        return ordered_ids
+    return await filter_authorized_datapoints(db, principal, ordered_ids, action=AuthzAction.READ)
+
+
+async def _can_read_datapoint(db: Database, principal: Principal, dp_id: uuid.UUID) -> bool:
+    if principal.type == "user" and principal.is_admin:
+        return True
+    allowed = await filter_authorized_datapoints(db, principal, [str(dp_id)], action=AuthzAction.READ)
+    return bool(allowed)
+
+
+async def _user_visu_page_has_datapoint(db: Database, username: str, dp_id: uuid.UUID) -> bool:
+    from obs.api.v1.visu import _check_user_access, _resolve_access_with_node
+
+    rows = await db.fetchall("SELECT id FROM visu_nodes WHERE type = 'PAGE' AND page_config IS NOT NULL")
+    for row in rows:
+        page_id = row["id"]
+        access, _ = await _resolve_access_with_node(db, page_id)
+        if access != "user":
+            continue
+        if not await _check_user_access(db, page_id, username):
+            continue
+        if await _page_has_datapoint(db, page_id, dp_id):
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -205,13 +269,17 @@ async def list_datapoints(
     size: int = Query(50, ge=1, le=10000),
     sort: str = Query("created_at", pattern="^(name|data_type|created_at|updated_at)$"),
     order: str = Query("asc", pattern="^(asc|desc)$"),
-    _user: str = Depends(get_current_user),
+    _user: Principal | str = Depends(get_current_principal),
+    db: Database = Depends(get_db),
 ) -> DataPointPage:
+    principal = _principal_from_dependency(_user)
     reg = get_registry()
     all_dps = sorted(reg.all(), key=_SORT_KEYS[sort], reverse=(order == "desc"))
-    total = len(all_dps)
+    allowed_ids = set(await _readable_datapoint_ids(db, principal, all_dps))
+    readable_dps = [dp for dp in all_dps if str(dp.id) in allowed_ids]
+    total = len(readable_dps)
     offset = page * size
-    items = [_enrich(dp) for dp in all_dps[offset : offset + size]]
+    items = [_enrich(dp) for dp in readable_dps[offset : offset + size]]
     return DataPointPage(
         items=items,
         total=total,
@@ -241,10 +309,14 @@ async def create_datapoint(
 @router.get("/{dp_id}", response_model=DataPointOut)
 async def get_datapoint(
     dp_id: uuid.UUID,
-    _user: str = Depends(get_current_user),
+    _user: Principal | str = Depends(get_current_principal),
+    db: Database = Depends(get_db),
 ) -> DataPointOut:
+    principal = _principal_from_dependency(_user)
     dp = get_registry().get(dp_id)
     if dp is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
+    if not await _can_read_datapoint(db, principal, dp_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
     return _enrich(dp)
 
@@ -317,7 +389,7 @@ async def delete_datapoint(
 async def get_value(
     dp_id: uuid.UUID,
     request: Request,
-    user: str | None = Depends(optional_current_user),
+    user: Principal | str | None = Depends(_optional_current_principal),
     db: Database = Depends(get_db),
 ) -> ValueOut:
     reg = get_registry()
@@ -345,6 +417,11 @@ async def get_value(
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
         elif access not in ("public", "readonly"):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    else:
+        principal = _principal_from_dependency(user)
+        if not await _can_read_datapoint(db, principal, dp_id):
+            if principal.type != "user" or not await _user_visu_page_has_datapoint(db, principal.subject, dp_id):
+                raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
 
     state = reg.get_value(dp_id)
     return ValueOut(

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -245,6 +245,30 @@ async def _user_visu_page_has_datapoint(db: Database, username: str, dp_id: uuid
     return False
 
 
+async def _page_context_allows_datapoint_read(
+    db: Database,
+    request: Request,
+    dp_id: uuid.UUID,
+    principal: Principal | None = None,
+) -> bool:
+    page_id = request.headers.get("X-Page-Id")
+    if not page_id or not await _page_has_datapoint(db, page_id, dp_id):
+        return False
+
+    from obs.api.v1.visu import _check_user_access, _resolve_access_with_node
+
+    access, defining_node_id = await _resolve_access_with_node(db, page_id)
+    if access in ("public", "readonly"):
+        return True
+    if access == "protected":
+        session_token = request.headers.get("X-Session-Token")
+        validate_id = defining_node_id or page_id
+        return bool(session_token and validate_session(session_token, validate_id))
+    if access == "user" and principal is not None and principal.type == "user":
+        return await _check_user_access(db, page_id, principal.subject)
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -420,7 +444,9 @@ async def get_value(
     else:
         principal = _principal_from_dependency(user)
         if not await _can_read_datapoint(db, principal, dp_id):
-            if principal.type != "user" or not await _user_visu_page_has_datapoint(db, principal.subject, dp_id):
+            if not await _page_context_allows_datapoint_read(db, request, dp_id, principal) and (
+                principal.type != "user" or not await _user_visu_page_has_datapoint(db, principal.subject, dp_id)
+            ):
                 raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
 
     state = reg.get_value(dp_id)

--- a/obs/api/v1/history.py
+++ b/obs/api/v1/history.py
@@ -11,9 +11,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
-from obs.api.auth import optional_current_user
+from obs.api.auth import Principal, get_current_principal
+from obs.api.authz import AuthzAction
+from obs.api.authz_service import filter_authorized_datapoints
 from obs.api.v1.sessions import validate_session
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -23,6 +26,8 @@ router = APIRouter(tags=["history"])
 DEFAULT_HISTORY_WINDOW_HOURS = 24 * 7
 MIN_HISTORY_WINDOW_HOURS = 1
 MAX_HISTORY_WINDOW_HOURS = 24 * 365
+_history_bearer = HTTPBearer(auto_error=False)
+_history_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +95,16 @@ async def _get_default_history_window_hours(db: Database) -> int:
     return max(MIN_HISTORY_WINDOW_HOURS, min(hours, MAX_HISTORY_WINDOW_HOURS))
 
 
+async def _optional_history_principal(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_history_bearer),
+    api_key: str | None = Depends(_history_api_key_header),
+    db: Database = Depends(get_db),
+) -> Principal | None:
+    if credentials is None and api_key is None:
+        return None
+    return await get_current_principal(credentials=credentials, api_key=api_key, db=db)
+
+
 async def _resolve_page_access(db: Database, node_id: str) -> str:
     """Traversiert die parent_id-Kette und gibt das effektive Access-Level zurück."""
     current_id: str | None = node_id
@@ -130,6 +145,20 @@ async def _check_history_access(
     raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
 
 
+async def _check_datapoint_read_access(db: Database, principal: Principal | None, dp_id: uuid.UUID) -> None:
+    if principal is None:
+        return
+
+    allowed = await filter_authorized_datapoints(
+        db,
+        principal,
+        [str(dp_id)],
+        action=AuthzAction.READ,
+    )
+    if str(dp_id) not in allowed:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -142,12 +171,13 @@ async def query_history(
     to_ts: str | None = Query(None, alias="to"),
     limit: int = Query(10000, ge=1, le=100000),
     request: Request = None,
-    user: str | None = Depends(optional_current_user),
+    principal: Principal | None = Depends(_optional_history_principal),
     db: Database = Depends(get_db),
 ) -> list[HistoryPoint]:
-    await _check_history_access(request, user, db)
+    await _check_history_access(request, principal.subject if principal else None, db)
     if get_registry().get(dp_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
+    await _check_datapoint_read_access(db, principal, dp_id)
 
     now = datetime.now(UTC)
     window_hours = await _get_default_history_window_hours(db)
@@ -167,12 +197,13 @@ async def aggregate_history(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
     request: Request = None,
-    user: str | None = Depends(optional_current_user),
+    principal: Principal | None = Depends(_optional_history_principal),
     db: Database = Depends(get_db),
 ) -> list[AggregatedPoint]:
-    await _check_history_access(request, user, db)
+    await _check_history_access(request, principal.subject if principal else None, db)
     if get_registry().get(dp_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
+    await _check_datapoint_read_access(db, principal, dp_id)
     if fn not in ("avg", "min", "max", "last"):
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/obs/api/v1/history.py
+++ b/obs/api/v1/history.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from obs.api.auth import Principal, get_current_principal
 from obs.api.authz import AuthzAction
 from obs.api.authz_service import filter_authorized_datapoints
+from obs.api.v1.datapoints import _page_context_allows_datapoint_read
 from obs.api.v1.sessions import validate_session
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -148,7 +149,12 @@ async def _check_history_access(
     raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
 
 
-async def _check_datapoint_read_access(db: Database, principal: Principal | None, dp_id: uuid.UUID) -> None:
+async def _check_datapoint_read_access(
+    db: Database,
+    principal: Principal | None,
+    dp_id: uuid.UUID,
+    request: Request,
+) -> None:
     if principal is None:
         return
 
@@ -158,7 +164,7 @@ async def _check_datapoint_read_access(db: Database, principal: Principal | None
         [str(dp_id)],
         action=AuthzAction.READ,
     )
-    if str(dp_id) not in allowed:
+    if str(dp_id) not in allowed and not await _page_context_allows_datapoint_read(db, request, dp_id, principal):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
 
 
@@ -180,7 +186,7 @@ async def query_history(
     await _check_history_access(request, principal.subject if principal else None, db)
     if get_registry().get(dp_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
-    await _check_datapoint_read_access(db, principal, dp_id)
+    await _check_datapoint_read_access(db, principal, dp_id, request)
 
     now = datetime.now(UTC)
     window_hours = await _get_default_history_window_hours(db)
@@ -206,7 +212,7 @@ async def aggregate_history(
     await _check_history_access(request, principal.subject if principal else None, db)
     if get_registry().get(dp_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"DataPoint {dp_id} not found")
-    await _check_datapoint_read_access(db, principal, dp_id)
+    await _check_datapoint_read_access(db, principal, dp_id, request)
     if fn not in ("avg", "min", "max", "last"):
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/obs/api/v1/history.py
+++ b/obs/api/v1/history.py
@@ -102,7 +102,10 @@ async def _optional_history_principal(
 ) -> Principal | None:
     if credentials is None and api_key is None:
         return None
-    return await get_current_principal(credentials=credentials, api_key=api_key, db=db)
+    try:
+        return await get_current_principal(credentials=credentials, api_key=api_key, db=db)
+    except HTTPException:
+        return None
 
 
 async def _resolve_page_access(db: Database, node_id: str) -> str:

--- a/obs/api/v1/knxproj.py
+++ b/obs/api/v1/knxproj.py
@@ -29,7 +29,9 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from obs.api.auth import get_admin_user, get_current_user
+from obs.api.auth import Principal, get_admin_user, get_current_principal, get_current_user
+from obs.api.authz import AuthzAction
+from obs.api.authz_service import filter_authorized_datapoints
 from obs.api.v1.services.hierarchy_import import EtsImportRequest, create_ets_hierarchy
 from obs.db.database import Database, get_db
 from obs.knxproj.csv_parser import parse_ga_csv
@@ -311,6 +313,97 @@ def _device_out_from_row(row: Any) -> KnxDeviceOut:
         app_ref=row["app_ref"] or "",
         imported_at=row["imported_at"],
     )
+
+
+def _principal_from_dependency(value: Principal | str) -> Principal:
+    if isinstance(value, Principal):
+        return value
+    return Principal(
+        subject=value,
+        type="api_key" if value.startswith("api_key:") else "user",
+        is_admin=value == "admin",
+    )
+
+
+def _is_admin_principal(principal: Principal) -> bool:
+    return principal.type == "user" and principal.is_admin
+
+
+def _parse_binding_group_addresses(config: str | None) -> list[str]:
+    if not config:
+        return []
+    try:
+        parsed = json.loads(config)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    addresses: list[str] = []
+    for key in ("group_address", "state_group_address"):
+        value = parsed.get(key)
+        if isinstance(value, str) and value:
+            addresses.append(value)
+    return addresses
+
+
+async def _authorized_knx_group_addresses(
+    db: Database,
+    principal: Principal,
+    group_addresses: list[str],
+) -> set[str]:
+    ordered_addresses = list(dict.fromkeys(group_addresses))
+    if not ordered_addresses:
+        return set()
+    if _is_admin_principal(principal):
+        return set(ordered_addresses)
+
+    rows = await db.fetchall(
+        """SELECT ab.datapoint_id, ab.config
+           FROM adapter_bindings ab
+           LEFT JOIN adapter_instances ai ON ai.id = ab.adapter_instance_id
+           WHERE ab.adapter_type = 'KNX'
+             AND ab.enabled = 1
+             AND (ab.adapter_instance_id IS NULL OR ai.enabled = 1)""",
+    )
+    datapoints_by_ga: dict[str, list[str]] = {ga: [] for ga in ordered_addresses}
+    wanted = set(ordered_addresses)
+    for row in rows:
+        for ga in _parse_binding_group_addresses(row["config"]):
+            if ga in wanted:
+                datapoints_by_ga.setdefault(ga, []).append(row["datapoint_id"])
+
+    candidate_dp_ids = list(dict.fromkeys(dp_id for dp_ids in datapoints_by_ga.values() for dp_id in dp_ids))
+    allowed_dp_ids = set(
+        await filter_authorized_datapoints(
+            db,
+            principal,
+            candidate_dp_ids,
+            action=AuthzAction.READ,
+        )
+    )
+    return {ga for ga, dp_ids in datapoints_by_ga.items() if any(dp_id in allowed_dp_ids for dp_id in dp_ids)}
+
+
+async def _authorized_knx_device_scope(
+    db: Database,
+    principal: Principal,
+) -> tuple[set[str], set[str]]:
+    rows = await db.fetchall(
+        """SELECT DISTINCT co.device_id, l.ga_address
+           FROM knx_comm_objects co
+           JOIN knx_co_ga_links l ON l.comm_object_id = co.id
+           WHERE l.ga_address IS NOT NULL""",
+    )
+    if not rows:
+        return set(), set()
+
+    allowed_ga_addresses = await _authorized_knx_group_addresses(
+        db,
+        principal,
+        [row["ga_address"] for row in rows],
+    )
+    allowed_device_ids = {row["device_id"] for row in rows if row["ga_address"] in allowed_ga_addresses}
+    return allowed_device_ids, allowed_ga_addresses
 
 
 async def _import_knx_devices_and_comm_objects(
@@ -870,7 +963,7 @@ async def list_knx_devices(
     trade: str = Query("", description="Optionaler Gewerkefilter (noch ohne Wirkung)"),
     page: int = Query(0, ge=0),
     size: int = Query(50, ge=1, le=500),
-    _user: str = Depends(get_current_user),
+    _user: Principal | str = Depends(get_current_principal),
     db: Database = Depends(get_db),
 ) -> KnxDevicePage:
     # room/trade are intentionally accepted already so the API surface stays
@@ -880,8 +973,15 @@ async def list_knx_devices(
     if not await _knx_device_schema_ready(db):
         return KnxDevicePage(items=[], total=0, page=page, size=size, pages=1)
 
+    principal = _principal_from_dependency(_user)
     where: list[str] = []
     params: list[Any] = []
+    if not _is_admin_principal(principal):
+        allowed_device_ids, _ = await _authorized_knx_device_scope(db, principal)
+        if not allowed_device_ids:
+            return KnxDevicePage(items=[], total=0, page=page, size=size, pages=1)
+        where.append(f"id IN ({','.join('?' for _ in allowed_device_ids)})")
+        params.extend(sorted(allowed_device_ids))
 
     if q:
         like = f"%{q.lower()}%"
@@ -936,11 +1036,17 @@ async def list_knx_devices(
 @router.get("/devices/{pa}", response_model=KnxDeviceDetailOut)
 async def get_knx_device(
     pa: str,
-    _user: str = Depends(get_current_user),
+    _user: Principal | str = Depends(get_current_principal),
     db: Database = Depends(get_db),
 ) -> KnxDeviceDetailOut:
     if not await _knx_device_schema_ready(db):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"KNX Gerät {pa} nicht gefunden")
+
+    principal = _principal_from_dependency(_user)
+    allowed_ga_addresses: set[str] | None = None
+    allowed_device_ids: set[str] | None = None
+    if not _is_admin_principal(principal):
+        allowed_device_ids, allowed_ga_addresses = await _authorized_knx_device_scope(db, principal)
 
     device_row = await db.fetchone(
         """SELECT
@@ -956,6 +1062,8 @@ async def get_knx_device(
         (pa,),
     )
     if not device_row:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"KNX Gerät {pa} nicht gefunden")
+    if allowed_device_ids is not None and device_row["id"] not in allowed_device_ids:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"KNX Gerät {pa} nicht gefunden")
 
     co_rows = await db.fetchall(
@@ -974,6 +1082,9 @@ async def get_knx_device(
 
     by_id: dict[str, KnxCommObjectOut] = {}
     for row in co_rows:
+        ga = row["ga_address"]
+        if allowed_ga_addresses is not None and ga not in allowed_ga_addresses:
+            continue
         co_id = row["id"]
         if co_id not in by_id:
             by_id[co_id] = KnxCommObjectOut(
@@ -983,7 +1094,6 @@ async def get_knx_device(
                 datapoint_type=row["datapoint_type"] or "",
                 ga_addresses=[],
             )
-        ga = row["ga_address"]
         if ga:
             by_id[co_id].ga_addresses.append(ga)
 
@@ -999,11 +1109,17 @@ async def list_knx_devices_for_group_address(
     ga: str,
     page: int = Query(0, ge=0),
     size: int = Query(50, ge=1, le=500),
-    _user: str = Depends(get_current_user),
+    _user: Principal | str = Depends(get_current_principal),
     db: Database = Depends(get_db),
 ) -> KnxDevicePage:
     if not await _knx_device_schema_ready(db):
         return KnxDevicePage(items=[], total=0, page=page, size=size, pages=1)
+
+    principal = _principal_from_dependency(_user)
+    if not _is_admin_principal(principal):
+        allowed_addresses = await _authorized_knx_group_addresses(db, principal, [ga])
+        if ga not in allowed_addresses:
+            return KnxDevicePage(items=[], total=0, page=page, size=size, pages=1)
 
     count_row = await db.fetchone(
         """SELECT COUNT(DISTINCT d.id) AS n

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -18,8 +18,8 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from obs.api.auth import Principal, get_current_principal
-from obs.api.authz import AuthzAction
-from obs.api.authz_service import filter_authorized_datapoints
+from obs.api.authz import AuthzAction, authorize
+from obs.api.authz_service import filter_authorized_datapoints, load_role_grants, resolve_hierarchy_targets
 from obs.api.v1.datapoints import _SORT_KEYS, DataPointOut, HierarchyNodeRef, NodePathSegment, _enrich
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -36,7 +36,22 @@ class SearchPage(BaseModel):
     query: dict
 
 
-async def _add_hierarchy(items: list[DataPointOut], db: Database) -> None:
+async def _filter_authorized_hierarchy_rows(db: Database, principal: Principal, rows: list) -> list:
+    if principal.type == "user" and principal.is_admin:
+        return rows
+
+    node_ids = [row["node_id"] for row in rows]
+    targets_by_node = {target.node_id: target for target in await resolve_hierarchy_targets(db, node_ids)}
+    grants = await load_role_grants(db, principal, node_type="hierarchy")
+    return [
+        row
+        for row in rows
+        if (target := targets_by_node.get(row["node_id"]))
+        and authorize(principal=principal, action=AuthzAction.READ, targets=[target], grants=grants).allowed
+    ]
+
+
+async def _add_hierarchy(items: list[DataPointOut], db: Database, principal: Principal) -> None:
     """Batch-query hierarchy node links and inject into items in-place.
 
     Also computes each node's ancestor path (root → leaf, excluding tree name)
@@ -57,6 +72,7 @@ async def _add_hierarchy(items: list[DataPointOut], db: Database) -> None:
             ORDER BY ht.name, hn.name""",
         dp_ids,
     )
+    rows = await _filter_authorized_hierarchy_rows(db, principal, rows)
     # Build ancestor paths for all linked nodes via recursive CTE (upstream
     # PR #462) — produces the richer node_path schema (objects with stable
     # node_id + node_name per segment) that the epic switched to during the
@@ -179,11 +195,12 @@ async def search(
                     UNION ALL
                     SELECT hn.id FROM hierarchy_nodes hn JOIN desc d ON hn.parent_id = d.id
                 )
-                SELECT DISTINCT hdl.datapoint_id
+                SELECT DISTINCT hdl.datapoint_id, hdl.node_id
                 FROM hierarchy_datapoint_links hdl
                 JOIN desc d ON hdl.node_id = d.id""",
                 node_id_list,
             )
+            rows = await _filter_authorized_hierarchy_rows(db, principal, rows)
             matched_ids = {r["datapoint_id"] for r in rows}
             results = [dp for dp in results if str(dp.id) in matched_ids]
 
@@ -193,12 +210,13 @@ async def search(
         if tree_id_list:
             placeholders = ",".join("?" * len(tree_id_list))
             rows = await db.fetchall(
-                f"""SELECT DISTINCT hdl.datapoint_id
+                f"""SELECT DISTINCT hdl.datapoint_id, hdl.node_id
                     FROM hierarchy_datapoint_links hdl
                     JOIN hierarchy_nodes hn ON hn.id = hdl.node_id
                     WHERE hn.tree_id IN ({placeholders})""",
                 tree_id_list,
             )
+            rows = await _filter_authorized_hierarchy_rows(db, principal, rows)
             matched_ids = {r["datapoint_id"] for r in rows}
             results = [dp for dp in results if str(dp.id) in matched_ids]
 
@@ -234,7 +252,7 @@ async def search(
     items = [_enrich(dp) for dp in results[offset : offset + size]]
 
     # 10. Enrich with hierarchy node assignments (single batch query)
-    await _add_hierarchy(items, db)
+    await _add_hierarchy(items, db, principal)
 
     return SearchPage(
         items=items,

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from obs.api.auth import get_current_user
+from obs.api.auth import Principal, get_current_principal
+from obs.api.authz import AuthzAction
+from obs.api.authz_service import filter_authorized_datapoints
 from obs.api.v1.datapoints import _SORT_KEYS, DataPointOut, HierarchyNodeRef, NodePathSegment, _enrich
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -112,9 +114,10 @@ async def search(
     order: str = Query("asc", pattern="^(asc|desc)$"),
     page: int = Query(0, ge=0),
     size: int = Query(50, ge=1, le=500),
-    _user: str = Depends(get_current_user),
+    _user: Principal | str = Depends(get_current_principal),
     db: Database = Depends(lambda: get_db()),
 ) -> SearchPage:
+    principal = _user if isinstance(_user, Principal) else Principal(subject=_user, type="user", is_admin=_user == "admin")
     reg = get_registry()
     results = reg.all()
 
@@ -210,15 +213,27 @@ async def search(
 
         results = [dp for dp in results if _quality_of(dp) == quality]
 
-    # 7. Sort
+    # 7. AuthZ read scope filter
+    if results and not (principal.type == "user" and principal.is_admin):
+        authorized_ids = set(
+            await filter_authorized_datapoints(
+                db,
+                principal,
+                [str(dp.id) for dp in results],
+                action=AuthzAction.READ,
+            )
+        )
+        results = [dp for dp in results if str(dp.id) in authorized_ids]
+
+    # 8. Sort
     results = sorted(results, key=_SORT_KEYS[sort], reverse=(order == "desc"))
 
-    # 8. Paginate
+    # 9. Paginate
     total = len(results)
     offset = page * size
     items = [_enrich(dp) for dp in results[offset : offset + size]]
 
-    # 9. Enrich with hierarchy node assignments (single batch query)
+    # 10. Enrich with hierarchy node assignments (single batch query)
     await _add_hierarchy(items, db)
 
     return SearchPage(

--- a/obs/api/v1/search.py
+++ b/obs/api/v1/search.py
@@ -51,7 +51,7 @@ async def _filter_authorized_hierarchy_rows(db: Database, principal: Principal, 
     ]
 
 
-async def _add_hierarchy(items: list[DataPointOut], db: Database, principal: Principal) -> None:
+async def _add_hierarchy(items: list[DataPointOut], db: Database, principal: Principal | None = None) -> None:
     """Batch-query hierarchy node links and inject into items in-place.
 
     Also computes each node's ancestor path (root → leaf, excluding tree name)
@@ -72,7 +72,8 @@ async def _add_hierarchy(items: list[DataPointOut], db: Database, principal: Pri
             ORDER BY ht.name, hn.name""",
         dp_ids,
     )
-    rows = await _filter_authorized_hierarchy_rows(db, principal, rows)
+    if principal is not None:
+        rows = await _filter_authorized_hierarchy_rows(db, principal, rows)
     # Build ancestor paths for all linked nodes via recursive CTE (upstream
     # PR #462) — produces the richer node_path schema (objects with stable
     # node_id + node_name per segment) that the epic switched to during the

--- a/tests/unit/test_authz_runtime.py
+++ b/tests/unit/test_authz_runtime.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import pytest
+
+from obs.api.auth import Principal
+from obs.api.authz import AuthzAction, GrantEffect, Role
+from obs.api.authz_service import (
+    filter_authorized_datapoints,
+    load_role_grants,
+    resolve_datapoint_targets,
+    resolve_hierarchy_targets,
+)
+from obs.db.database import Database
+
+
+NOW = "2026-06-10T00:00:00+00:00"
+
+
+@pytest.fixture
+async def db() -> Database:
+    database = Database(":memory:")
+    await database.connect()
+    try:
+        yield database
+    finally:
+        await database.disconnect()
+
+
+async def _insert_tree(db: Database, tree_id: str = "tree") -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_trees (id, name, description, created_at, updated_at)
+        VALUES (?, ?, '', ?, ?)
+        """,
+        (tree_id, tree_id, NOW, NOW),
+    )
+
+
+async def _insert_node(db: Database, node_id: str, *, parent_id: str | None = None, tree_id: str = "tree") -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_nodes
+            (id, tree_id, parent_id, name, description, node_order, icon, created_at, updated_at)
+        VALUES (?, ?, ?, ?, '', 0, NULL, ?, ?)
+        """,
+        (node_id, tree_id, parent_id, node_id, NOW, NOW),
+    )
+
+
+async def _insert_datapoint(db: Database, dp_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO datapoints (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, created_at, updated_at)
+        VALUES (?, ?, 'FLOAT', NULL, '[]', ?, NULL, ?, ?)
+        """,
+        (dp_id, dp_id, f"obs/test/{dp_id}", NOW, NOW),
+    )
+
+
+async def _link_datapoint(db: Database, dp_id: str, node_id: str, link_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_datapoint_links (id, node_id, datapoint_id, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (link_id, node_id, dp_id, NOW),
+    )
+
+
+async def _insert_grant(
+    db: Database,
+    *,
+    principal_type: str = "user",
+    principal_id: str = "alice",
+    node_type: str = "hierarchy",
+    node_id: str,
+    role: str = "guest",
+    effect: str = "allow",
+) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO authz_node_roles (principal_type, principal_id, node_type, node_id, role, effect)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (principal_type, principal_id, node_type, node_id, role, effect),
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_role_grants_converts_db_rows_with_text_enums_and_ancestors(db: Database):
+    await _insert_tree(db)
+    await _insert_node(db, "building")
+    await _insert_node(db, "floor", parent_id="building")
+    await _insert_node(db, "room", parent_id="floor")
+    await _insert_grant(db, node_id="room", role="operator", effect="deny")
+
+    grants = await load_role_grants(db, Principal(subject="alice", type="user", is_admin=False))
+
+    assert len(grants) == 1
+    assert grants[0].role is Role.OPERATOR
+    assert grants[0].effect is GrantEffect.DENY
+    assert grants[0].ancestors == ("building", "floor")
+
+
+@pytest.mark.asyncio
+async def test_load_role_grants_matches_api_key_principal_to_persisted_raw_key_id(db: Database):
+    await _insert_tree(db)
+    await _insert_node(db, "room")
+    await _insert_grant(
+        db,
+        principal_type="api_key",
+        principal_id="key-1",
+        node_id="room",
+        role="guest",
+    )
+
+    grants = await load_role_grants(db, Principal(subject="api_key:key-1", type="api_key", is_admin=False))
+
+    assert len(grants) == 1
+    assert grants[0].principal_id == "key-1"
+    assert grants[0].role is Role.GUEST
+
+
+@pytest.mark.asyncio
+async def test_resolve_hierarchy_targets_returns_ancestor_paths(db: Database):
+    await _insert_tree(db)
+    await _insert_node(db, "building")
+    await _insert_node(db, "floor", parent_id="building")
+    await _insert_node(db, "room", parent_id="floor")
+
+    targets = await resolve_hierarchy_targets(db, ["room"])
+
+    assert len(targets) == 1
+    assert targets[0].node_type == "hierarchy"
+    assert targets[0].node_id == "room"
+    assert targets[0].ancestors == ("building", "floor")
+
+
+@pytest.mark.asyncio
+async def test_resolve_datapoint_targets_includes_all_linked_hierarchy_nodes(db: Database):
+    await _insert_tree(db)
+    await _insert_node(db, "wing-a")
+    await _insert_node(db, "room-a", parent_id="wing-a")
+    await _insert_node(db, "wing-b")
+    await _insert_node(db, "room-b", parent_id="wing-b")
+    await _insert_datapoint(db, "dp-1")
+    await _link_datapoint(db, "dp-1", "room-a", "link-a")
+    await _link_datapoint(db, "dp-1", "room-b", "link-b")
+
+    targets_by_dp = await resolve_datapoint_targets(db, ["dp-1"])
+
+    targets = targets_by_dp["dp-1"]
+    assert {target.node_id for target in targets} == {"room-a", "room-b"}
+    assert {target.ancestors for target in targets} == {("wing-a",), ("wing-b",)}
+
+
+@pytest.mark.asyncio
+async def test_filter_authorized_datapoints_evaluates_all_linked_targets(db: Database):
+    await _insert_tree(db)
+    await _insert_node(db, "room-a")
+    await _insert_node(db, "room-b")
+    await _insert_datapoint(db, "dp-1")
+    await _link_datapoint(db, "dp-1", "room-a", "link-a")
+    await _link_datapoint(db, "dp-1", "room-b", "link-b")
+    await _insert_grant(db, node_id="room-a", role="guest", effect="allow")
+    await _insert_grant(db, node_id="room-b", role="guest", effect="deny")
+
+    allowed = await filter_authorized_datapoints(
+        db,
+        Principal(subject="alice", type="user", is_admin=False),
+        ["dp-1"],
+        action=AuthzAction.READ,
+    )
+
+    assert allowed == []
+
+
+@pytest.mark.asyncio
+async def test_unlinked_datapoints_keep_admin_bridge_but_deny_ungranted_non_admin(db: Database):
+    await _insert_datapoint(db, "dp-unlinked")
+
+    admin_allowed = await filter_authorized_datapoints(
+        db,
+        Principal(subject="admin", type="user", is_admin=True),
+        ["dp-unlinked"],
+    )
+    user_allowed = await filter_authorized_datapoints(
+        db,
+        Principal(subject="alice", type="user", is_admin=False),
+        ["dp-unlinked"],
+    )
+
+    assert admin_allowed == ["dp-unlinked"]
+    assert user_allowed == []

--- a/tests/unit/test_coverage_config_ringbuffer_misc.py
+++ b/tests/unit/test_coverage_config_ringbuffer_misc.py
@@ -1368,7 +1368,7 @@ async def test_query_history_dp_not_found(monkeypatch):
                 to_ts=None,
                 limit=100,
                 request=request,
-                user="admin",
+                principal=None,
                 db=db,
             )
     assert exc_info.value.status_code == 404
@@ -1397,7 +1397,7 @@ async def test_query_history_success(monkeypatch):
             to_ts=None,
             limit=100,
             request=request,
-            user="admin",
+            principal=None,
             db=db,
         )
 
@@ -1424,7 +1424,7 @@ async def test_aggregate_history_invalid_fn(monkeypatch):
                 from_ts=None,
                 to_ts=None,
                 request=request,
-                user="admin",
+                principal=None,
                 db=db,
             )
     assert exc_info.value.status_code == 422
@@ -1454,7 +1454,7 @@ async def test_aggregate_history_success(monkeypatch):
             from_ts=None,
             to_ts=None,
             request=request,
-            user="admin",
+            principal=None,
             db=db,
         )
 
@@ -1480,7 +1480,7 @@ async def test_aggregate_history_dp_not_found(monkeypatch):
                 from_ts=None,
                 to_ts=None,
                 request=request,
-                user="admin",
+                principal=None,
                 db=db,
             )
     assert exc_info.value.status_code == 404

--- a/tests/unit/test_datapoints_authz.py
+++ b/tests/unit/test_datapoints_authz.py
@@ -257,6 +257,60 @@ async def test_get_value_public_page_path_remains_compatible_without_grant(monke
 
 
 @pytest.mark.asyncio
+async def test_get_value_authenticated_public_page_path_remains_compatible_without_grant(monkeypatch, db: Database):
+    datapoint = _dp("00000000-0000-0000-0000-000000000042", "Authenticated public page value")
+    await _insert_datapoint(db, datapoint)
+    page_config = f"""
+    {{
+      "grid_cols": 12,
+      "grid_row_height": 80,
+      "grid_cell_width": 120,
+      "background": null,
+      "widgets": [
+        {{
+          "id": "widget-1",
+          "name": "Widget",
+          "type": "value",
+          "datapoint_id": "{datapoint.id}",
+          "status_datapoint_id": null,
+          "x": 0,
+          "y": 0,
+          "w": 2,
+          "h": 1,
+          "config": {{}}
+        }}
+      ]
+    }}
+    """
+    await db.execute_and_commit(
+        """
+        INSERT INTO visu_nodes
+            (id, parent_id, name, type, node_order, icon, access, access_pin, page_config, created_at, updated_at)
+        VALUES ('page-public-auth', NULL, 'Page', 'PAGE', 0, NULL, 'public', NULL, ?, ?, ?)
+        """,
+        (page_config, NOW, NOW),
+    )
+    registry = _RegistryStub([datapoint])
+    state = ValueState()
+    state.update(20.0, "good")
+    registry._values[datapoint.id] = state
+    monkeypatch.setattr(dp_api, "get_registry", lambda: registry)
+    monkeypatch.setattr("obs.api.v1.visu._resolve_access_with_node", AsyncMock(return_value=("public", None)))
+
+    request = MagicMock()
+    request.headers.get = lambda key, default=None: {"X-Page-Id": "page-public-auth"}.get(key, default)
+    result = await dp_api.get_value(
+        dp_id=datapoint.id,
+        request=request,
+        user=Principal(subject="alice", type="user", is_admin=False),
+        db=db,
+    )
+
+    assert result.value == 20.0
+    assert result.quality == "good"
+
+
+@pytest.mark.asyncio
 async def test_get_value_assigned_user_visu_page_remains_compatible_without_grant(monkeypatch, db: Database):
     datapoint = _dp("00000000-0000-0000-0000-000000000051", "User page value")
     await _insert_datapoint(db, datapoint)

--- a/tests/unit/test_datapoints_authz.py
+++ b/tests/unit/test_datapoints_authz.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from obs.api.auth import Principal
+from obs.api.v1 import datapoints as dp_api
+from obs.core.registry import ValueState
+from obs.db.database import Database
+
+
+NOW = "2026-06-10T00:00:00+00:00"
+
+
+class _RegistryStub:
+    def __init__(self, dps=None):
+        self._dps = {dp.id: dp for dp in dps or []}
+        self._values: dict[uuid.UUID, ValueState] = {}
+
+    def all(self):
+        return list(self._dps.values())
+
+    def get(self, dp_id):
+        return self._dps.get(dp_id)
+
+    def get_value(self, dp_id):
+        return self._values.get(dp_id)
+
+
+@pytest.fixture
+async def db() -> Database:
+    database = Database(":memory:")
+    await database.connect()
+    try:
+        yield database
+    finally:
+        await database.disconnect()
+
+
+def _dp(dp_id: str, name: str):
+    parsed_id = uuid.UUID(dp_id)
+    return SimpleNamespace(
+        id=parsed_id,
+        name=name,
+        data_type="FLOAT",
+        unit="degC",
+        tags=[],
+        mqtt_topic=f"dp/{parsed_id}/value",
+        mqtt_alias=None,
+        persist_value=True,
+        record_history=True,
+        created_at=datetime(2026, 6, 10, tzinfo=UTC),
+        updated_at=datetime(2026, 6, 10, tzinfo=UTC),
+    )
+
+
+async def _insert_tree(db: Database) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_trees (id, name, description, created_at, updated_at)
+        VALUES ('tree', 'tree', '', ?, ?)
+        """,
+        (NOW, NOW),
+    )
+
+
+async def _insert_node(db: Database, node_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_nodes
+            (id, tree_id, parent_id, name, description, node_order, icon, created_at, updated_at)
+        VALUES (?, 'tree', NULL, ?, '', 0, NULL, ?, ?)
+        """,
+        (node_id, node_id, NOW, NOW),
+    )
+
+
+async def _insert_datapoint(db: Database, dp) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO datapoints
+            (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, persist_value, record_history, created_at, updated_at)
+        VALUES (?, ?, ?, ?, '[]', ?, NULL, 1, 1, ?, ?)
+        """,
+        (str(dp.id), dp.name, dp.data_type, dp.unit, dp.mqtt_topic, NOW, NOW),
+    )
+
+
+async def _link_datapoint(db: Database, dp_id: uuid.UUID, node_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_datapoint_links (id, node_id, datapoint_id, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (str(uuid.uuid4()), node_id, str(dp_id), NOW),
+    )
+
+
+async def _insert_grant(db: Database, node_id: str, *, principal_id: str = "alice") -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO authz_node_roles (principal_type, principal_id, node_type, node_id, role, effect)
+        VALUES ('user', ?, 'hierarchy', ?, 'guest', 'allow')
+        """,
+        (principal_id, node_id),
+    )
+
+
+async def _prepare_linked_datapoints(db: Database, dps, *, authorized_node: str = "allowed") -> None:
+    await _insert_tree(db)
+    await _insert_node(db, authorized_node)
+    await _insert_node(db, "blocked")
+    for dp in dps:
+        await _insert_datapoint(db, dp)
+    await _insert_grant(db, authorized_node)
+
+
+@pytest.mark.asyncio
+async def test_list_datapoints_filters_before_pagination_and_preserves_sort(monkeypatch, db: Database):
+    hidden = _dp("00000000-0000-0000-0000-000000000001", "Alpha hidden")
+    allowed_b = _dp("00000000-0000-0000-0000-000000000002", "Bravo allowed")
+    allowed_c = _dp("00000000-0000-0000-0000-000000000003", "Charlie allowed")
+    await _prepare_linked_datapoints(db, [hidden, allowed_b, allowed_c])
+    await _link_datapoint(db, hidden.id, "blocked")
+    await _link_datapoint(db, allowed_b.id, "allowed")
+    await _link_datapoint(db, allowed_c.id, "allowed")
+    monkeypatch.setattr(dp_api, "get_registry", lambda: _RegistryStub([hidden, allowed_b, allowed_c]))
+
+    result = await dp_api.list_datapoints(
+        page=0,
+        size=1,
+        sort="name",
+        order="asc",
+        _user=Principal(subject="alice", type="user", is_admin=False),
+        db=db,
+    )
+
+    assert result.total == 2
+    assert result.pages == 2
+    assert [item.name for item in result.items] == ["Bravo allowed"]
+
+
+@pytest.mark.asyncio
+async def test_get_datapoint_returns_404_for_existing_out_of_scope_datapoint(monkeypatch, db: Database):
+    hidden = _dp("00000000-0000-0000-0000-000000000011", "Hidden")
+    await _prepare_linked_datapoints(db, [hidden])
+    await _link_datapoint(db, hidden.id, "blocked")
+    monkeypatch.setattr(dp_api, "get_registry", lambda: _RegistryStub([hidden]))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dp_api.get_datapoint(
+            dp_id=hidden.id,
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_value_authenticated_returns_404_for_existing_out_of_scope_datapoint(monkeypatch, db: Database):
+    hidden = _dp("00000000-0000-0000-0000-000000000021", "Hidden value")
+    await _prepare_linked_datapoints(db, [hidden])
+    await _link_datapoint(db, hidden.id, "blocked")
+    registry = _RegistryStub([hidden])
+    state = ValueState()
+    state.update(21.5, "good")
+    registry._values[hidden.id] = state
+    monkeypatch.setattr(dp_api, "get_registry", lambda: registry)
+
+    request = MagicMock()
+    request.headers = {}
+    with pytest.raises(HTTPException) as exc_info:
+        await dp_api.get_value(
+            dp_id=hidden.id,
+            request=request,
+            user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_list_keeps_no_grant_visibility(monkeypatch, db: Database):
+    first = _dp("00000000-0000-0000-0000-000000000031", "Alpha")
+    second = _dp("00000000-0000-0000-0000-000000000032", "Bravo")
+    await _insert_datapoint(db, first)
+    await _insert_datapoint(db, second)
+    monkeypatch.setattr(dp_api, "get_registry", lambda: _RegistryStub([first, second]))
+
+    result = await dp_api.list_datapoints(
+        page=0,
+        size=50,
+        sort="name",
+        order="asc",
+        _user=Principal(subject="admin", type="user", is_admin=True),
+        db=db,
+    )
+
+    assert result.total == 2
+    assert [item.name for item in result.items] == ["Alpha", "Bravo"]
+
+
+@pytest.mark.asyncio
+async def test_get_value_public_page_path_remains_compatible_without_grant(monkeypatch, db: Database):
+    datapoint = _dp("00000000-0000-0000-0000-000000000041", "Public page value")
+    await _insert_datapoint(db, datapoint)
+    page_config = f"""
+    {{
+      "grid_cols": 12,
+      "grid_row_height": 80,
+      "grid_cell_width": 120,
+      "background": null,
+      "widgets": [
+        {{
+          "id": "widget-1",
+          "name": "Widget",
+          "type": "value",
+          "datapoint_id": "{datapoint.id}",
+          "status_datapoint_id": null,
+          "x": 0,
+          "y": 0,
+          "w": 2,
+          "h": 1,
+          "config": {{}}
+        }}
+      ]
+    }}
+    """
+    await db.execute_and_commit(
+        """
+        INSERT INTO visu_nodes
+            (id, parent_id, name, type, node_order, icon, access, access_pin, page_config, created_at, updated_at)
+        VALUES ('page-public', NULL, 'Page', 'PAGE', 0, NULL, 'public', NULL, ?, ?, ?)
+        """,
+        (page_config, NOW, NOW),
+    )
+    registry = _RegistryStub([datapoint])
+    state = ValueState()
+    state.update(19.0, "good")
+    registry._values[datapoint.id] = state
+    monkeypatch.setattr(dp_api, "get_registry", lambda: registry)
+    monkeypatch.setattr("obs.api.v1.visu._resolve_access_with_node", AsyncMock(return_value=("public", None)))
+
+    request = MagicMock()
+    request.headers.get = lambda key, default=None: {"X-Page-Id": "page-public"}.get(key, default)
+    result = await dp_api.get_value(dp_id=datapoint.id, request=request, user=None, db=db)
+
+    assert result.value == 19.0
+    assert result.quality == "good"
+
+
+@pytest.mark.asyncio
+async def test_get_value_assigned_user_visu_page_remains_compatible_without_grant(monkeypatch, db: Database):
+    datapoint = _dp("00000000-0000-0000-0000-000000000051", "User page value")
+    await _insert_datapoint(db, datapoint)
+    await db.execute_and_commit(
+        """
+        INSERT INTO users (id, username, password_hash, created_at, is_admin)
+        VALUES ('user-id', 'alice', 'hash', ?, 0)
+        """,
+        (NOW,),
+    )
+    page_config = f"""
+    {{
+      "grid_cols": 12,
+      "grid_row_height": 80,
+      "grid_cell_width": 120,
+      "background": null,
+      "widgets": [
+        {{
+          "id": "widget-1",
+          "name": "Widget",
+          "type": "value",
+          "datapoint_id": "{datapoint.id}",
+          "status_datapoint_id": null,
+          "x": 0,
+          "y": 0,
+          "w": 2,
+          "h": 1,
+          "config": {{}}
+        }}
+      ]
+    }}
+    """
+    await db.execute_and_commit(
+        """
+        INSERT INTO visu_nodes
+            (id, parent_id, name, type, node_order, icon, access, access_pin, page_config, created_at, updated_at)
+        VALUES ('page-user', NULL, 'User Page', 'PAGE', 0, NULL, 'user', NULL, ?, ?, ?)
+        """,
+        (page_config, NOW, NOW),
+    )
+    await db.execute_and_commit("INSERT INTO visu_node_users (node_id, username) VALUES ('page-user', 'alice')")
+    registry = _RegistryStub([datapoint])
+    state = ValueState()
+    state.update(23.0, "good")
+    registry._values[datapoint.id] = state
+    monkeypatch.setattr(dp_api, "get_registry", lambda: registry)
+
+    request = MagicMock()
+    request.headers = {}
+    result = await dp_api.get_value(
+        dp_id=datapoint.id,
+        request=request,
+        user=Principal(subject="alice", type="user", is_admin=False),
+        db=db,
+    )
+
+    assert result.value == 23.0
+    assert result.quality == "good"

--- a/tests/unit/test_history_authz.py
+++ b/tests/unit/test_history_authz.py
@@ -114,6 +114,46 @@ def _principal(subject: str = "alice", *, is_admin: bool = False) -> Principal:
 
 
 @pytest.mark.asyncio
+async def test_invalid_auth_with_public_page_falls_back_to_page_access(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _insert_datapoint(db, dp_id)
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    async def _invalid_auth(*, credentials, api_key, db):
+        raise HTTPException(status_code=401, detail="invalid auth")
+
+    monkeypatch.setattr(history_api, "get_current_principal", _invalid_auth)
+
+    principal = await history_api._optional_history_principal(
+        credentials=SimpleNamespace(credentials="invalid-token"),
+        api_key=None,
+        db=db,
+    )
+
+    plugin = MagicMock()
+    plugin.query = AsyncMock(return_value=[])
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+    monkeypatch.setattr(history_api, "_resolve_page_access", AsyncMock(return_value="public"))
+
+    request = MagicMock()
+    request.headers.get.return_value = "page-1"
+
+    result = await history_api.query_history(
+        dp_id=dp_id,
+        from_ts=None,
+        to_ts=None,
+        limit=100,
+        request=request,
+        principal=principal,
+        db=db,
+    )
+
+    assert principal is None
+    assert result == []
+    plugin.query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_query_history_with_read_grant_reaches_plugin(monkeypatch, db: Database):
     dp_id = uuid.uuid4()
     await _seed_datapoint_scope(db, dp_id, grant_principal="alice")

--- a/tests/unit/test_history_authz.py
+++ b/tests/unit/test_history_authz.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from obs.api.auth import Principal
+from obs.api.v1 import history as history_api
+from obs.db.database import Database
+
+
+NOW = "2026-06-10T00:00:00+00:00"
+
+
+@pytest.fixture
+async def db() -> Database:
+    database = Database(":memory:")
+    await database.connect()
+    try:
+        yield database
+    finally:
+        await database.disconnect()
+
+
+class _RegistryStub:
+    def __init__(self, dp_id: uuid.UUID):
+        self._dp_id = dp_id
+        self._dp = SimpleNamespace(id=dp_id)
+
+    def get(self, dp_id: uuid.UUID):
+        if dp_id == self._dp_id:
+            return self._dp
+        return None
+
+
+async def _insert_tree(db: Database) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_trees (id, name, description, created_at, updated_at)
+        VALUES ('tree', 'tree', '', ?, ?)
+        """,
+        (NOW, NOW),
+    )
+
+
+async def _insert_node(db: Database, node_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_nodes
+            (id, tree_id, parent_id, name, description, node_order, icon, created_at, updated_at)
+        VALUES (?, 'tree', NULL, ?, '', 0, NULL, ?, ?)
+        """,
+        (node_id, node_id, NOW, NOW),
+    )
+
+
+async def _insert_datapoint(db: Database, dp_id: uuid.UUID) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO datapoints (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, created_at, updated_at)
+        VALUES (?, 'History DP', 'FLOAT', NULL, '[]', ?, NULL, ?, ?)
+        """,
+        (str(dp_id), f"obs/test/{dp_id}", NOW, NOW),
+    )
+
+
+async def _link_datapoint(db: Database, dp_id: uuid.UUID, node_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_datapoint_links (id, node_id, datapoint_id, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (f"link-{node_id}", node_id, str(dp_id), NOW),
+    )
+
+
+async def _insert_read_grant(db: Database, *, principal_id: str, node_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO authz_node_roles (principal_type, principal_id, node_type, node_id, role, effect)
+        VALUES ('user', ?, 'hierarchy', ?, 'guest', 'allow')
+        """,
+        (principal_id, node_id),
+    )
+
+
+async def _seed_datapoint_scope(
+    db: Database,
+    dp_id: uuid.UUID,
+    *,
+    node_id: str = "room",
+    grant_principal: str | None = None,
+) -> None:
+    await _insert_tree(db)
+    await _insert_node(db, node_id)
+    await _insert_datapoint(db, dp_id)
+    await _link_datapoint(db, dp_id, node_id)
+    if grant_principal is not None:
+        await _insert_read_grant(db, principal_id=grant_principal, node_id=node_id)
+
+
+def _request() -> MagicMock:
+    request = MagicMock()
+    request.headers.get.return_value = None
+    return request
+
+
+def _principal(subject: str = "alice", *, is_admin: bool = False) -> Principal:
+    return Principal(subject=subject, type="user", is_admin=is_admin)
+
+
+@pytest.mark.asyncio
+async def test_query_history_with_read_grant_reaches_plugin(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _seed_datapoint_scope(db, dp_id, grant_principal="alice")
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    plugin = MagicMock()
+    plugin.query = AsyncMock(return_value=[{"ts": "2026-06-10T00:00:00Z", "v": 21.5, "u": "degC", "q": "good"}])
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+
+    result = await history_api.query_history(
+        dp_id=dp_id,
+        from_ts="2026-06-10T00:00:00Z",
+        to_ts="2026-06-10T01:00:00Z",
+        limit=100,
+        request=_request(),
+        principal=_principal("alice"),
+        db=db,
+    )
+
+    assert result[0].v == 21.5
+    plugin.query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_query_history_without_read_grant_returns_404_and_skips_plugin(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _seed_datapoint_scope(db, dp_id)
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    plugin = MagicMock()
+    plugin.query = AsyncMock()
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await history_api.query_history(
+            dp_id=dp_id,
+            from_ts=None,
+            to_ts=None,
+            limit=100,
+            request=_request(),
+            principal=_principal("alice"),
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 404
+    plugin.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_history_with_read_grant_reaches_plugin(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _seed_datapoint_scope(db, dp_id, grant_principal="alice")
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    plugin = MagicMock()
+    plugin.aggregate = AsyncMock(return_value=[{"bucket": datetime(2026, 6, 10, tzinfo=UTC), "v": 21.5, "n": 1}])
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+
+    result = await history_api.aggregate_history(
+        dp_id=dp_id,
+        fn="avg",
+        interval="1h",
+        from_ts="2026-06-10T00:00:00Z",
+        to_ts="2026-06-10T01:00:00Z",
+        request=_request(),
+        principal=_principal("alice"),
+        db=db,
+    )
+
+    assert result[0].bucket == "2026-06-10T00:00:00Z"
+    plugin.aggregate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_history_without_read_grant_returns_404_and_skips_plugin(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _seed_datapoint_scope(db, dp_id)
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    plugin = MagicMock()
+    plugin.aggregate = AsyncMock()
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await history_api.aggregate_history(
+            dp_id=dp_id,
+            fn="avg",
+            interval="1h",
+            from_ts=None,
+            to_ts=None,
+            request=_request(),
+            principal=_principal("alice"),
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 404
+    plugin.aggregate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_admin_query_history_remains_allowed_without_grants(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _seed_datapoint_scope(db, dp_id)
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    plugin = MagicMock()
+    plugin.query = AsyncMock(return_value=[])
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+
+    result = await history_api.query_history(
+        dp_id=dp_id,
+        from_ts=None,
+        to_ts=None,
+        limit=100,
+        request=_request(),
+        principal=_principal("admin", is_admin=True),
+        db=db,
+    )
+
+    assert result == []
+    plugin.query.assert_awaited_once()

--- a/tests/unit/test_history_authz.py
+++ b/tests/unit/test_history_authz.py
@@ -88,6 +88,39 @@ async def _insert_read_grant(db: Database, *, principal_id: str, node_id: str) -
     )
 
 
+async def _insert_public_visu_page(db: Database, page_id: str, dp_id: uuid.UUID) -> None:
+    page_config = f"""
+    {{
+      "grid_cols": 12,
+      "grid_row_height": 80,
+      "grid_cell_width": 120,
+      "background": null,
+      "widgets": [
+        {{
+          "id": "widget-1",
+          "name": "Chart",
+          "type": "chart",
+          "datapoint_id": "{dp_id}",
+          "status_datapoint_id": null,
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 3,
+          "config": {{}}
+        }}
+      ]
+    }}
+    """
+    await db.execute_and_commit(
+        """
+        INSERT INTO visu_nodes
+            (id, parent_id, name, type, node_order, icon, access, access_pin, page_config, created_at, updated_at)
+        VALUES (?, NULL, 'Page', 'PAGE', 0, NULL, 'public', NULL, ?, ?, ?)
+        """,
+        (page_id, page_config, NOW, NOW),
+    )
+
+
 async def _seed_datapoint_scope(
     db: Database,
     dp_id: uuid.UUID,
@@ -200,6 +233,35 @@ async def test_query_history_without_read_grant_returns_404_and_skips_plugin(mon
 
     assert exc_info.value.status_code == 404
     plugin.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_history_authenticated_public_page_context_remains_compatible_without_grant(monkeypatch, db: Database):
+    dp_id = uuid.uuid4()
+    await _seed_datapoint_scope(db, dp_id)
+    await _insert_public_visu_page(db, "page-public-history", dp_id)
+    monkeypatch.setattr(history_api, "get_registry", lambda: _RegistryStub(dp_id))
+
+    plugin = MagicMock()
+    plugin.query = AsyncMock(return_value=[])
+    monkeypatch.setattr(history_api, "get_history_plugin", lambda: plugin)
+    monkeypatch.setattr("obs.api.v1.visu._resolve_access_with_node", AsyncMock(return_value=("public", None)))
+
+    request = MagicMock()
+    request.headers.get = lambda key, default=None: {"X-Page-Id": "page-public-history"}.get(key, default)
+
+    result = await history_api.query_history(
+        dp_id=dp_id,
+        from_ts=None,
+        to_ts=None,
+        limit=100,
+        request=request,
+        principal=_principal("alice"),
+        db=db,
+    )
+
+    assert result == []
+    plugin.query.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_knxproj_devices_api.py
+++ b/tests/unit/test_knxproj_devices_api.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 import pytest
 from fastapi import HTTPException
 
+from obs.api.auth import Principal
 from obs.api.v1 import knxproj as knxproj_api
 from obs.db.database import Database
 
@@ -56,6 +58,112 @@ async def _prepare_db() -> Database:
     )
     await db.commit()
 
+    return db
+
+
+async def _insert_authz_tree(db: Database) -> None:
+    now = datetime.now(UTC).isoformat()
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_trees (id, name, description, created_at, updated_at)
+        VALUES ('tree', 'tree', '', ?, ?)
+        """,
+        (now, now),
+    )
+    await db.executemany(
+        """
+        INSERT INTO hierarchy_nodes
+            (id, tree_id, parent_id, name, description, node_order, icon, created_at, updated_at)
+        VALUES (?, 'tree', NULL, ?, '', 0, NULL, ?, ?)
+        """,
+        [
+            ("allowed-room", "allowed-room", now, now),
+            ("blocked-room", "blocked-room", now, now),
+        ],
+    )
+    await db.commit()
+
+
+async def _insert_knx_instance(db: Database, *, instance_id: str = "knx-main", enabled: bool = True) -> None:
+    now = datetime.now(UTC).isoformat()
+    await db.execute_and_commit(
+        """
+        INSERT INTO adapter_instances (id, adapter_type, name, config, enabled, created_at, updated_at)
+        VALUES (?, 'KNX', ?, '{}', ?, ?, ?)
+        """,
+        (instance_id, instance_id, int(enabled), now, now),
+    )
+
+
+async def _insert_scoped_datapoint(
+    db: Database,
+    *,
+    dp_id: str,
+    name: str,
+    node_id: str,
+    ga: str,
+    state_ga: str | None = None,
+    binding_enabled: bool = True,
+    adapter_instance_id: str = "knx-main",
+) -> None:
+    now = datetime.now(UTC).isoformat()
+    config = {"group_address": ga}
+    if state_ga:
+        config["state_group_address"] = state_ga
+    await db.execute_and_commit(
+        """
+        INSERT INTO datapoints
+            (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, persist_value, record_history, created_at, updated_at)
+        VALUES (?, ?, 'BOOLEAN', NULL, '[]', ?, NULL, 1, 1, ?, ?)
+        """,
+        (dp_id, name, f"dp/{dp_id}/value", now, now),
+    )
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_datapoint_links (id, node_id, datapoint_id, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (f"link-{dp_id}", node_id, dp_id, now),
+    )
+    await db.execute_and_commit(
+        """
+        INSERT INTO adapter_bindings
+            (id, datapoint_id, adapter_type, adapter_instance_id, direction, config, enabled, created_at, updated_at)
+        VALUES (?, ?, 'KNX', ?, 'SOURCE', ?, ?, ?, ?)
+        """,
+        (f"binding-{dp_id}", dp_id, adapter_instance_id, json.dumps(config), int(binding_enabled), now, now),
+    )
+
+
+async def _grant_room(db: Database, *, principal_id: str = "alice", node_id: str = "allowed-room") -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO authz_node_roles (principal_type, principal_id, node_type, node_id, role, effect)
+        VALUES ('user', ?, 'hierarchy', ?, 'guest', 'allow')
+        """,
+        (principal_id, node_id),
+    )
+
+
+async def _prepare_scoped_devices_db() -> Database:
+    db = await _prepare_db()
+    await _insert_authz_tree(db)
+    await _insert_knx_instance(db)
+    await _insert_scoped_datapoint(
+        db,
+        dp_id="00000000-0000-0000-0000-000000000101",
+        name="Allowed switch",
+        node_id="allowed-room",
+        ga="1/2/3",
+    )
+    await _insert_scoped_datapoint(
+        db,
+        dp_id="00000000-0000-0000-0000-000000000102",
+        name="Blocked status",
+        node_id="blocked-room",
+        ga="1/2/4",
+    )
+    await _grant_room(db)
     return db
 
 
@@ -238,5 +346,156 @@ async def test_list_knx_devices_order_number_filter():
         )
         assert result.total == 1
         assert result.items[0].order_number == "HS-10"
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_list_knx_devices_only_returns_devices_with_readable_group_address():
+    db = await _prepare_scoped_devices_db()
+    try:
+        result = await knxproj_api.list_knx_devices(
+            q="",
+            manufacturer="",
+            order_number="",
+            page=0,
+            size=50,
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+        assert result.total == 2
+        assert [item.pa for item in result.items] == ["1.1.1", "1.1.2"]
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_get_knx_device_hides_out_of_scope_comm_object_links():
+    db = await _prepare_scoped_devices_db()
+    try:
+        result = await knxproj_api.get_knx_device(
+            pa="1.1.1",
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+        assert result.pa == "1.1.1"
+        assert [co.id for co in result.comm_objects] == ["co-1"]
+        assert result.comm_objects[0].ga_addresses == ["1/2/3"]
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_get_knx_device_returns_404_when_device_has_no_readable_group_address():
+    db = await _prepare_scoped_devices_db()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await knxproj_api.get_knx_device(
+                pa="1.1.3",
+                _user=Principal(subject="alice", type="user", is_admin=False),
+                db=db,
+            )
+
+        assert exc_info.value.status_code == 404
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_group_address_device_lookup_requires_readable_group_address():
+    db = await _prepare_scoped_devices_db()
+    try:
+        allowed = await knxproj_api.list_knx_devices_for_group_address(
+            ga="1/2/3",
+            page=0,
+            size=50,
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+        blocked = await knxproj_api.list_knx_devices_for_group_address(
+            ga="1/2/4",
+            page=0,
+            size=50,
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+        assert [item.pa for item in allowed.items] == ["1.1.1", "1.1.2"]
+        assert allowed.total == 2
+        assert blocked.items == []
+        assert blocked.total == 0
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_scope_includes_state_group_address():
+    db = await _prepare_db()
+    try:
+        await _insert_authz_tree(db)
+        await _insert_knx_instance(db)
+        await _insert_scoped_datapoint(
+            db,
+            dp_id="00000000-0000-0000-0000-000000000201",
+            name="Allowed state",
+            node_id="allowed-room",
+            ga="9/9/9",
+            state_ga="1/2/4",
+        )
+        await _grant_room(db)
+
+        result = await knxproj_api.list_knx_devices_for_group_address(
+            ga="1/2/4",
+            page=0,
+            size=50,
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+        assert [item.pa for item in result.items] == ["1.1.1"]
+    finally:
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_scope_ignores_disabled_knx_bindings_and_instances():
+    db = await _prepare_db()
+    try:
+        await _insert_authz_tree(db)
+        await _insert_knx_instance(db, instance_id="knx-enabled", enabled=True)
+        await _insert_knx_instance(db, instance_id="knx-disabled", enabled=False)
+        await _insert_scoped_datapoint(
+            db,
+            dp_id="00000000-0000-0000-0000-000000000301",
+            name="Disabled binding",
+            node_id="allowed-room",
+            ga="1/2/3",
+            binding_enabled=False,
+            adapter_instance_id="knx-enabled",
+        )
+        await _insert_scoped_datapoint(
+            db,
+            dp_id="00000000-0000-0000-0000-000000000302",
+            name="Disabled instance",
+            node_id="allowed-room",
+            ga="1/2/4",
+            adapter_instance_id="knx-disabled",
+        )
+        await _grant_room(db)
+
+        result = await knxproj_api.list_knx_devices(
+            q="",
+            manufacturer="",
+            order_number="",
+            page=0,
+            size=50,
+            _user=Principal(subject="alice", type="user", is_admin=False),
+            db=db,
+        )
+
+        assert result.items == []
+        assert result.total == 0
     finally:
         await db.disconnect()

--- a/tests/unit/test_search_authz.py
+++ b/tests/unit/test_search_authz.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+import obs.api.v1.datapoints as datapoints_api
+import obs.api.v1.search as search_api
+from obs.api.auth import Principal
+from obs.db.database import Database
+from obs.models.datapoint import DataPoint
+
+
+NOW = "2026-06-10T00:00:00+00:00"
+
+
+class _RegistryStub:
+    def __init__(self, datapoints: list[DataPoint]) -> None:
+        self._datapoints = datapoints
+
+    def all(self) -> list[DataPoint]:
+        return list(self._datapoints)
+
+    def get_value(self, dp_id):
+        return None
+
+
+@pytest.fixture
+async def db() -> Database:
+    database = Database(":memory:")
+    await database.connect()
+    try:
+        yield database
+    finally:
+        await database.disconnect()
+
+
+async def _insert_tree(db: Database, tree_id: str = "building") -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_trees (id, name, description, created_at, updated_at)
+        VALUES (?, ?, '', ?, ?)
+        """,
+        (tree_id, tree_id, NOW, NOW),
+    )
+
+
+async def _insert_node(db: Database, node_id: str, *, tree_id: str = "building", parent_id: str | None = None) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_nodes
+            (id, tree_id, parent_id, name, description, node_order, icon, created_at, updated_at)
+        VALUES (?, ?, ?, ?, '', 0, NULL, ?, ?)
+        """,
+        (node_id, tree_id, parent_id, node_id, NOW, NOW),
+    )
+
+
+async def _insert_datapoint(db: Database, dp: DataPoint) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO datapoints
+            (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, persist_value, record_history, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(dp.id),
+            dp.name,
+            dp.data_type,
+            dp.unit,
+            "[]",
+            dp.mqtt_topic,
+            dp.mqtt_alias,
+            int(dp.persist_value),
+            int(dp.record_history),
+            dp.created_at.isoformat(),
+            dp.updated_at.isoformat(),
+        ),
+    )
+
+
+async def _link_datapoint(db: Database, dp: DataPoint, node_id: str, link_id: str) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO hierarchy_datapoint_links (id, node_id, datapoint_id, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (link_id, node_id, str(dp.id), NOW),
+    )
+
+
+async def _insert_grant(
+    db: Database,
+    *,
+    principal_id: str = "alice",
+    node_id: str,
+    role: str = "guest",
+    effect: str = "allow",
+) -> None:
+    await db.execute_and_commit(
+        """
+        INSERT INTO authz_node_roles (principal_type, principal_id, node_type, node_id, role, effect)
+        VALUES ('user', ?, 'hierarchy', ?, ?, ?)
+        """,
+        (principal_id, node_id, role, effect),
+    )
+
+
+async def _call_search(
+    db: Database,
+    principal: Principal,
+    *,
+    q: str = "",
+    node_id: str = "",
+    tree_id: str = "",
+):
+    return await search_api.search(
+        q=q,
+        tag="",
+        type="",
+        adapter="",
+        quality="",
+        node_id=node_id,
+        tree_id=tree_id,
+        sort="name",
+        order="asc",
+        page=0,
+        size=50,
+        _user=principal,
+        db=db,
+    )
+
+
+def _dp(name: str) -> DataPoint:
+    return DataPoint(name=name, data_type="FLOAT", unit="°C", created_at=datetime.now(UTC), updated_at=datetime.now(UTC))
+
+
+@pytest.mark.asyncio
+async def test_non_admin_search_returns_only_readable_datapoints(db: Database, monkeypatch):
+    await _insert_tree(db)
+    await _insert_node(db, "room-allowed")
+    await _insert_node(db, "room-denied")
+    allowed = _dp("AuthZ Search Allowed")
+    denied = _dp("AuthZ Search Denied")
+    await _insert_datapoint(db, allowed)
+    await _insert_datapoint(db, denied)
+    await _link_datapoint(db, allowed, "room-allowed", "link-allowed")
+    await _link_datapoint(db, denied, "room-denied", "link-denied")
+    await _insert_grant(db, node_id="room-allowed")
+    registry = _RegistryStub([allowed, denied])
+    monkeypatch.setattr(search_api, "get_registry", lambda: registry)
+    monkeypatch.setattr(datapoints_api, "get_registry", lambda: registry)
+
+    result = await _call_search(db, Principal(subject="alice", type="user", is_admin=False), q="AuthZ Search")
+
+    assert [item.id for item in result.items] == [allowed.id]
+    assert result.total == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_deny_removes_otherwise_matching_search_result(db: Database, monkeypatch):
+    await _insert_tree(db)
+    await _insert_node(db, "floor")
+    await _insert_node(db, "allowed-room", parent_id="floor")
+    await _insert_node(db, "denied-room", parent_id="floor")
+    allowed = _dp("AuthZ Search Allowed")
+    denied = _dp("AuthZ Search Explicit Deny")
+    await _insert_datapoint(db, allowed)
+    await _insert_datapoint(db, denied)
+    await _link_datapoint(db, allowed, "allowed-room", "link-allowed-room")
+    await _link_datapoint(db, denied, "denied-room", "link-denied-room")
+    await _insert_grant(db, node_id="floor")
+    await _insert_grant(db, node_id="denied-room", effect="deny")
+    registry = _RegistryStub([allowed, denied])
+    monkeypatch.setattr(search_api, "get_registry", lambda: registry)
+    monkeypatch.setattr(datapoints_api, "get_registry", lambda: registry)
+
+    result = await _call_search(db, Principal(subject="alice", type="user", is_admin=False), q="AuthZ Search")
+
+    assert [item.id for item in result.items] == [allowed.id]
+    assert result.total == 1
+
+
+@pytest.mark.asyncio
+async def test_node_and_tree_filters_compose_with_authz_filtering(db: Database, monkeypatch):
+    await _insert_tree(db, "allowed-tree")
+    await _insert_tree(db, "other-tree")
+    await _insert_node(db, "allowed-root", tree_id="allowed-tree")
+    await _insert_node(db, "allowed-room", tree_id="allowed-tree", parent_id="allowed-root")
+    await _insert_node(db, "unauthorized-room", tree_id="allowed-tree", parent_id="allowed-root")
+    await _insert_node(db, "other-room", tree_id="other-tree")
+    allowed = _dp("AuthZ Search Allowed")
+    unauthorized_same_tree = _dp("AuthZ Search Unauthorized Same Tree")
+    other_tree = _dp("AuthZ Search Other Tree")
+    await _insert_datapoint(db, allowed)
+    await _insert_datapoint(db, unauthorized_same_tree)
+    await _insert_datapoint(db, other_tree)
+    await _link_datapoint(db, allowed, "allowed-room", "link-allowed")
+    await _link_datapoint(db, unauthorized_same_tree, "unauthorized-room", "link-unauthorized")
+    await _link_datapoint(db, other_tree, "other-room", "link-other")
+    await _insert_grant(db, node_id="allowed-room")
+    registry = _RegistryStub([allowed, unauthorized_same_tree, other_tree])
+    monkeypatch.setattr(search_api, "get_registry", lambda: registry)
+    monkeypatch.setattr(datapoints_api, "get_registry", lambda: registry)
+    principal = Principal(subject="alice", type="user", is_admin=False)
+
+    node_result = await _call_search(db, principal, q="AuthZ Search", node_id="allowed-root")
+    tree_result = await _call_search(db, principal, q="AuthZ Search", tree_id="allowed-tree")
+
+    assert [item.id for item in node_result.items] == [allowed.id]
+    assert node_result.total == 1
+    assert [item.id for item in tree_result.items] == [allowed.id]
+    assert tree_result.total == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_search_still_returns_ungranted_datapoints(db: Database, monkeypatch):
+    admin_visible = _dp("AuthZ Search Admin Visible")
+    await _insert_datapoint(db, admin_visible)
+    registry = _RegistryStub([admin_visible])
+    monkeypatch.setattr(search_api, "get_registry", lambda: registry)
+    monkeypatch.setattr(datapoints_api, "get_registry", lambda: registry)
+
+    result = await _call_search(db, Principal(subject="admin", type="user", is_admin=True), q="AuthZ Search")
+
+    assert [item.id for item in result.items] == [admin_visible.id]
+    assert result.total == 1

--- a/tests/unit/test_search_authz.py
+++ b/tests/unit/test_search_authz.py
@@ -214,6 +214,30 @@ async def test_node_and_tree_filters_compose_with_authz_filtering(db: Database, 
 
 
 @pytest.mark.asyncio
+async def test_search_hierarchy_metadata_and_filters_hide_unauthorized_links(db: Database, monkeypatch):
+    await _insert_tree(db, "building")
+    await _insert_node(db, "allowed-room", tree_id="building")
+    await _insert_node(db, "secret-room", tree_id="building")
+    shared = _dp("AuthZ Search Shared")
+    await _insert_datapoint(db, shared)
+    await _link_datapoint(db, shared, "allowed-room", "link-shared-allowed")
+    await _link_datapoint(db, shared, "secret-room", "link-shared-secret")
+    await _insert_grant(db, node_id="allowed-room")
+    registry = _RegistryStub([shared])
+    monkeypatch.setattr(search_api, "get_registry", lambda: registry)
+    monkeypatch.setattr(datapoints_api, "get_registry", lambda: registry)
+    principal = Principal(subject="alice", type="user", is_admin=False)
+
+    default_result = await _call_search(db, principal, q="AuthZ Search Shared")
+    secret_node_result = await _call_search(db, principal, q="AuthZ Search Shared", node_id="secret-room")
+
+    assert [item.id for item in default_result.items] == [shared.id]
+    assert [node.node_id for node in default_result.items[0].hierarchy_nodes] == ["allowed-room"]
+    assert secret_node_result.items == []
+    assert secret_node_result.total == 0
+
+
+@pytest.mark.asyncio
 async def test_admin_search_still_returns_ungranted_datapoints(db: Database, monkeypatch):
     admin_visible = _dp("AuthZ Search Admin Visible")
     await _insert_datapoint(db, admin_visible)


### PR DESCRIPTION
## Summary

- apply Phase 2 READ scope to KNX project device list/detail endpoints
- resolve device visibility through KNX group address bindings to authorized datapoints
- hide out-of-scope communication object links from non-admin detail responses

## Linked Issues

Part of #583.
Builds on #792.

Closes #624.

## Validation

- TDD red before implementation: `tests/unit/test_knxproj_devices_api.py -q` failed on the four new authz cases
- Focused after implementation: `tests/unit/test_knxproj_devices_api.py -q`: `8 passed`
- AuthZ regression set: `tests/unit/test_knxproj_devices_api.py tests/unit/test_authz_runtime.py tests/unit/test_search_authz.py tests/unit/test_datapoints_authz.py -q`: `24 passed`
- `ruff check obs/api/v1/knxproj.py tests/unit/test_knxproj_devices_api.py`: passed
- `ruff format --check obs/api/v1/knxproj.py tests/unit/test_knxproj_devices_api.py`: passed
- Pre-push hook: full CI parity pytest: `4113 passed, 13 skipped`

## Stack Notes

This PR is intentionally stacked on draft PR #792. Until #792 merges, GitHub may show the Wave 1 commits in the comparison against `main`; after #792 lands, this PR should reduce to the single #624 commit.
