### PR TITLE
Visu: Link widget — show_arrow toggle

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -24,6 +24,8 @@
 * Admin GUI: Logic editor block palette — individual block sections (Logic, Objects, Math, …) can now be collapsed and expanded by clicking the section header; the entire palette column can also be collapsed to a slim rail and restored the same way. Both states persist across page reloads. https://github.com/abeggled/openbridgeserver/issues/875
 * Admin GUI: The minimap in the logic editor can now be dragged to any position within the canvas; the position is saved and restored across page reloads. https://github.com/abeggled/openbridgeserver/issues/879
 
+* Visu: Link widget: the navigation arrow (→) can now be hidden independently of the icon via the "show_arrow" option (default: shown).
+
 ### Fixes 🐞
 * Visu: Kamera widget — Basic Auth and API-Key credential fields are now always shown when the matching auth type is selected, including after loading a page saved with an older auth format. The config panel no longer renders blank when a widget with a null or missing config is selected. Legacy authType values stored as display text are normalised to canonical form on load. https://github.com/abeggled/openbridgeserver/issues/823
 * Backend: KNX adapter no longer forwards non-finite float values (`inf`, `-inf`, `nan`) produced by DPT decoders to the event bus. Such values are now published with `quality=bad` and `value=null` instead of propagating to the InfluxDB history plugin, which rejected them with HTTP 400 "invalid boolean". https://github.com/abeggled/openbridgeserver/issues/827

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -601,6 +601,7 @@
       "defaultLabel": "Link",
       "labelPlaceholder": "z.B. Wohnzimmer",
       "noTarget": "Kein Ziel",
+      "showArrow": "Navigationspfeil (→) anzeigen",
       "showIcon": "Icon anzeigen",
       "preserveIconColor": "SVG-Icon-Farbe erhalten (kein Schwarz/Weiß)",
       "targetPage": "Ziel-Seite",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -601,6 +601,7 @@
       "defaultLabel": "Link",
       "labelPlaceholder": "e.g. Living room",
       "noTarget": "No target",
+      "showArrow": "Show navigation arrow (→)",
       "showIcon": "Show icon",
       "preserveIconColor": "Preserve SVG icon color (no black/white)",
       "targetPage": "Target page",

--- a/frontend/src/widgets/Link/Config.vue
+++ b/frontend/src/widgets/Link/Config.vue
@@ -13,6 +13,7 @@ const cfg = reactive({
   label:               (props.modelValue.label               as string)  ?? '',
   icon:                (props.modelValue.icon                as string)  ?? '🔗',
   target_node_id:      (props.modelValue.target_node_id      as string)  ?? '',
+  show_arrow:          (props.modelValue.show_arrow          as boolean) ?? true,
   show_icon:           (props.modelValue.show_icon           as boolean) ?? true,
   preserve_icon_color: (props.modelValue.preserve_icon_color as boolean) ?? false,
   label_size:          (props.modelValue.label_size          as string)  ?? 'sm',
@@ -24,6 +25,7 @@ watch(() => props.modelValue, (v) => {
   cfg.label               = (v.label               as string)  ?? ''
   cfg.icon                = (v.icon                as string)  ?? '🔗'
   cfg.target_node_id      = (v.target_node_id      as string)  ?? ''
+  cfg.show_arrow          = (v.show_arrow          as boolean) ?? true
   cfg.show_icon           = (v.show_icon           as boolean) ?? true
   cfg.preserve_icon_color = (v.preserve_icon_color as boolean) ?? false
   cfg.label_size          = (v.label_size          as string)  ?? 'sm'
@@ -156,6 +158,12 @@ onUnmounted(() => document.removeEventListener('mousedown', onDocClick))
         <option value="border">{{ $t('widgets.link.activeIndicatorBorder') }}</option>
       </select>
     </div>
+
+    <!-- Navigationspfeil anzeigen -->
+    <label class="flex items-center gap-2 cursor-pointer select-none">
+      <input type="checkbox" v-model="cfg.show_arrow" class="rounded" />
+      <span class="text-xs text-gray-500 dark:text-gray-400">{{ $t('widgets.link.showArrow') }}</span>
+    </label>
 
     <!-- Ziel-Seite (suchbarer Picker) -->
     <div>

--- a/frontend/src/widgets/Link/Widget.vue
+++ b/frontend/src/widgets/Link/Widget.vue
@@ -20,14 +20,15 @@ const store    = useVisuStore()
 const { t } = useI18n()
 const label    = computed(() => (props.config.label         as string | undefined) ?? t('widgets.link.defaultLabel'))
 const icon     = computed(() => (props.config.icon          as string | undefined) ?? '🔗')
-const targetId = computed(() => (props.config.target_node_id as string | undefined) ?? '')
-const showIcon = computed(() => props.config.show_icon !== false)
+const targetId  = computed(() => (props.config.target_node_id as string | undefined) ?? '')
+const showIcon  = computed(() => props.config.show_icon !== false)
 const preserveIconColor = computed(() => props.config.preserve_icon_color === true)
 const labelSize = computed(() => {
   const s = props.config.label_size as string | undefined
   const map: Record<string, string> = { xs: 'text-xs', sm: 'text-sm', md: 'text-base', lg: 'text-lg', xl: 'text-xl' }
   return map[s ?? ''] ?? 'text-sm'
 })
+const showArrow = computed(() => props.config.show_arrow !== false)
 
 const activeIndicator = computed(() => (props.config.active_indicator as string | undefined) ?? 'none')
 
@@ -94,7 +95,7 @@ function navigate() {
   >
     <span v-if="showIcon" class="text-4xl leading-none" data-testid="link-icon"><VisuIcon :icon="icon" :preserve-color="preserveIconColor" /></span>
     <span class="font-medium text-gray-800 dark:text-gray-200 text-center leading-tight" :class="labelSize">{{ label }}</span>
-    <span v-if="!editorMode && targetId" class="text-xs text-gray-400 dark:text-gray-500">→</span>
+    <span v-if="showArrow && !editorMode && targetId" class="text-xs text-gray-400 dark:text-gray-500">→</span>
     <span v-else-if="!targetId" class="text-xs text-gray-400 dark:text-gray-600">{{ $t('widgets.link.noTarget') }}</span>
 
     <!-- active_indicator: dot -->

--- a/frontend/src/widgets/Link/index.ts
+++ b/frontend/src/widgets/Link/index.ts
@@ -14,6 +14,7 @@ WidgetRegistry.register({
   defaultConfig: {
     label: '',
     icon: '🔗',
+    show_arrow: true,
     target_node_id: '',
     show_icon: true,
     preserve_icon_color: false,


### PR DESCRIPTION
## Summary

- Adds a `show_arrow` boolean option to the Link widget (default: `true`)
- When set to `false`, the navigation arrow (→) is hidden without affecting icon or label visibility
- New checkbox "Navigationspfeil (→) anzeigen" in the editor config panel
- Fully backward-compatible: existing widgets without the option set continue to show the arrow

## Test plan

- [x] Open Visu Editor, select a Link widget → "Navigationspfeil (→) anzeigen" checkbox visible in config panel
- [x] Uncheck → arrow disappears in viewer, icon and label remain
- [x] Check → arrow reappears
- [x] New widget inserted from palette has arrow visible by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)