### PR TITLE
Visu: Link widget — show_icon toggle

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 * Security: `GET /api/v1/weather/fetch` now requires authenticated access and no longer accepts tokens in the URL query string. Weather widgets on PIN-protected Visu pages continue to work with their page-scoped session token, but unauthenticated public weather proxy calls are rejected; private/local weather endpoints still require an explicit URL Target Allowlist entry. https://github.com/abeggled/openbridgeserver/issues/791
 
 ### New features ✨
+* Visu: Link widget now supports hiding the icon via the "show_icon" option. https://github.com/abeggled/openbridgeserver/issues/839
 * Backend/Admin GUI: OBS internal datapoints without adapter bindings can now be written through MQTT `dp/{uuid}/set` or the object detail view; the write is stored as the current value and propagated through the normal registry, retained MQTT value, history/ringbuffer, WebSocket, and logic event path. https://github.com/abeggled/openbridgeserver/issues/715
 * Backend: ETS hierarchy import logic is now available as a reusable backend service while keeping `POST /api/v1/hierarchy/import-from-ets` behavior unchanged. This prepares the KNX project import to create selected ETS hierarchies in the same import flow. https://github.com/abeggled/openbridgeserver/issues/727
 * Backend: `.knxproj` imports can now create selected ETS hierarchies in the same backend request, reporting per-hierarchy node/link counts and non-fatal failures for unavailable ETS data. https://github.com/abeggled/openbridgeserver/issues/728

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -570,10 +570,12 @@
       "dpWStatus": "Weiss lesen (Status, optional)"
     },
     "link": {
-      "title": "Link",
-      "targetPage": "Ziel-Seite",
       "defaultLabel": "Link",
-      "noTarget": "Kein Ziel"
+      "labelPlaceholder": "z.B. Wohnzimmer",
+      "noTarget": "Kein Ziel",
+      "showIcon": "Icon anzeigen",
+      "targetPage": "Ziel-Seite",
+      "title": "Link"
     },
     "qrcode": {
       "title": "QR-Code",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -570,10 +570,12 @@
       "dpWStatus": "Read white (status, optional)"
     },
     "link": {
-      "title": "Link",
-      "targetPage": "Target page",
       "defaultLabel": "Link",
-      "noTarget": "No target"
+      "labelPlaceholder": "e.g. Living room",
+      "noTarget": "No target",
+      "showIcon": "Show icon",
+      "targetPage": "Target page",
+      "title": "Link"
     },
     "qrcode": {
       "title": "QR code",

--- a/frontend/src/widgets/Link/Config.vue
+++ b/frontend/src/widgets/Link/Config.vue
@@ -10,16 +10,18 @@ const emit  = defineEmits<{ (e: 'update:modelValue', val: Record<string, unknown
 
 const store = useVisuStore()
 const cfg = reactive({
-  label:          (props.modelValue.label          as string) ?? '',
-  icon:           (props.modelValue.icon           as string) ?? '🔗',
-  target_node_id: (props.modelValue.target_node_id as string) ?? '',
+  label:          (props.modelValue.label          as string)  ?? '',
+  icon:           (props.modelValue.icon           as string)  ?? '🔗',
+  target_node_id: (props.modelValue.target_node_id as string)  ?? '',
+  show_icon:      (props.modelValue.show_icon      as boolean) ?? true,
 })
 
 // Sync bei Widget-Wechsel
 watch(() => props.modelValue, (v) => {
-  cfg.label          = (v.label          as string) ?? ''
-  cfg.icon           = (v.icon           as string) ?? '🔗'
-  cfg.target_node_id = (v.target_node_id as string) ?? ''
+  cfg.label          = (v.label          as string)  ?? ''
+  cfg.icon           = (v.icon           as string)  ?? '🔗'
+  cfg.target_node_id = (v.target_node_id as string)  ?? ''
+  cfg.show_icon      = (v.show_icon      as boolean) ?? true
 })
 
 watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
@@ -103,6 +105,12 @@ onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
       <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1">{{ $t('widgets.stufenschalter.icon') }}</label>
       <IconPicker v-model="cfg.icon" />
     </div>
+
+    <!-- Icon anzeigen -->
+    <label class="flex items-center gap-2 cursor-pointer select-none">
+      <input type="checkbox" v-model="cfg.show_icon" class="rounded" />
+      <span class="text-xs text-gray-500 dark:text-gray-400">Icon anzeigen</span>
+    </label>
 
     <!-- Ziel-Seite (suchbarer Picker) -->
     <div>

--- a/frontend/src/widgets/Link/Config.vue
+++ b/frontend/src/widgets/Link/Config.vue
@@ -50,6 +50,10 @@ const selectedNode = computed(() =>
   cfg.target_node_id ? store.getNode(cfg.target_node_id) : null,
 )
 
+const selectedNodeTitle = computed(() =>
+  selectedNode.value ? nodePath(selectedNode.value) : undefined,
+)
+
 const filteredNodes = computed(() => {
   const q = searchQuery.value.toLowerCase().trim()
   return store.nodes
@@ -95,7 +99,7 @@ onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
       <input
         v-model="cfg.label"
         type="text"
-        placeholder="z.B. Wohnzimmer"
+        :placeholder="$t('widgets.link.labelPlaceholder')"
         class="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded px-2 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
       />
     </div>
@@ -109,7 +113,7 @@ onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
     <!-- Icon anzeigen -->
     <label class="flex items-center gap-2 cursor-pointer select-none">
       <input type="checkbox" v-model="cfg.show_icon" class="rounded" />
-      <span class="text-xs text-gray-500 dark:text-gray-400">Icon anzeigen</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{{ $t('widgets.link.showIcon') }}</span>
     </label>
 
     <!-- Ziel-Seite (suchbarer Picker) -->
@@ -129,7 +133,7 @@ onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
           <span
             class="flex-1 text-sm truncate"
             :class="selectedNode ? 'text-gray-900 dark:text-gray-100' : 'text-gray-400 dark:text-gray-500'"
-            :title="selectedNode ? nodePath(selectedNode) : undefined"
+            :title="selectedNodeTitle"
           >
             {{ selectedNode ? nodePath(selectedNode) : $t('widgets.common.selectPage') }}
           </span>

--- a/frontend/src/widgets/Link/Widget.vue
+++ b/frontend/src/widgets/Link/Widget.vue
@@ -18,6 +18,7 @@ const { t } = useI18n()
 const label    = computed(() => (props.config.label         as string | undefined) ?? t('widgets.link.defaultLabel'))
 const icon     = computed(() => (props.config.icon          as string | undefined) ?? '🔗')
 const targetId = computed(() => (props.config.target_node_id as string | undefined) ?? '')
+const showIcon = computed(() => props.config.show_icon !== false)
 
 function navigate() {
   if (props.editorMode || !targetId.value) return
@@ -33,7 +34,7 @@ function navigate() {
       : 'cursor-pointer hover:bg-gray-200/60 dark:hover:bg-white/5 active:bg-gray-300/60 dark:active:bg-white/10'"
     @click="navigate"
   >
-    <span class="text-4xl leading-none" data-testid="link-icon"><VisuIcon :icon="icon" /></span>
+    <span v-if="showIcon" class="text-4xl leading-none" data-testid="link-icon"><VisuIcon :icon="icon" /></span>
     <span class="text-sm font-medium text-gray-800 dark:text-gray-200 text-center leading-tight">{{ label }}</span>
     <span v-if="!editorMode && targetId" class="text-xs text-gray-400 dark:text-gray-500">→</span>
     <span v-else-if="!targetId" class="text-xs text-gray-400 dark:text-gray-600">{{ $t('widgets.link.noTarget') }}</span>

--- a/frontend/src/widgets/Link/index.ts
+++ b/frontend/src/widgets/Link/index.ts
@@ -15,6 +15,7 @@ WidgetRegistry.register({
     label: '',
     icon: '🔗',
     target_node_id: '',
+    show_icon: true,
   },
   compatibleTypes: ['*'],
   noDatapoint: true,


### PR DESCRIPTION
## Summary
- Adds a `show_icon` boolean option to the Link widget (default: `true`)
- When set to `false`, the icon span is hidden via `v-if`, leaving only the label and arrow visible
- Useful for compact text-only navigation links

## Test plan
- [x] Open Visu Editor, select a Link widget → "Icon anzeigen" checkbox is visible in config panel
- [x] Uncheck the box, save, verify the icon disappears in the viewer
- [x] Check the box again, save, verify the icon reappears
- [x] Verify default behavior (no `show_icon` in config) still shows the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)