### PR TITLE
fix(logic): surface node execution errors instead of silently discarding them

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -15,6 +15,7 @@
 * Backend: High-volume third-party DEBUG loggers (e.g. `aiosqlite`, which logs two lines per SQL operation) are now floored at INFO, so enabling DEBUG globally no longer floods the logs and saturates a CPU core. https://github.com/abeggled/openbridgeserver/issues/798
 * Visu: German string literals in backend adapter code reached the GUI untranslated, bypassing the i18n/Weblate pipeline. https://github.com/abeggled/openbridgeserver/issues/779
 * Visu: Zeitschaltuhr widgets now only show and manage Schaltpunkte for the configured scheduler instance, preventing unrelated KNX or other adapter bindings on the same object from being listed or deleted. https://github.com/abeggled/openbridgeserver/issues/782
+* Backend: Logic-Executor verschluckt Node-Fehler still (result = {}) — kein sichtbares Feedback. https://github.com/abeggled/openbridgeserver/issues/788
 
 ### Known Issues 🔔
 * none

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -170,6 +170,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -181,6 +182,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -191,6 +193,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -369,6 +372,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -418,6 +422,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,6 +439,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -450,6 +456,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -466,6 +473,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -482,6 +490,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,6 +507,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,6 +524,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -530,6 +541,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -546,6 +558,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -562,6 +575,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,6 +592,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,6 +609,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -610,6 +626,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -628,6 +645,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -644,6 +662,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +819,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +836,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -840,9 +853,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -860,9 +870,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,6 +1027,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1061,7 +1069,7 @@
       "version": "25.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2288,6 +2296,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2574,7 +2583,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -2677,6 +2686,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2697,6 +2707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2717,6 +2728,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2737,6 +2749,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2757,6 +2770,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2777,6 +2791,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2797,6 +2812,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2817,6 +2833,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2837,6 +2854,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2857,6 +2875,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2877,6 +2896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3614,6 +3634,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -3627,7 +3648,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -1305,6 +1305,7 @@
     "saved": "Graph gespeichert",
     "errorSave": "Fehler beim Speichern",
     "runResult": "Graph ausgeführt — {count} Nodes evaluiert",
+    "nodeError": "⚠ Fehler",
     "duplicated": "Graph dupliziert als „{name}“",
     "errorDuplicate": "Fehler beim Duplizieren",
     "errorExport": "Fehler beim Exportieren",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -1305,6 +1305,7 @@
     "saved": "Graph saved",
     "errorSave": "Error saving graph",
     "runResult": "Graph executed — {count} nodes evaluated",
+    "nodeError": "⚠ Error",
     "duplicated": "Graph duplicated as “{name}”",
     "errorDuplicate": "Error duplicating graph",
     "errorExport": "Error exporting graph",

--- a/gui/src/views/LogicView.vue
+++ b/gui/src/views/LogicView.vue
@@ -324,6 +324,11 @@ function fmtDebugVal(nodeOut) {
     return String(v).slice(0, 18)
   }
 
+  // node execution error — show prominently before any other key handling
+  if ('__error__' in nodeOut) {
+    return `${t('logic.nodeError')}: ${String(nodeOut.__error__).slice(0, 50)}`
+  }
+
   // notify nodes — show message content + sent status (before generic key loop)
   if ('_message' in nodeOut) {
     const msg  = nodeOut._message !== null && nodeOut._message !== undefined

--- a/gui/tests/views/LogicView.auth.spec.js
+++ b/gui/tests/views/LogicView.auth.spec.js
@@ -268,3 +268,340 @@ describe('LogicView auth gates', () => {
     revokeObjectURL.mockRestore()
   })
 })
