### PR TITLE
fix(security): require auth for weather fetch

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ## 2026.7.0
 ### Breaking changes 🚨
-* none
+* Security: `GET /api/v1/weather/fetch` now requires authenticated access and no longer accepts tokens in the URL query string. Weather widgets on PIN-protected Visu pages continue to work with their page-scoped session token, but unauthenticated public weather proxy calls are rejected; private/local weather endpoints still require an explicit URL Target Allowlist entry. https://github.com/abeggled/openbridgeserver/issues/791
 
 ### New features ✨
 * Backend: ETS hierarchy import logic is now available as a reusable backend service while keeping `POST /api/v1/hierarchy/import-from-ets` behavior unchanged. This prepares the KNX project import to create selected ETS hierarchies in the same import flow. https://github.com/abeggled/openbridgeserver/issues/727

--- a/frontend/src/widgets/Wetter/Widget.test.ts
+++ b/frontend/src/widgets/Wetter/Widget.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getJwt, getWriteContext } from '@/api/client'
+import WetterWidget from './Widget.vue'
+
+const apiState = vi.hoisted(() => ({
+  jwt: 'jwt-1',
+  context: {
+    pageId: 'page-1',
+    sessionToken: 'session-1',
+    definingId: 'def-1',
+  },
+}))
+
+vi.mock('@/api/client', () => ({
+  getJwt: vi.fn(() => apiState.jwt),
+  getWriteContext: vi.fn(() => apiState.context),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    locale: { value: 'de' },
+  }),
+}))
+
+const getJwtMock = vi.mocked(getJwt)
+const getWriteContextMock = vi.mocked(getWriteContext)
+
+let wrapper: VueWrapper | null = null
+
+function mountWidget() {
+  wrapper = mount(WetterWidget, {
+    props: {
+      config: {
+        url: 'http://example.com/weather',
+        refreshInterval: 600,
+      },
+      datapointId: null,
+      value: null,
+      statusValue: null,
+      editorMode: false,
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  })
+  return wrapper
+}
+
+beforeEach(() => {
+  apiState.jwt = 'jwt-1'
+  apiState.context = {
+    pageId: 'page-1',
+    sessionToken: 'session-1',
+    definingId: 'def-1',
+  }
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      timezone: 'Europe/Zurich',
+      current: {
+        dt: 1714000000,
+        sunrise: 1713930000,
+        sunset: 1713980000,
+        temp: 14.5,
+        feels_like: 12.3,
+        humidity: 68,
+        pressure: 1015,
+        uvi: 3.2,
+        visibility: 10000,
+        wind_speed: 3.1,
+        wind_deg: 200,
+        clouds: 40,
+        weather: [{ id: 802, main: 'Clouds', description: 'cloudy', icon: '03d' }],
+      },
+      daily: [],
+    }),
+  }))
+})
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('Wetter widget fetch auth', () => {
+  it('sends JWT and protected-page context headers to the weather proxy', async () => {
+    mountWidget()
+    await flushPromises()
+
+    const fetchMock = vi.mocked(fetch)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/weather/fetch?url=http%3A%2F%2Fexample.com%2Fweather')
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      headers: {
+        Authorization: 'Bearer jwt-1',
+        'X-Page-Id': 'page-1',
+        'X-Session-Token': 'session-1',
+      },
+    })
+    expect(getJwtMock).toHaveBeenCalledTimes(1)
+    expect(getWriteContextMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/widgets/Wetter/Widget.vue
+++ b/frontend/src/widgets/Wetter/Widget.vue
@@ -2,7 +2,7 @@
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { DataPointValue } from '@/types'
-import { getJwt } from '@/api/client'
+import { getJwt, getWriteContext } from '@/api/client'
 
 // ── OWM One Call API Typen ─────────────────────────────────────────────────────
 
@@ -167,9 +167,15 @@ async function fetchWeather(): Promise<void> {
 
   try {
     const jwt = getJwt() ?? ''
+    const writeContext = getWriteContext()
     const params = new URLSearchParams({ url: url.value })
+    const headers: Record<string, string> = {}
+    if (jwt) headers.Authorization = `Bearer ${jwt}`
+    if (writeContext.pageId) headers['X-Page-Id'] = writeContext.pageId
+    if (writeContext.sessionToken) headers['X-Session-Token'] = writeContext.sessionToken
+
     const resp = await fetch(`/api/v1/weather/fetch?${params.toString()}`, {
-      headers: jwt ? { Authorization: `Bearer ${jwt}` } : {},
+      headers,
     })
 
     if (!resp.ok) {

--- a/obs/api/v1/route_classification_registry.py
+++ b/obs/api/v1/route_classification_registry.py
@@ -22,7 +22,6 @@ RouteSignature: TypeAlias = tuple[str, str]
 PUBLIC_ROUTE_ALLOWLIST: Final[frozenset[RouteSignature]] = frozenset(
     {
         ("GET", "/api/v1/system/health"),
-        ("GET", "/api/v1/weather/fetch"),
     }
 )
 
@@ -128,7 +127,7 @@ ROUTE_CLASSIFICATIONS: Final[dict[RouteSignature, RouteCategory]] = {
     ("GET", "/api/v1/visu/pages/{node_id}"): "read_live",
     ("GET", "/api/v1/visu/tree"): "read_live",
     ("GET", "/api/v1/visu/widget-ref/{page_id}"): "read_live",
-    ("GET", "/api/v1/weather/fetch"): "public",
+    ("GET", "/api/v1/weather/fetch"): "read_live",
     ("PATCH", "/api/v1/adapters/instances/{instance_id}"): "config_mutation",
     ("PATCH", "/api/v1/adapters/{adapter_type}/config"): "config_mutation",
     ("PATCH", "/api/v1/auth/users/{username}"): "config_mutation",

--- a/obs/api/v1/weather.py
+++ b/obs/api/v1/weather.py
@@ -70,17 +70,119 @@ async def _check_ssrf(
 
 
 async def _page_has_weather_url(db: Database, page_id: str, url: str) -> bool:
+    return await _page_has_weather_url_for_session(db, page_id, url, session_token=None)
+
+
+async def _load_page_config(db: Database, page_id: str) -> PageConfig | None:
     row = await db.fetchone("SELECT page_config FROM visu_nodes WHERE id = ? AND type = 'PAGE'", (page_id,))
     if not row or not row["page_config"]:
-        return False
+        return None
 
     try:
-        page = PageConfig.model_validate_json(row["page_config"])
+        return PageConfig.model_validate_json(row["page_config"])
     except Exception:
+        return None
+
+
+def _widget_type_key(widget_type: object) -> str:
+    return str(widget_type or "").replace("_", "").casefold()
+
+
+async def _source_page_allows_session(db: Database, page_id: str, session_token: str | None) -> bool:
+    from obs.api.v1.visu import _resolve_access_with_node
+
+    access, defining_node_id = await _resolve_access_with_node(db, page_id)
+    if access in ("public", "readonly"):
+        return True
+    if access == "protected" and session_token:
+        return validate_session(session_token, defining_node_id or page_id)
+    return False
+
+
+async def _widget_has_weather_url(
+    db: Database,
+    *,
+    widget_type: object,
+    config: dict[str, object],
+    requested_url: str,
+    session_token: str | None,
+    visited_refs: set[tuple[str, str]],
+) -> bool:
+    widget_key = _widget_type_key(widget_type)
+    if widget_key == "wetter":
+        return str(config.get("url") or "").strip() == requested_url
+
+    if widget_key == "grundriss":
+        mini_widgets = config.get("miniWidgets")
+        if not isinstance(mini_widgets, list):
+            return False
+        for mini_widget in mini_widgets:
+            if not isinstance(mini_widget, dict):
+                continue
+            mini_config = mini_widget.get("config")
+            if not isinstance(mini_config, dict):
+                mini_config = {}
+            if await _widget_has_weather_url(
+                db,
+                widget_type=mini_widget.get("widgetType"),
+                config=mini_config,
+                requested_url=requested_url,
+                session_token=session_token,
+                visited_refs=visited_refs,
+            ):
+                return True
+        return False
+
+    if widget_key != "widgetref":
+        return False
+
+    source_page_id = str(config.get("source_page_id") or "").strip()
+    source_widget_name = str(config.get("source_widget_name") or "").strip()
+    if not source_page_id or not source_widget_name:
+        return False
+    ref_key = (source_page_id, source_widget_name)
+    if ref_key in visited_refs:
+        return False
+    visited_refs.add(ref_key)
+
+    if not await _source_page_allows_session(db, source_page_id, session_token):
+        return False
+
+    source_page = await _load_page_config(db, source_page_id)
+    if source_page is None:
+        return False
+
+    source_widget = next((candidate for candidate in source_page.widgets if candidate.name == source_widget_name), None)
+    if source_widget is None:
+        return False
+    return await _widget_has_weather_url(
+        db,
+        widget_type=source_widget.type,
+        config=source_widget.config,
+        requested_url=requested_url,
+        session_token=session_token,
+        visited_refs=visited_refs,
+    )
+
+
+async def _page_has_weather_url_for_session(db: Database, page_id: str, url: str, *, session_token: str | None) -> bool:
+    page = await _load_page_config(db, page_id)
+    if page is None:
         return False
 
     requested_url = url.strip()
-    return any(widget.type == "Wetter" and str(widget.config.get("url") or "").strip() == requested_url for widget in page.widgets)
+    visited_refs: set[tuple[str, str]] = set()
+    for widget in page.widgets:
+        if await _widget_has_weather_url(
+            db,
+            widget_type=widget.type,
+            config=widget.config,
+            requested_url=requested_url,
+            session_token=session_token,
+            visited_refs=visited_refs,
+        ):
+            return True
+    return False
 
 
 async def _require_weather_access(
@@ -103,7 +205,7 @@ async def _require_weather_access(
     validate_id = defining_node_id or page_id
     if access != "protected" or not validate_session(session_token, validate_id):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Valid session token required")
-    if not await _page_has_weather_url(db, page_id, url):
+    if not await _page_has_weather_url_for_session(db, page_id, url, session_token=session_token):
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Weather URL is not configured on the page")
 
 

--- a/obs/api/v1/weather.py
+++ b/obs/api/v1/weather.py
@@ -1,6 +1,6 @@
 """Wetter-Proxy — holt Wetterdaten von einer konfigurierten API-URL.
 
-GET /api/v1/weather/fetch?url=…
+GET /api/v1/weather/fetch?url=…  (authenticated)
 
 Unterstützt OpenWeatherMap One Call API 3.0 (und kompatible Dienste).
 
@@ -19,7 +19,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 
-from obs.api.auth import optional_current_user
+from obs.api.auth import get_current_user
 from obs.security.url_targets import UrlTargetBlockedError, build_pinned_url_targets
 
 router = APIRouter(tags=["weather"])
@@ -27,16 +27,9 @@ router = APIRouter(tags=["weather"])
 
 async def _build_fetch_targets(
     url: str,
-    *,
-    allow_private_networks: bool = False,
 ) -> tuple[list[str], dict[str, str], dict[str, str]]:
     try:
-        try:
-            return await asyncio.to_thread(build_pinned_url_targets, url, allow_private_networks=allow_private_networks)
-        except TypeError as exc:
-            if "allow_private_networks" not in str(exc):
-                raise
-            return await asyncio.to_thread(build_pinned_url_targets, url)
+        return await asyncio.to_thread(build_pinned_url_targets, url)
     except UrlTargetBlockedError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=exc.decision.api_detail()) from exc
     except ValueError as exc:
@@ -46,11 +39,10 @@ async def _build_fetch_targets(
 async def _check_ssrf(
     url: str,
     *,
-    allow_private_networks: bool,
     legacy_detail: bool = True,
 ) -> tuple[list[str], dict[str, str], dict[str, str]]:
     try:
-        return await _build_fetch_targets(url, allow_private_networks=allow_private_networks)
+        return await _build_fetch_targets(url)
     except HTTPException as exc:
         detail = exc.detail
         if isinstance(detail, dict):
@@ -80,7 +72,7 @@ async def _check_ssrf(
 @router.get("/fetch")
 async def fetch_weather(
     url: str = Query(..., description="Vollständige Wetter-API-URL (inkl. API-Key)"),
-    current_user: str | None = Depends(optional_current_user),
+    _user: str = Depends(get_current_user),
 ) -> JSONResponse:
     """Holt Wetterdaten von der konfigurierten API-URL und gibt sie als JSON zurück.
     Der API-Key wird als Teil der URL übergeben (z.B. OpenWeatherMap appid=…).
@@ -95,20 +87,7 @@ async def fetch_weather(
             detail="Nur HTTP/HTTPS-URLs erlaubt",
         )
 
-    try:
-        fetch_targets = await _check_ssrf(
-            url,
-            allow_private_networks=current_user is not None,
-            legacy_detail=False,
-        )
-    except TypeError as exc:
-        if "legacy_detail" not in str(exc):
-            raise
-        fetch_targets = await _check_ssrf(
-            url,
-            allow_private_networks=current_user is not None,
-        )
-    request_urls, pinned_headers, request_extensions = fetch_targets or ([url], {}, {})
+    request_urls, pinned_headers, request_extensions = await _check_ssrf(url, legacy_detail=False)
 
     try:
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as hc:

--- a/obs/api/v1/weather.py
+++ b/obs/api/v1/weather.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 import asyncio
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 
-from obs.api.auth import get_current_user
+from obs.api.auth import optional_current_user
+from obs.api.v1.sessions import validate_session
+from obs.db.database import Database, get_db
+from obs.models.visu import PageConfig
 from obs.security.url_targets import UrlTargetBlockedError, build_pinned_url_targets
 
 router = APIRouter(tags=["weather"])
@@ -66,13 +69,51 @@ async def _check_ssrf(
         raise
 
 
+async def _page_has_weather_url(db: Database, page_id: str, url: str) -> bool:
+    row = await db.fetchone("SELECT page_config FROM visu_nodes WHERE id = ? AND type = 'PAGE'", (page_id,))
+    if not row or not row["page_config"]:
+        return False
+
+    try:
+        page = PageConfig.model_validate_json(row["page_config"])
+    except Exception:
+        return False
+
+    requested_url = url.strip()
+    return any(widget.type == "Wetter" and str(widget.config.get("url") or "").strip() == requested_url for widget in page.widgets)
+
+
+async def _require_weather_access(
+    request: Request,
+    url: str,
+    user: str | None = Depends(optional_current_user),
+    db: Database = Depends(get_db),
+) -> None:
+    if user is not None:
+        return
+
+    page_id = request.headers.get("X-Page-Id")
+    session_token = request.headers.get("X-Session-Token")
+    if not page_id or not session_token:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+
+    from obs.api.v1.visu import _resolve_access_with_node
+
+    access, defining_node_id = await _resolve_access_with_node(db, page_id)
+    validate_id = defining_node_id or page_id
+    if access != "protected" or not validate_session(session_token, validate_id):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Valid session token required")
+    if not await _page_has_weather_url(db, page_id, url):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Weather URL is not configured on the page")
+
+
 # ── Fetch-Endpunkt ─────────────────────────────────────────────────────────────
 
 
 @router.get("/fetch")
 async def fetch_weather(
     url: str = Query(..., description="Vollständige Wetter-API-URL (inkl. API-Key)"),
-    _user: str = Depends(get_current_user),
+    _user: object = Depends(_require_weather_access),
 ) -> JSONResponse:
     """Holt Wetterdaten von der konfigurierten API-URL und gibt sie als JSON zurück.
     Der API-Key wird als Teil der URL übergeben (z.B. OpenWeatherMap appid=…).

--- a/tests/integration/test_weather.py
+++ b/tests/integration/test_weather.py
@@ -170,6 +170,57 @@ async def _create_weather_page(
     return page_id
 
 
+async def _create_page_with_widgets(
+    client,
+    auth_headers: dict[str, str],
+    *,
+    access: str,
+    widgets: list[dict[str, object]],
+    access_pin: str | None = None,
+) -> str:
+    payload: dict[str, object] = {
+        "name": f"weather-page-{uuid.uuid4().hex[:8]}",
+        "type": "PAGE",
+        "order": 999,
+        "access": access,
+    }
+    if access_pin is not None:
+        payload["access_pin"] = access_pin
+
+    create_resp = await client.post("/api/v1/visu/nodes", json=payload, headers=auth_headers)
+    assert create_resp.status_code == 201, create_resp.text
+    page_id = create_resp.json()["id"]
+
+    save_resp = await client.put(
+        f"/api/v1/visu/pages/{page_id}",
+        json={
+            "grid_cols": 12,
+            "grid_row_height": 80,
+            "grid_cell_width": 80,
+            "background": None,
+            "widgets": widgets,
+        },
+        headers=auth_headers,
+    )
+    assert save_resp.status_code in (200, 204), save_resp.text
+    return page_id
+
+
+def _weather_widget(weather_url: str, *, name: str = "Weather") -> dict[str, object]:
+    return {
+        "id": str(uuid.uuid4()),
+        "name": name,
+        "type": "Wetter",
+        "datapoint_id": None,
+        "status_datapoint_id": None,
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 5,
+        "config": {"url": weather_url},
+    }
+
+
 # ── Tests ──────────────────────────────────────────────────────────────────────
 
 
@@ -251,6 +302,108 @@ async def test_fetch_rejects_public_visu_page_without_login(client, auth_headers
         )
         assert resp.status_code == 401
     finally:
+        await client.delete(f"/api/v1/visu/nodes/{page_id}", headers=auth_headers)
+
+
+async def test_fetch_allows_protected_visu_session_for_widget_ref_weather_url(client, auth_headers, bypass_ssrf):
+    pin = "1234"
+    srv = _MockWeatherServer()
+    source_page_id = await _create_page_with_widgets(
+        client,
+        auth_headers,
+        access="public",
+        widgets=[_weather_widget(f"{srv.base_url}/weather", name="Outdoor weather")],
+    )
+    page_id = await _create_page_with_widgets(
+        client,
+        auth_headers,
+        access="protected",
+        access_pin=pin,
+        widgets=[
+            {
+                "id": str(uuid.uuid4()),
+                "name": "Weather reference",
+                "type": "WidgetRef",
+                "datapoint_id": None,
+                "status_datapoint_id": None,
+                "x": 0,
+                "y": 0,
+                "w": 6,
+                "h": 5,
+                "config": {"source_page_id": source_page_id, "source_widget_name": "Outdoor weather"},
+            }
+        ],
+    )
+    try:
+        auth_resp = await client.post(f"/api/v1/visu/nodes/{page_id}/auth", json={"pin": pin})
+        assert auth_resp.status_code == 200, auth_resp.text
+        session_token = auth_resp.json()["session_token"]
+
+        resp = await client.get(
+            f"/api/v1/weather/fetch?url={srv.base_url}/weather",
+            headers={"X-Page-Id": page_id, "X-Session-Token": session_token},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["timezone"] == "Europe/Zurich"
+    finally:
+        srv.shutdown()
+        await client.delete(f"/api/v1/visu/nodes/{page_id}", headers=auth_headers)
+        await client.delete(f"/api/v1/visu/nodes/{source_page_id}", headers=auth_headers)
+
+
+async def test_fetch_allows_protected_visu_session_for_grundriss_weather_url(client, auth_headers, bypass_ssrf):
+    pin = "1234"
+    srv = _MockWeatherServer()
+    page_id = await _create_page_with_widgets(
+        client,
+        auth_headers,
+        access="protected",
+        access_pin=pin,
+        widgets=[
+            {
+                "id": str(uuid.uuid4()),
+                "name": "Floor plan",
+                "type": "Grundriss",
+                "datapoint_id": None,
+                "status_datapoint_id": None,
+                "x": 0,
+                "y": 0,
+                "w": 6,
+                "h": 5,
+                "config": {
+                    "image": "data:image/png;base64,",
+                    "miniWidgets": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "label": "Weather",
+                            "widgetType": "Wetter",
+                            "config": {"url": f"{srv.base_url}/weather"},
+                            "datapointId": None,
+                            "statusDatapointId": None,
+                            "x": 100,
+                            "y": 100,
+                            "wPx": 240,
+                            "hPx": 160,
+                            "visible": True,
+                        }
+                    ],
+                },
+            }
+        ],
+    )
+    try:
+        auth_resp = await client.post(f"/api/v1/visu/nodes/{page_id}/auth", json={"pin": pin})
+        assert auth_resp.status_code == 200, auth_resp.text
+        session_token = auth_resp.json()["session_token"]
+
+        resp = await client.get(
+            f"/api/v1/weather/fetch?url={srv.base_url}/weather",
+            headers={"X-Page-Id": page_id, "X-Session-Token": session_token},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["timezone"] == "Europe/Zurich"
+    finally:
+        srv.shutdown()
         await client.delete(f"/api/v1/visu/nodes/{page_id}", headers=auth_headers)
 
 

--- a/tests/integration/test_weather.py
+++ b/tests/integration/test_weather.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import threading
 import unittest.mock
+import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
@@ -120,6 +121,55 @@ class _MockWeatherServer:
         self._server.shutdown()
 
 
+async def _create_weather_page(
+    client,
+    auth_headers: dict[str, str],
+    *,
+    access: str,
+    weather_url: str,
+    access_pin: str | None = None,
+) -> str:
+    payload: dict[str, object] = {
+        "name": f"weather-page-{uuid.uuid4().hex[:8]}",
+        "type": "PAGE",
+        "order": 999,
+        "access": access,
+    }
+    if access_pin is not None:
+        payload["access_pin"] = access_pin
+
+    create_resp = await client.post("/api/v1/visu/nodes", json=payload, headers=auth_headers)
+    assert create_resp.status_code == 201, create_resp.text
+    page_id = create_resp.json()["id"]
+
+    save_resp = await client.put(
+        f"/api/v1/visu/pages/{page_id}",
+        json={
+            "grid_cols": 12,
+            "grid_row_height": 80,
+            "grid_cell_width": 80,
+            "background": None,
+            "widgets": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "Weather",
+                    "type": "Wetter",
+                    "datapoint_id": None,
+                    "status_datapoint_id": None,
+                    "x": 0,
+                    "y": 0,
+                    "w": 6,
+                    "h": 5,
+                    "config": {"url": weather_url},
+                },
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert save_resp.status_code in (200, 204), save_resp.text
+    return page_id
+
+
 # ── Tests ──────────────────────────────────────────────────────────────────────
 
 
@@ -136,6 +186,72 @@ async def test_fetch_invalid_token_returns_401(client, bypass_ssrf):
         headers={"Authorization": "Bearer not.valid.jwt"},
     )
     assert resp.status_code == 401
+
+
+async def test_fetch_allows_protected_visu_session_for_configured_weather_url(client, auth_headers, bypass_ssrf):
+    pin = "1234"
+    srv = _MockWeatherServer()
+    page_id = await _create_weather_page(
+        client,
+        auth_headers,
+        access="protected",
+        access_pin=pin,
+        weather_url=f"{srv.base_url}/weather",
+    )
+    try:
+        auth_resp = await client.post(f"/api/v1/visu/nodes/{page_id}/auth", json={"pin": pin})
+        assert auth_resp.status_code == 200, auth_resp.text
+        session_token = auth_resp.json()["session_token"]
+
+        resp = await client.get(
+            f"/api/v1/weather/fetch?url={srv.base_url}/weather",
+            headers={"X-Page-Id": page_id, "X-Session-Token": session_token},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["timezone"] == "Europe/Zurich"
+    finally:
+        srv.shutdown()
+        await client.delete(f"/api/v1/visu/nodes/{page_id}", headers=auth_headers)
+
+
+async def test_fetch_rejects_protected_visu_session_for_unconfigured_weather_url(client, auth_headers, bypass_ssrf):
+    pin = "1234"
+    page_id = await _create_weather_page(
+        client,
+        auth_headers,
+        access="protected",
+        access_pin=pin,
+        weather_url="http://example.com/configured-weather",
+    )
+    try:
+        auth_resp = await client.post(f"/api/v1/visu/nodes/{page_id}/auth", json={"pin": pin})
+        assert auth_resp.status_code == 200, auth_resp.text
+        session_token = auth_resp.json()["session_token"]
+
+        resp = await client.get(
+            "/api/v1/weather/fetch?url=http://example.com/other-weather",
+            headers={"X-Page-Id": page_id, "X-Session-Token": session_token},
+        )
+        assert resp.status_code == 403
+    finally:
+        await client.delete(f"/api/v1/visu/nodes/{page_id}", headers=auth_headers)
+
+
+async def test_fetch_rejects_public_visu_page_without_login(client, auth_headers, bypass_ssrf):
+    page_id = await _create_weather_page(
+        client,
+        auth_headers,
+        access="public",
+        weather_url="http://example.com/weather",
+    )
+    try:
+        resp = await client.get(
+            "/api/v1/weather/fetch?url=http://example.com/weather",
+            headers={"X-Page-Id": page_id},
+        )
+        assert resp.status_code == 401
+    finally:
+        await client.delete(f"/api/v1/visu/nodes/{page_id}", headers=auth_headers)
 
 
 async def test_fetch_uses_private_network_blocking_mode(client, auth_headers, monkeypatch):

--- a/tests/integration/test_weather.py
+++ b/tests/integration/test_weather.py
@@ -3,8 +3,8 @@
 GET /api/v1/weather/fetch
 
 Abgedeckt:
-  1.  Public: Kein Token nötig
-  2.  Public: Ungültiger _token wird ignoriert
+  1.  Kein Token → 401
+  2.  Ungültiger Token → 401
   3.  Ungültiges URL-Schema (ftp://) → 400
   4.  Wetter-API erreichbar → 200, JSON-Daten weitergeleitet
   5.  Wetter-API nicht erreichbar → 502
@@ -12,7 +12,7 @@ Abgedeckt:
   7.  Wetter-API antwortet 404 → 502
   8.  Wetter-API antwortet mit Redirect → 400
   9.  Wetter-API liefert kein JSON (HTML) → 502
-  10. Auth via ?_token= Query-Param (statt Authorization-Header)
+  10. Query-Token wird nicht als Auth akzeptiert
   11. Content-Type application/json;charset=utf-8 wird akzeptiert
 
 SSRF-Schutz:
@@ -123,51 +123,26 @@ class _MockWeatherServer:
 # ── Tests ──────────────────────────────────────────────────────────────────────
 
 
-# 1. Public: Kein Token nötig
-async def test_fetch_no_auth_required(client, bypass_ssrf):
-    srv = _MockWeatherServer()
-    try:
-        resp = await client.get(f"/api/v1/weather/fetch?url={srv.base_url}/weather")
-        assert resp.status_code == 200
-    finally:
-        srv.shutdown()
+# 1. Kein Token
+async def test_fetch_no_auth_returns_401(client, bypass_ssrf):
+    resp = await client.get("/api/v1/weather/fetch?url=http://example.com/weather")
+    assert resp.status_code == 401
 
 
-# 2. Public: Ungültiger _token wird ignoriert
-async def test_fetch_invalid_token_is_ignored_for_public_route(client, bypass_ssrf):
-    srv = _MockWeatherServer()
-    try:
-        resp = await client.get(
-            f"/api/v1/weather/fetch?url={srv.base_url}/weather&_token=not.valid.jwt",
-        )
-        assert resp.status_code == 200
-    finally:
-        srv.shutdown()
+# 2. Ungültiger Token
+async def test_fetch_invalid_token_returns_401(client, bypass_ssrf):
+    resp = await client.get(
+        "/api/v1/weather/fetch?url=http://example.com/weather",
+        headers={"Authorization": "Bearer not.valid.jwt"},
+    )
+    assert resp.status_code == 401
 
 
-async def test_fetch_public_request_uses_private_network_blocking_mode(client, monkeypatch):
+async def test_fetch_uses_private_network_blocking_mode(client, auth_headers, monkeypatch):
     observed: dict[str, bool] = {}
 
-    def _wrapped_build_targets(url: str, *, allow_private_networks: bool, **_kwargs):
-        observed["allow_private_networks"] = allow_private_networks
-        return [url], {}, {}
-
-    monkeypatch.setattr(_weather_module, "build_pinned_url_targets", _wrapped_build_targets)
-
-    srv = _MockWeatherServer()
-    try:
-        resp = await client.get(f"/api/v1/weather/fetch?url={srv.base_url}/weather")
-        assert resp.status_code == 200
-        assert observed["allow_private_networks"] is False
-    finally:
-        srv.shutdown()
-
-
-async def test_fetch_authenticated_request_allows_private_network_mode(client, auth_headers, monkeypatch):
-    observed: dict[str, bool] = {}
-
-    def _wrapped_build_targets(url: str, *, allow_private_networks: bool, **_kwargs):
-        observed["allow_private_networks"] = allow_private_networks
+    def _wrapped_build_targets(url: str, **kwargs):
+        observed["allow_private_networks"] = bool(kwargs.get("allow_private_networks"))
         return [url], {}, {}
 
     monkeypatch.setattr(_weather_module, "build_pinned_url_targets", _wrapped_build_targets)
@@ -179,7 +154,7 @@ async def test_fetch_authenticated_request_allows_private_network_mode(client, a
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        assert observed["allow_private_networks"] is True
+        assert observed["allow_private_networks"] is False
     finally:
         srv.shutdown()
 
@@ -281,18 +256,14 @@ async def test_fetch_non_json_response_returns_502(client, auth_headers, bypass_
         srv.shutdown()
 
 
-# 10. Auth via ?_token= Query-Param
-async def test_fetch_auth_via_query_token(client, auth_headers, bypass_ssrf):
+# 10. Query-Token wird nicht als Auth akzeptiert
+async def test_fetch_query_token_returns_401(client, auth_headers, bypass_ssrf):
     token = auth_headers["Authorization"].removeprefix("Bearer ")
-    srv = _MockWeatherServer()
-    try:
-        resp = await client.get(
-            f"/api/v1/weather/fetch?url={srv.base_url}/weather&_token={token}",
-            # Bewusst kein Authorization-Header
-        )
-        assert resp.status_code == 200
-    finally:
-        srv.shutdown()
+    resp = await client.get(
+        f"/api/v1/weather/fetch?url=http://example.com/weather&_token={token}",
+        # Bewusst kein Authorization-Header: Weather akzeptiert keine Tokens in URLs.
+    )
+    assert resp.status_code == 401
 
 
 # 11. Content-Type application/json;charset=utf-8 wird akzeptiert
@@ -351,13 +322,15 @@ async def test_fetch_ssrf_loopback_ipv6_blocked(client, auth_headers):
     assert resp.json()["detail"]["code"] == "url_target_blocked"
 
 
-async def test_fetch_ssrf_private_network_without_auth_blocked(client):
+async def test_fetch_ssrf_private_network_blocked_for_authenticated_user(client, auth_headers):
+    resp = await client.get(
+        "/api/v1/weather/fetch?url=http://192.168.1.10/weather",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "url_target_blocked"
+
+
+async def test_fetch_ssrf_private_network_without_auth_is_rejected_before_fetch(client):
     resp = await client.get("/api/v1/weather/fetch?url=http://192.168.1.10/weather")
-    assert resp.status_code == 400
-    assert resp.json()["detail"]["code"] == "url_target_blocked"
-
-
-async def test_fetch_ssrf_user_query_param_does_not_enable_private_networks(client):
-    resp = await client.get("/api/v1/weather/fetch?url=http://192.168.1.10/weather&_user=admin")
-    assert resp.status_code == 400
-    assert resp.json()["detail"]["code"] == "url_target_blocked"
+    assert resp.status_code == 401

--- a/tests/unit/test_api_v1_route_classification_registry.py
+++ b/tests/unit/test_api_v1_route_classification_registry.py
@@ -31,10 +31,11 @@ def test_all_v1_routes_are_classified_and_registry_has_no_stale_entries() -> Non
     assert discovered == classified
 
 
-def test_public_allowlist_is_explicit_and_covers_weather() -> None:
-    weather_route = ("GET", "/api/v1/weather/fetch")
-    assert weather_route in PUBLIC_ROUTE_ALLOWLIST
-    assert ROUTE_CLASSIFICATIONS[weather_route] == "public"
-
+def test_public_allowlist_is_explicit() -> None:
     public_classified = {route for route, category in ROUTE_CLASSIFICATIONS.items() if category == "public"}
     assert public_classified == set(PUBLIC_ROUTE_ALLOWLIST)
+
+
+def test_weather_fetch_requires_authenticated_read_classification() -> None:
+    assert ROUTE_CLASSIFICATIONS[("GET", "/api/v1/weather/fetch")] == "read_live"
+    assert ("GET", "/api/v1/weather/fetch") not in PUBLIC_ROUTE_ALLOWLIST

--- a/tests/unit/test_coverage_system_core.py
+++ b/tests/unit/test_coverage_system_core.py
@@ -2061,7 +2061,7 @@ class TestFetchWeather:
         from obs.api.v1.weather import fetch_weather
 
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_weather(url="ftp://example.com/file", current_user="admin")
+            await fetch_weather(url="ftp://example.com/file", _user="admin")
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
@@ -2093,7 +2093,7 @@ class TestFetchWeather:
 
         monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _FakeHttpxClient())
 
-        result = await fetch_weather(url="http://example.com/weather", current_user="admin")
+        result = await fetch_weather(url="http://example.com/weather", _user="admin")
         assert result.status_code == 200
 
     @pytest.mark.asyncio
@@ -2125,7 +2125,7 @@ class TestFetchWeather:
         monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _FakeHttpxClient())
 
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_weather(url="http://example.com/weather", current_user="admin")
+            await fetch_weather(url="http://example.com/weather", _user="admin")
         assert exc_info.value.status_code == 502
 
     @pytest.mark.asyncio
@@ -2156,7 +2156,7 @@ class TestFetchWeather:
         monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _FakeHttpxClient())
 
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_weather(url="http://example.com/weather", current_user="admin")
+            await fetch_weather(url="http://example.com/weather", _user="admin")
         assert exc_info.value.status_code == 502
 
     @pytest.mark.asyncio
@@ -2187,7 +2187,7 @@ class TestFetchWeather:
         monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _FakeHttpxClient())
 
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_weather(url="http://example.com/weather", current_user="admin")
+            await fetch_weather(url="http://example.com/weather", _user="admin")
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
@@ -2215,7 +2215,7 @@ class TestFetchWeather:
         monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _FakeHttpxClient())
 
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_weather(url="http://example.com/weather", current_user="admin")
+            await fetch_weather(url="http://example.com/weather", _user="admin")
         assert exc_info.value.status_code == 502
 
     @pytest.mark.asyncio
@@ -2246,5 +2246,5 @@ class TestFetchWeather:
         monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _FakeHttpxClient())
 
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_weather(url="http://example.com/weather", current_user="admin")
+            await fetch_weather(url="http://example.com/weather", _user="admin")
         assert exc_info.value.status_code == 502

--- a/tests/unit/test_weather_unit.py
+++ b/tests/unit/test_weather_unit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import socket
 from typing import Any
 
@@ -36,6 +37,43 @@ class _ClientStub:
 
     async def get(self, _url: str, **_kwargs):
         return self._response
+
+
+class _PageDbStub:
+    def __init__(self, pages: dict[str, dict[str, object]]):
+        self._pages = pages
+
+    async def fetchone(self, _query: str, params: tuple[str, ...]):
+        page_id = params[0]
+        page = self._pages.get(page_id)
+        if page is None:
+            return None
+        return {"page_config": json.dumps(page)}
+
+
+def _page_config_with_widgets(widgets: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "grid_cols": 12,
+        "grid_row_height": 80,
+        "grid_cell_width": 80,
+        "background": None,
+        "widgets": widgets,
+    }
+
+
+def _weather_widget(url: str, *, name: str = "Weather") -> dict[str, object]:
+    return {
+        "id": name,
+        "name": name,
+        "type": "Wetter",
+        "datapoint_id": None,
+        "status_datapoint_id": None,
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 5,
+        "config": {"url": url},
+    }
 
 
 @pytest.mark.asyncio
@@ -185,3 +223,81 @@ async def test_fetch_weather_httpx_request_error_returns_502(monkeypatch):
 
     assert exc.value.status_code == 502
     assert "nicht erreichbar" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_page_has_weather_url_finds_widget_ref_target(monkeypatch):
+    db = _PageDbStub(
+        {
+            "current": _page_config_with_widgets(
+                [
+                    {
+                        "id": "ref",
+                        "name": "Reference",
+                        "type": "WidgetRef",
+                        "datapoint_id": None,
+                        "status_datapoint_id": None,
+                        "x": 0,
+                        "y": 0,
+                        "w": 6,
+                        "h": 5,
+                        "config": {"source_page_id": "source", "source_widget_name": "Outdoor weather"},
+                    }
+                ]
+            ),
+            "source": _page_config_with_widgets([_weather_widget("http://example.com/weather", name="Outdoor weather")]),
+        }
+    )
+
+    async def _allow(_db, _page_id, _session_token):
+        return True
+
+    monkeypatch.setattr(weather, "_source_page_allows_session", _allow)
+
+    assert await weather._page_has_weather_url_for_session(
+        db,
+        "current",
+        "http://example.com/weather",
+        session_token="session-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_page_has_weather_url_finds_grundriss_mini_widget():
+    db = _PageDbStub(
+        {
+            "current": _page_config_with_widgets(
+                [
+                    {
+                        "id": "grundriss",
+                        "name": "Floor plan",
+                        "type": "Grundriss",
+                        "datapoint_id": None,
+                        "status_datapoint_id": None,
+                        "x": 0,
+                        "y": 0,
+                        "w": 6,
+                        "h": 5,
+                        "config": {
+                            "miniWidgets": [
+                                {
+                                    "id": "mini-weather",
+                                    "widgetType": "Wetter",
+                                    "config": {"url": "http://example.com/weather"},
+                                    "datapointId": None,
+                                    "statusDatapointId": None,
+                                }
+                            ]
+                        },
+                    }
+                ]
+            )
+        }
+    )
+
+    assert await weather._page_has_weather_url_for_session(
+        db,
+        "current",
+        "http://example.com/weather",
+        session_token="session-1",
+    )

--- a/tests/unit/test_weather_unit.py
+++ b/tests/unit/test_weather_unit.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 import obs.api.v1.weather as weather
+from obs.config import SecuritySettings, Settings, override_settings
 
 
 class _Resp:
@@ -33,7 +34,7 @@ class _ClientStub:
     async def __aexit__(self, *_args):
         return False
 
-    async def get(self, _url: str):
+    async def get(self, _url: str, **_kwargs):
         return self._response
 
 
@@ -42,27 +43,33 @@ async def test_check_ssrf_blocks_loopback_ip(monkeypatch):
     monkeypatch.setattr(socket, "getaddrinfo", lambda *_args, **_kwargs: [(None, None, None, None, ("127.0.0.1", 0))])
 
     with pytest.raises(HTTPException) as exc:
-        await weather._check_ssrf("http://example.test", allow_private_networks=True)
+        await weather._check_ssrf("http://example.test")
 
     assert exc.value.status_code == 400
     assert "nicht erlaubt" in exc.value.detail
 
 
 @pytest.mark.asyncio
-async def test_check_ssrf_blocks_private_network_for_public_requests(monkeypatch):
+async def test_check_ssrf_blocks_private_network(monkeypatch):
     monkeypatch.setattr(socket, "getaddrinfo", lambda *_args, **_kwargs: [(None, None, None, None, ("192.168.1.10", 0))])
 
     with pytest.raises(HTTPException) as exc:
-        await weather._check_ssrf("http://example.test", allow_private_networks=False)
+        await weather._check_ssrf("http://example.test")
 
     assert exc.value.status_code == 400
 
 
 @pytest.mark.asyncio
-async def test_check_ssrf_allows_private_network_for_authenticated_requests(monkeypatch):
+async def test_check_ssrf_allows_allowlisted_private_network(monkeypatch, tmp_path):
+    allowlist_path = tmp_path / "url_targets.yaml"
+    override_settings(Settings(security=SecuritySettings(jwt_secret="unit-test-secret-32-chars-xxx", url_target_allowlist_path=str(allowlist_path))))
+    allowlist_path.write_text(
+        "version: 1\nallowed_targets:\n  - target: 192.168.1.10/32\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(socket, "getaddrinfo", lambda *_args, **_kwargs: [(None, None, None, None, ("192.168.1.10", 0))])
 
-    await weather._check_ssrf("http://example.test", allow_private_networks=True)
+    await weather._check_ssrf("http://example.test")
 
 
 @pytest.mark.asyncio
@@ -73,7 +80,7 @@ async def test_check_ssrf_unresolvable_host_returns_502(monkeypatch):
     monkeypatch.setattr(socket, "getaddrinfo", _raise)
 
     with pytest.raises(HTTPException) as exc:
-        await weather._check_ssrf("http://missing.example", allow_private_networks=True)
+        await weather._check_ssrf("http://missing.example")
 
     assert exc.value.status_code == 502
     assert "nicht auflösbar" in exc.value.detail
@@ -82,21 +89,21 @@ async def test_check_ssrf_unresolvable_host_returns_502(monkeypatch):
 @pytest.mark.asyncio
 async def test_fetch_weather_rejects_non_http_scheme():
     with pytest.raises(HTTPException) as exc:
-        await weather.fetch_weather(url="ftp://example.com/weather", current_user="alice")
+        await weather.fetch_weather(url="ftp://example.com/weather", _user="alice")
 
     assert exc.value.status_code == 400
 
 
 @pytest.mark.asyncio
 async def test_fetch_weather_rejects_redirect(monkeypatch):
-    async def _ok(_url: str, *, allow_private_networks: bool):
-        return None
+    async def _ok(_url: str, **_kwargs):
+        return [_url], {}, {}
 
     monkeypatch.setattr(weather, "_check_ssrf", _ok)
     monkeypatch.setattr(weather.httpx, "AsyncClient", lambda **_kwargs: _ClientStub(_Resp(status_code=302)))
 
     with pytest.raises(HTTPException) as exc:
-        await weather.fetch_weather(url="http://example.com/weather", current_user="alice")
+        await weather.fetch_weather(url="http://example.com/weather", _user="alice")
 
     assert exc.value.status_code == 400
     assert "Redirects" in exc.value.detail
@@ -104,8 +111,8 @@ async def test_fetch_weather_rejects_redirect(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_weather_rejects_non_json_content_type(monkeypatch):
-    async def _ok(_url: str, *, allow_private_networks: bool):
-        return None
+    async def _ok(_url: str, **_kwargs):
+        return [_url], {}, {}
 
     monkeypatch.setattr(weather, "_check_ssrf", _ok)
     monkeypatch.setattr(
@@ -115,7 +122,7 @@ async def test_fetch_weather_rejects_non_json_content_type(monkeypatch):
     )
 
     with pytest.raises(HTTPException) as exc:
-        await weather.fetch_weather(url="http://example.com/weather", current_user="alice")
+        await weather.fetch_weather(url="http://example.com/weather", _user="alice")
 
     assert exc.value.status_code == 502
     assert "kein JSON" in exc.value.detail
@@ -123,8 +130,8 @@ async def test_fetch_weather_rejects_non_json_content_type(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_weather_rejects_invalid_json(monkeypatch):
-    async def _ok(_url: str, *, allow_private_networks: bool):
-        return None
+    async def _ok(_url: str, **_kwargs):
+        return [_url], {}, {}
 
     monkeypatch.setattr(weather, "_check_ssrf", _ok)
     monkeypatch.setattr(
@@ -134,7 +141,7 @@ async def test_fetch_weather_rejects_invalid_json(monkeypatch):
     )
 
     with pytest.raises(HTTPException) as exc:
-        await weather.fetch_weather(url="http://example.com/weather", current_user="alice")
+        await weather.fetch_weather(url="http://example.com/weather", _user="alice")
 
     assert exc.value.status_code == 502
     assert "gültiges JSON" in exc.value.detail
@@ -142,14 +149,14 @@ async def test_fetch_weather_rejects_invalid_json(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_weather_success_returns_payload(monkeypatch):
-    async def _ok(_url: str, *, allow_private_networks: bool):
-        return None
+    async def _ok(_url: str, **_kwargs):
+        return [_url], {}, {}
 
     payload = {"ok": True, "temp": 21.0}
     monkeypatch.setattr(weather, "_check_ssrf", _ok)
     monkeypatch.setattr(weather.httpx, "AsyncClient", lambda **_kwargs: _ClientStub(_Resp(status_code=200, json_data=payload)))
 
-    response = await weather.fetch_weather(url="http://example.com/weather", current_user=None)
+    response = await weather.fetch_weather(url="http://example.com/weather", _user="alice")
 
     assert response.status_code == 200
     assert response.body.decode("utf-8") == '{"ok":true,"temp":21.0}'
@@ -157,8 +164,8 @@ async def test_fetch_weather_success_returns_payload(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_weather_httpx_request_error_returns_502(monkeypatch):
-    async def _ok(_url: str, *, allow_private_networks: bool):
-        return None
+    async def _ok(_url: str, **_kwargs):
+        return [_url], {}, {}
 
     class _FailingClient:
         async def __aenter__(self):
@@ -174,7 +181,7 @@ async def test_fetch_weather_httpx_request_error_returns_502(monkeypatch):
     monkeypatch.setattr(weather.httpx, "AsyncClient", lambda **_kwargs: _FailingClient())
 
     with pytest.raises(HTTPException) as exc:
-        await weather.fetch_weather(url="http://example.com/weather", current_user="alice")
+        await weather.fetch_weather(url="http://example.com/weather", _user="alice")
 
     assert exc.value.status_code == 502
     assert "nicht erreichbar" in exc.value.detail


### PR DESCRIPTION
## Summary
- require authentication for `GET /api/v1/weather/fetch`
- remove Weather-specific private-network mode so internal targets still require the URL target allowlist
- update route classification and Weather tests to assert the endpoint is no longer public

Closes #791

## Validation
- `tools/with-venv ./tools/lint.sh --check`
- `tools/with-venv pytest tests/integration/test_weather.py tests/unit/test_weather_unit.py tests/unit/test_api_v1_route_classification_registry.py tests/unit/test_url_target_policy.py`
- `tools/with-venv pytest tests/unit tests/adapters tests/contracts`
- `tools/with-venv pytest tests/integration`
- `tools/with-venv pytest tests/unit tests/adapters tests/contracts --cov=obs --cov-report=term-missing` (total 81%)
- pre-push hook: i18n gate, ruff, full pytest/coverage (`4110 passed`, total 88%)