### PR TITLE
[codex] Fix datapoint unit clearing

### DIFF
--- a/gui/tests/components/datapoints/DataPointForm.spec.js
+++ b/gui/tests/components/datapoints/DataPointForm.spec.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+import DataPointForm from '@/components/datapoints/DataPointForm.vue'
+
+function mountForm(initial, saveHandler = vi.fn().mockResolvedValue()) {
+  return mount(DataPointForm, {
+    props: {
+      initial,
+      datatypes: [{ name: 'FLOAT' }, { name: 'BOOLEAN' }],
+      saveHandler,
+    },
+    global: {
+      stubs: {
+        Spinner: { template: '<span />' },
+      },
+    },
+  })
+}
+
+describe('DataPointForm', () => {
+  it('submits unit null when an existing unit is reset to none', async () => {
+    const saveHandler = vi.fn().mockResolvedValue()
+    const wrapper = mountForm(
+      {
+        id: 'dp-unit-reset',
+        name: 'Unit Reset',
+        data_type: 'FLOAT',
+        unit: '°C',
+        tags: [],
+        mqtt_alias: null,
+        persist_value: true,
+        record_history: true,
+      },
+      saveHandler
+    )
+
+    await wrapper.find('[data-testid="select-unit"]').setValue('')
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(saveHandler).toHaveBeenCalledWith(expect.objectContaining({ unit: null }))
+  })
+})

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -285,7 +285,7 @@ async def update_datapoint(
             quality = "uncertain"
 
     # --- Mutation phase (all validation passed) ---
-    # value=None in model_copy ensures exclude_none=True in reg.update() drops it —
+    # value=None in model_copy keeps value updates out of DataPoint metadata;
     # DataPoint has no value field.
     dp = await reg.update(dp_id, body.model_copy(update={"value": None}))
 

--- a/obs/core/registry.py
+++ b/obs/core/registry.py
@@ -206,7 +206,10 @@ class DataPointRegistry:
 
     async def update(self, dp_id: uuid.UUID, payload: DataPointUpdate) -> DataPoint:
         dp = self.get_or_raise(dp_id)
-        updates = payload.model_dump(exclude_none=True)
+        updates = payload.model_dump(exclude_none=True, exclude={"value"})
+        for clearable_field in ("unit", "mqtt_alias"):
+            if clearable_field in payload.model_fields_set:
+                updates[clearable_field] = getattr(payload, clearable_field)
         now = datetime.now(UTC)
 
         old_name = dp.name

--- a/tests/gui/admin/datapoints.spec.ts
+++ b/tests/gui/admin/datapoints.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { apiPost, apiDelete } from '../helpers'
+import { apiGet, apiPost, apiDelete } from '../helpers'
 
 // ---------------------------------------------------------------------------
 // Test 1: DataPoint anlegen via GUI-Flow und in der Liste sehen
@@ -339,5 +339,40 @@ test('DataPoint mit Einheit ° anlegen', async ({ page }) => {
       await apiDelete(`/api/v1/datapoints/${id}`)
       break
     }
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Test 10: Einheit im Bearbeiten-Dialog auf "keine" zurücksetzen
+// ---------------------------------------------------------------------------
+
+test('DataPoint-Einheit kann über den Bearbeiten-Dialog geleert werden', async ({ page }) => {
+  const name = `E2E-UnitReset-${Date.now()}`
+  const created = await apiPost('/api/v1/datapoints', {
+    name,
+    data_type: 'FLOAT',
+    unit: '°C',
+    tags: [],
+  }) as { id: string }
+  const dpId = created.id
+
+  try {
+    await page.goto('/datapoints')
+    await page.waitForSelector('[data-testid="input-search"]', { timeout: 10_000 })
+    await page.fill('[data-testid="input-search"]', name)
+    await page.waitForTimeout(500)
+    await expect(page.locator(`[data-testid="dp-row-${dpId}"]`)).toBeVisible({ timeout: 5_000 })
+
+    const row = page.locator(`[data-testid="dp-row-${dpId}"]`)
+    await row.locator('[title="Bearbeiten"]').click()
+    await expect(page.locator('[data-testid="select-unit"]')).toHaveValue('°C', { timeout: 5_000 })
+    await page.selectOption('[data-testid="select-unit"]', '')
+    await page.click('[data-testid="btn-save"]')
+    await expect(page.locator('[data-testid="btn-save"]')).not.toBeVisible({ timeout: 5_000 })
+
+    const updated = await apiGet(`/api/v1/datapoints/${dpId}`) as { unit: string | null }
+    expect(updated.unit).toBeNull()
+  } finally {
+    await apiDelete(`/api/v1/datapoints/${dpId}`)
   }
 })

--- a/tests/integration/test_datapoints_extra.py
+++ b/tests/integration/test_datapoints_extra.py
@@ -196,6 +196,28 @@ async def test_patch_metadata_only_does_not_overwrite_value(client, auth_headers
     assert val_resp.json()["value"] == pytest.approx(99.0)
 
 
+async def test_patch_unit_null_clears_existing_unit(client, auth_headers):
+    resp = await client.post(
+        "/api/v1/datapoints/",
+        json={"name": f"ClearUnit-{uuid.uuid4().hex[:8]}", "data_type": "FLOAT", "unit": "km"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    dp_id = resp.json()["id"]
+
+    patch_resp = await client.patch(
+        f"/api/v1/datapoints/{dp_id}",
+        json={"unit": None},
+        headers=auth_headers,
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    assert patch_resp.json()["unit"] is None
+
+    get_resp = await client.get(f"/api/v1/datapoints/{dp_id}", headers=auth_headers)
+    assert get_resp.status_code == 200
+    assert get_resp.json()["unit"] is None
+
+
 async def test_patch_value_type_mismatch_returns_422(client, auth_headers):
     dp = await _make_dp(client, auth_headers, data_type="INTEGER")
     resp = await client.patch(


### PR DESCRIPTION
## Summary

Fixes #814.

- Treat an explicit `unit: null` PATCH as a real datapoint metadata update instead of dropping it with omitted fields.
- Keep value writes out of datapoint metadata updates explicitly.
- Add regressions for clearing a datapoint unit from `km`/`°C` back to `null`, including backend, form-level, and admin E2E coverage.

## Validation

- `.venv/bin/pytest tests/integration/test_datapoints.py tests/integration/test_datapoints_extra.py -q`
- `.venv/bin/pytest tests/unit/test_coverage_system_core.py tests/unit/test_models.py -q`
- `npm run test -- tests/components/datapoints/DataPointForm.spec.js`
- `./scripts/check-i18n-hardcoded-strings.sh`
- `git diff --check`

Note: targeted local Playwright could not run in the sandbox because `npx` attempted to fetch `@playwright/test` from npm and DNS access is blocked. The PR E2E workflow runs the added Playwright regression in CI.