+
+describe('LogicView fmtDebugVal branches', () => {
+  async function mountWithActiveGraph() {
+    const graph = makeGraph('graph-1')
+    return mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+  }
+
+  it('formats __error__ output prominently before other key handling', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+    wrapper.vm.applyDebugValues({ n1: { __error__: 'Division by zero' } })
+    expect(wrapper.vm.nodes[0].data._dbg).toMatch(/Division by zero/)
+  })
+
+  it('formats _message output for notify nodes', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+
+    wrapper.vm.applyDebugValues({ n1: { _message: 'Alert!', sent: true } })
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('"Alert!"')
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('sent=✓')
+
+    wrapper.vm.applyDebugValues({ n1: { _message: null } })
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('—')
+
+    wrapper.vm.applyDebugValues({ n1: { _message: 'hi' } })
+    expect(wrapper.vm.nodes[0].data._dbg).toBe('"hi"')
+  })
+
+  it('formats _write_value output for datapoint_write nodes', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+    wrapper.vm.applyDebugValues({ n1: { _write_value: 99 } })
+    expect(wrapper.vm.nodes[0].data._dbg).toBe('→ 99')
+  })
+
+  it('formats generic public-key pairs as fallback', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+
+    wrapper.vm.applyDebugValues({ n1: { active: true } })
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('active=✓')
+
+    wrapper.vm.applyDebugValues({ n1: { active: false } })
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('active=✗')
+
+    wrapper.vm.applyDebugValues({ n1: { state: null } })
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('state=—')
+
+    wrapper.vm.applyDebugValues({ n1: { label: 'hello' } })
+    expect(wrapper.vm.nodes[0].data._dbg).toContain('label=hello')
+  })
+
+  it('returns undefined _dbg when output is null or non-object', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+
+    wrapper.vm.applyDebugValues({ n1: null })
+    expect(wrapper.vm.nodes[0].data._dbg).toBeUndefined()
+
+    wrapper.vm.applyDebugValues({ n1: 'string' })
+    expect(wrapper.vm.nodes[0].data._dbg).toBeUndefined()
+  })
+
+  it('returns undefined _dbg when all keys are private', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+    wrapper.vm.applyDebugValues({ n1: { _internal: 42 } })
+    expect(wrapper.vm.nodes[0].data._dbg).toBeUndefined()
+  })
+
+  it('clears _dbg from all nodes when debug mode is toggled off', async () => {
+    const { wrapper } = await mountWithActiveGraph()
+
+    wrapper.vm.toggleDebug() // false → true
+    wrapper.vm.applyDebugValues({ n1: { value: 1, changed: false } })
+    expect(wrapper.vm.nodes[0].data._dbg).toBeDefined()
+
+    wrapper.vm.toggleDebug() // true → false, triggers clearDebugValues
+    expect(wrapper.vm.debugMode).toBe(false)
+    expect(wrapper.vm.nodes[0].data).not.toHaveProperty('_dbg')
+  })
+})
+
+describe('LogicView WebSocket', () => {
+  let savedWebSocket
+  beforeEach(() => { savedWebSocket = global.WebSocket })
+  afterEach(() => { global.WebSocket = savedWebSocket })
+
+  function overrideStorage(overrides = {}) {
+    const storage = {
+      getItem: vi.fn().mockImplementation(k => overrides[k] ?? null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    }
+    Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+    Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+  }
+
+  it('skips WebSocket when no access_token in storage', async () => {
+    let wsCreated = false
+    global.WebSocket = class { constructor() { wsCreated = true } }
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+    expect(wsCreated).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('connects WebSocket on mount and closes it on unmount', async () => {
+    let wsInstance = null
+    global.WebSocket = class { constructor() { wsInstance = this; this.close = vi.fn() } }
+    overrideStorage({ access_token: 'tok' })
+
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+    expect(wsInstance).toBeTruthy()
+
+    wrapper.unmount()
+    expect(wsInstance.close).toHaveBeenCalled()
+  })
+
+  it('applies debug values from a logic_run WebSocket message when debug mode is on', async () => {
+    let wsInstance = null
+    global.WebSocket = class { constructor() { wsInstance = this; this.close = vi.fn() } }
+    overrideStorage({ access_token: 'tok', logic_debug_mode: '1' })
+
+    const graph = makeGraph('graph-1')
+    const { wrapper } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+
+    wsInstance.onmessage({ data: JSON.stringify({ action: 'logic_run', graph_id: 'graph-1', outputs: { n1: { value: 77, changed: true } } }) })
+    expect(wrapper.vm.nodes[0].data._dbg).toBe('= 77')
+  })
+
+  it('ignores logic_run message for a different graph_id', async () => {
+    let wsInstance = null
+    global.WebSocket = class { constructor() { wsInstance = this; this.close = vi.fn() } }
+    overrideStorage({ access_token: 'tok', logic_debug_mode: '1' })
+
+    const graph = makeGraph('graph-1')
+    const { wrapper } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+
+    wsInstance.onmessage({ data: JSON.stringify({ action: 'logic_run', graph_id: 'OTHER', outputs: { n1: { value: 99, changed: true } } }) })
+    expect(wrapper.vm.nodes[0].data._dbg).toBeUndefined()
+  })
+
+  it('ignores logic_run message when debug mode is off', async () => {
+    let wsInstance = null
+    global.WebSocket = class { constructor() { wsInstance = this; this.close = vi.fn() } }
+    overrideStorage({ access_token: 'tok' })
+
+    const graph = makeGraph('graph-1')
+    const { wrapper } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+
+    wsInstance.onmessage({ data: JSON.stringify({ action: 'logic_run', graph_id: 'graph-1', outputs: { n1: { value: 99, changed: true } } }) })
+    expect(wrapper.vm.nodes[0].data._dbg).toBeUndefined()
+  })
+
+  it('does not reconnect after close code 4001', async () => {
+    let wsInstance = null
+    let wsCreatedCount = 0
+    global.WebSocket = class { constructor() { wsInstance = this; this.close = vi.fn(); wsCreatedCount++ } }
+    overrideStorage({ access_token: 'tok' })
+
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+    expect(wsCreatedCount).toBe(1)
+
+    wsInstance.onclose({ code: 4001 })
+    vi.advanceTimersByTime(4100)
+    expect(wsCreatedCount).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('reconnects automatically after an abnormal close', async () => {
+    let wsInstance = null
+    let wsCreatedCount = 0
+    global.WebSocket = class { constructor() { wsInstance = this; this.close = vi.fn(); wsCreatedCount++ } }
+    overrideStorage({ access_token: 'tok' })
+
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+    expect(wsCreatedCount).toBe(1)
+
+    wsInstance.onclose({ code: 1006 })
+    vi.advanceTimersByTime(4100)
+    expect(wsCreatedCount).toBe(2)
+
+    wrapper.unmount()
+  })
+
+  it('handles WebSocket constructor error gracefully', async () => {
+    global.WebSocket = class { constructor() { throw new Error('blocked by browser') } }
+    overrideStorage({ access_token: 'tok' })
+
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+    expect(wrapper.vm).toBeTruthy()
+    wrapper.unmount()
+  })
+})
+
+describe('LogicView operation error handling', () => {
+  it('shows error status when doDuplicateGraph fails', async () => {
+    const graph = makeGraph('graph-1')
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+    logicApi.duplicateGraph.mockRejectedValue({ response: { data: { detail: 'Duplicate failed' } } })
+
+    await wrapper.vm.doDuplicateGraph()
+
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+
+  it('shows error status when doExportGraph fails', async () => {
+    const graph = makeGraph('graph-1')
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+    logicApi.exportGraph.mockRejectedValue({ response: { data: { detail: 'Export failed' } } })
+
+    await wrapper.vm.doExportGraph()
+
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+
+  it('shows error status when doRenameGraph fails', async () => {
+    const graph = makeGraph('graph-1')
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+    logicApi.patchGraph.mockRejectedValue({ response: { data: { detail: 'Rename failed' } } })
+
+    wrapper.vm.openRenameGraph()
+    wrapper.vm.renameGraphName = 'Updated Name'
+    await wrapper.vm.doRenameGraph()
+
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+
+  it('shows error status when saveGraph fails', async () => {
+    const graph = makeGraph('graph-1')
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+    logicApi.saveGraph.mockRejectedValue({ response: { data: { detail: 'Save failed' } } })
+
+    await wrapper.vm.saveGraph()
+
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+
+  it('shows error status when runGraph fails', async () => {
+    const graph = makeGraph('graph-1')
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+    logicApi.runGraph.mockRejectedValue({ response: { data: { detail: 'Run failed' } } })
+
+    await wrapper.vm.runGraph()
+
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+
+  it('shows error status when doToggleEnabled fails', async () => {
+    const graph = makeGraph('graph-1')
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      routeQuery: { graph: 'graph-1' },
+      graphDetails: { 'graph-1': graph },
+    })
+    logicApi.patchGraph.mockRejectedValue({ response: { data: { detail: 'Toggle failed' } } })
+
+    await wrapper.vm.doToggleEnabled()
+
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+})
+
+describe('LogicView import edge cases', () => {
+  it('opens rename dialog when imported graph name already exists', async () => {
+    const graph = makeGraph('graph-1')
+    const dup = makeGraph('graph-dup', { name: 'Main Graph' })
+    const { wrapper, logicApi } = await mountLogicView({
+      isAdmin: true,
+      graphs: [graph],
+      graphDetails: { 'graph-1': graph, 'graph-dup': dup },
+    })
+
+    logicApi.importGraph.mockResolvedValue({ data: dup })
+
+    const file = new File([JSON.stringify({})], 'logic.json', { type: 'application/json' })
+    await wrapper.vm.onImportFile({ target: { files: [file], value: 'logic.json' } })
+    await flushPromises()
+
+    expect(wrapper.vm.showRenameGraph).toBe(true)
+    expect(wrapper.vm.renameGraphName).toBe('Main Graph')
+  })
+
+  it('shows error status when the import file contains invalid JSON', async () => {
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+
+    const badFile = new File(['not valid json {{'], 'logic.json', { type: 'application/json' })
+    await wrapper.vm.onImportFile({ target: { files: [badFile], value: 'logic.json' } })
+    await flushPromises()
+
+    expect(wrapper.vm.statusMsg).toBeTruthy()
+    expect(wrapper.vm.statusMsg.ok).toBe(false)
+  })
+})

--- a/obs/logic/executor.py
+++ b/obs/logic/executor.py
@@ -93,7 +93,7 @@ class GraphExecutor:
                 result = self._eval_node(node, inputs)
             except Exception as exc:
                 logger.warning("Node %s (%s) error: %s", node.id, node.type, exc)
-                result = {}
+                result = {"__error__": str(exc)}
 
             outputs[node.id] = result
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -773,29 +773,58 @@ class TestPythonScriptNode:
         out = run_single("python_script", {"script": "result = math.sqrt(inputs['a'])"}, {"a": 9})
         assert out["result"] == pytest.approx(3.0)
 
-    def test_script_error_returns_empty_output(self):
-        # execute() catches all errors internally and logs them — never raises to caller
+    def test_script_error_sets_error_key(self):
+        # execute() catches all errors internally and logs them — never raises to caller;
+        # the failing node gets {"__error__": "<msg>"} so callers can surface the failure.
         n1 = node("p", "python_script", {"script": "result = 1 / 0"})
         exc = make_executor([n1])
         out = exc.execute({"p": {}})
-        assert out.get("p") == {}  # node output is empty on error
+        assert "__error__" in out.get("p", {})
+        assert isinstance(out["p"]["__error__"], str)
+        assert out["p"]["__error__"]  # non-empty message
 
-    def test_os_import_blocked_returns_empty_output(self):
-        # __import__ is not in builtins → ExecutionError caught internally → empty output
+    def test_os_import_blocked_sets_error_key(self):
+        # __import__ is not in builtins → ExecutionError caught internally → __error__ set
         n1 = node("p", "python_script", {"script": "import os; result = os.getcwd()"})
         exc = make_executor([n1])
         out = exc.execute({"p": {}})
-        assert out.get("p") == {}
+        assert "__error__" in out.get("p", {})
 
     def test_round_uses_mathematical_rounding(self):
         out = run_single("python_script", {"script": "result = round(inputs['a'], 1)"}, {"a": 21.15})
         assert out["result"] == pytest.approx(21.2)
 
-    def test_math_dunder_attribute_blocked_returns_empty_output(self):
+    def test_math_dunder_attribute_blocked_sets_error_key(self):
         n1 = node("p", "python_script", {"script": "result = math.__dict__"})
         exc = make_executor([n1])
         out = exc.execute({"p": {}})
-        assert out.get("p") == {}
+        assert "__error__" in out.get("p", {})
+
+    def test_error_node_downstream_receives_none(self):
+        # A node downstream of a failing node gets None as input (not the error dict).
+        nodes = [
+            node("bad", "python_script", {"script": "result = 1 / 0"}),
+            node("good", "math_formula", {"formula": "a + 1"}),
+        ]
+        edges = [edge("bad", "good", source_handle="result", target_handle="in1")]
+        exc = make_executor(nodes, edges)
+        out = exc.execute()
+        assert "__error__" in out["bad"]
+        # in1 resolves to None (handle "result" absent from error dict) → 0.0 + 1 = 1.0
+        assert out["good"]["result"] == pytest.approx(1.0)
+
+    def test_graph_continues_after_node_error(self):
+        # When one node fails, the rest of the graph still executes.
+        nodes = [
+            node("ok", "const_value", {"value": "5", "data_type": "number"}),
+            node("bad", "python_script", {"script": "result = 1 / 0"}),
+            node("out", "math_formula", {"formula": "a"}),
+        ]
+        edges = [edge("ok", "out", source_handle="value", target_handle="in1")]
+        exc = make_executor(nodes, edges)
+        out = exc.execute()
+        assert "__error__" in out["bad"]
+        assert out["out"]["result"] == pytest.approx(5.0)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

When a node in a Logic Graph threw an exception at runtime, the executor
silently caught it, logged a single `WARNING` line, and returned an empty
dict (`result = {}`). Downstream nodes then received `None` as input and
continued computing — producing wrong results without any indication that
something had gone wrong. The only trace of the failure was a log line
that was easy to miss, especially in graphs with many nodes.

Concretely: a `math_formula` node with a division-by-zero, a
`python_script` node with a typo, or any node whose config is incomplete
would silently output nothing, while every downstream node would
"successfully" produce incorrect values.

## What changed

### Backend — `obs/logic/executor.py`

A failing node now returns `{"__error__": "<exception message>"}` instead
of `{}`. This means:
- The error is visible in the response of `POST /api/v1/logic/graphs/{id}/run`
  under `outputs.<node_id>.__error__`
- Downstream nodes still receive `None` for any handle that would have
  come from the failed node (unchanged behaviour — `_get_output_value`
  returns `None` for missing handles, and `__error__` is not a valid
  handle name)
- Graph execution continues after a node error (no abort), consistent
  with the existing behaviour for home-automation use cases where a
  partial result is still preferable to a complete stop

### Admin GUI — `gui/src/views/LogicView.vue`

`fmtDebugVal` (the function that formats the debug-band text shown below
each node after a Run or live trigger) now handles `__error__` before the
generic `_`-key filter. A failing node shows:

```
⚠ Fehler: Script error: division by zero
```

in its debug band, making the error immediately visible in the Logic
Editor without having to tail logs.

### i18n — `de.json` / `en.json`

New key `logic.nodeError` (`"⚠ Fehler"` / `"⚠ Error"`) so the error
label in the debug band is translatable via the normal vue-i18n pipeline.

### Tests — `tests/unit/test_executor.py`

- Three existing tests that asserted `out == {}` on node error are
  updated to assert `"__error__" in out` with a non-empty string value.
- Two new tests added:
  - `test_error_node_downstream_receives_none`: verifies that a node
    downstream of a failed node gets `None` as input (not the error
    dict), and computes correctly from that `None`.
  - `test_graph_continues_after_node_error`: verifies that an unrelated
    branch of the graph still produces correct output when one node fails.

## Test plan

- [ ] Run `tools/with-venv pytest tests/unit/test_executor.py` — all 240 tests pass
- [ ] Run `cd gui && npm run build` — clean build, no missing i18n keys
- [ ] Manually: create a Logic Graph with a `python_script` node containing
  `result = 1 / 0`, connect a downstream node, hit **▶ Ausführen** with
  Debug mode on — the failing node shows `⚠ Fehler: Script error: …` in
  its debug band; the downstream node shows its (None-based) result
- [ ] Confirm server log still contains the `WARNING` line for traceability

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)