### PR TITLE
Fix memory leak safeguards for logic and InfluxDB

### DIFF
--- a/obs/core/event_bus.py
+++ b/obs/core/event_bus.py
@@ -39,6 +39,7 @@ class DataValueEvent:
     source_adapter: str  # adapter_type string
     ts: datetime = field(default_factory=lambda: datetime.now(UTC))
     binding_id: uuid.UUID | None = None
+    logic_depth: int = 0
 
 
 @dataclass

--- a/obs/history/influxdb_plugin.py
+++ b/obs/history/influxdb_plugin.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -55,6 +56,8 @@ _INFLUX_AGGFN: dict[str, str] = {
     "max": "MAX",
     "last": "LAST",
 }
+_WRITE_BACKOFF_INITIAL_SECONDS = 5.0
+_WRITE_BACKOFF_MAX_SECONDS = 60.0
 
 
 class InfluxDBHistoryPlugin(HistoryPlugin):
@@ -79,6 +82,10 @@ class InfluxDBHistoryPlugin(HistoryPlugin):
         self._database = database  # v1/v3 db name
         self._username = username
         self._password = password
+        self._client: httpx.AsyncClient | None = None
+        self._write_backoff_until = 0.0
+        self._write_backoff_seconds = _WRITE_BACKOFF_INITIAL_SECONDS
+        self._write_skip_logged = False
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -128,6 +135,16 @@ class InfluxDBHistoryPlugin(HistoryPlugin):
         elif self._token:
             h["Authorization"] = f"Bearer {self._token}"
         return h
+
+    def _get_write_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=10)
+        return self._client
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
 
     def _escape_tag(self, s: str) -> str:
         """Escape InfluxDB line-protocol tag value (no comma, space, equals)."""
@@ -229,16 +246,36 @@ class InfluxDBHistoryPlugin(HistoryPlugin):
         url, params = self._write_url_params()
         headers = self._headers(content_type="text/plain; charset=utf-8")
 
-        try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                r = await client.post(
-                    url,
-                    content=line.encode(),
-                    params=params,
-                    headers=headers,
+        now = time.monotonic()
+        if now < self._write_backoff_until:
+            if not self._write_skip_logged:
+                logger.warning(
+                    "InfluxDB write suppressed for %.1fs after previous failure",
+                    self._write_backoff_until - now,
                 )
-                r.raise_for_status()
+                self._write_skip_logged = True
+            return
+
+        try:
+            client = self._get_write_client()
+            r = await client.post(
+                url,
+                content=line.encode(),
+                params=params,
+                headers=headers,
+            )
+            r.raise_for_status()
+            self._write_backoff_until = 0.0
+            self._write_backoff_seconds = _WRITE_BACKOFF_INITIAL_SECONDS
+            self._write_skip_logged = False
         except Exception as exc:
+            try:
+                await self.disconnect()
+            except Exception:
+                pass
+            self._write_backoff_until = time.monotonic() + self._write_backoff_seconds
+            self._write_backoff_seconds = min(self._write_backoff_seconds * 2, _WRITE_BACKOFF_MAX_SECONDS)
+            self._write_skip_logged = False
             logger.error("InfluxDB write failed: %s", exc)
             raise
 

--- a/obs/logic/executor.py
+++ b/obs/logic/executor.py
@@ -18,6 +18,7 @@ from typing import Any
 from obs.logic.models import FlowData, LogicNode
 
 logger = logging.getLogger(__name__)
+_AVG_MULTI_MAX_SAMPLES = 100_000
 
 _COMPARE_OPS = {
     ">": operator.gt,
@@ -837,9 +838,11 @@ class GraphExecutor:
                     current_avg: float | None = sum(values) / len(values)
                     now_utc = _dt.datetime.now(_dt.UTC)
                     state["samples"].append([now_utc.isoformat(), current_avg])
-                    # Trim buffer: keep only samples within the max window (365 days)
+                    # Keep the 365-day window bounded even for high-frequency inputs.
                     cutoff_iso = (now_utc - _dt.timedelta(days=365)).isoformat()
                     state["samples"] = [s for s in state["samples"] if s[0] >= cutoff_iso]
+                    if len(state["samples"]) > _AVG_MULTI_MAX_SAMPLES:
+                        state["samples"] = state["samples"][-_AVG_MULTI_MAX_SAMPLES:]
                 else:
                     current_avg = None
                 # Compute moving averages for each time window

--- a/obs/logic/manager.py
+++ b/obs/logic/manager.py
@@ -52,6 +52,7 @@ _THROTTLE_UNITS: dict[str, float] = {
     "min": 60_000.0,
     "h": 3_600_000.0,
 }
+_MAX_LOGIC_CASCADE_DEPTH = 10
 
 _ICAL_MAX_BYTES = 1_048_576
 _ICAL_MAX_REDIRECTS = 5
@@ -620,6 +621,7 @@ class LogicManager:
     async def _on_value_event(self, event: Any) -> None:
         dp_id = str(event.datapoint_id)
         now = datetime.now(UTC)
+        logic_depth = int(getattr(event, "logic_depth", 0) or 0)
 
         for graph_id in list(self._graphs):
             entry = self._graphs.get(graph_id)
@@ -630,6 +632,15 @@ class LogicManager:
                 continue
             trigger_nodes = [n for n in flow.nodes if n.type == "datapoint_read" and n.data.get("datapoint_id") == dp_id]
             if not trigger_nodes:
+                continue
+            if logic_depth >= _MAX_LOGIC_CASCADE_DEPTH:
+                logger.warning(
+                    "Logic cascade depth limit reached: suppressing graph=%s (%s) for dp=%s depth=%d",
+                    graph_id[:8],
+                    name,
+                    dp_id,
+                    logic_depth,
+                )
                 continue
 
             graph_state = self._node_state.setdefault(graph_id, {})
@@ -686,7 +697,7 @@ class LogicManager:
 
             if not overrides:
                 continue
-            await self._execute_graph(graph_id, name, flow, overrides)
+            await self._execute_graph(graph_id, name, flow, overrides, logic_depth=logic_depth)
 
     async def _on_datapoint_renamed(self, event: Any) -> None:
         """Update datapoint_name in all logic nodes that reference the renamed DataPoint."""
@@ -739,6 +750,7 @@ class LogicManager:
         name: str,
         flow: FlowData,
         overrides: dict[str, dict[str, Any]],
+        logic_depth: int = 0,
     ) -> dict[str, Any]:
         execute_now = datetime.now(UTC)
         graph_state = self._node_state.setdefault(graph_id, {})
@@ -1388,6 +1400,7 @@ class LogicManager:
                     value=write_val,
                     quality="good",
                     source_adapter="logic",
+                    logic_depth=logic_depth + 1,
                 )
                 await self._event_bus.publish(event)
                 logger.debug("Graph %s: wrote dp %s = %s", graph_id, dp_id_str, write_val)

--- a/tests/unit/test_avg_multi.py
+++ b/tests/unit/test_avg_multi.py
@@ -205,6 +205,17 @@ class TestAvgMultiBuffer:
         assert "samples" in state["a"]
         assert len(state["a"]["samples"]) == 1
 
+    def test_buffer_trimmed_to_max_sample_count(self, monkeypatch):
+        """High-frequency inputs must not keep an unbounded 365-day sample list."""
+        from obs.logic import executor as executor_mod
+
+        monkeypatch.setattr(executor_mod, "_AVG_MULTI_MAX_SAMPLES", 3)
+        state: dict = {}
+        for value in [1.0, 2.0, 3.0, 4.0, 5.0]:
+            _run_avg({"input_count": 1}, {"in_1": value}, state)
+
+        assert [sample[1] for sample in state["a"]["samples"]] == [3.0, 4.0, 5.0]
+
 
 # ===========================================================================
 # persist_state toggle — manager-level filtering

--- a/tests/unit/test_coverage_adapters_hierarchy_logic.py
+++ b/tests/unit/test_coverage_adapters_hierarchy_logic.py
@@ -2870,6 +2870,31 @@ class TestLogicManagerValueEvent:
         assert len(executed) == 0
 
     @pytest.mark.asyncio
+    async def test_on_value_event_suppresses_logic_cascade_at_depth_limit(self):
+        dp_id = uuid.uuid4()
+        flow = _make_flow(
+            nodes=[
+                {
+                    "id": "n1",
+                    "type": "datapoint_read",
+                    "position": {"x": 0, "y": 0},
+                    "data": {"datapoint_id": str(dp_id)},
+                }
+            ]
+        )
+        mgr, _, _, _ = _make_logic_manager(graphs={"g1": ("G1", True, flow)})
+        mgr._execute_graph = AsyncMock()
+
+        event = MagicMock()
+        event.datapoint_id = dp_id
+        event.value = 1.0
+        event.logic_depth = 10
+
+        await mgr._on_value_event(event)
+
+        mgr._execute_graph.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_on_value_event_min_delta_pct_suppresses(self):
         dp_id = uuid.uuid4()
         flow = _make_flow(
@@ -3136,6 +3161,30 @@ class TestLogicManagerExecuteGraph:
 
         # The event_bus.publish should have been called for the write
         assert event_bus.publish.called
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_increments_logic_depth_on_write(self):
+        write_dp_id = uuid.uuid4()
+        flow = _make_flow(
+            nodes=[
+                {
+                    "id": "n_write",
+                    "type": "datapoint_write",
+                    "position": {"x": 200, "y": 0},
+                    "data": {"datapoint_id": str(write_dp_id)},
+                },
+            ],
+        )
+        mgr, db, event_bus, registry = _make_logic_manager(graphs={"g1": ("G1", True, flow)})
+        registry.get_value = MagicMock(return_value=None)
+        db.execute_and_commit = AsyncMock()
+
+        with patch("obs.api.v1.websocket.get_ws_manager") as mock_ws:
+            mock_ws.return_value.broadcast = AsyncMock()
+            await mgr._execute_graph("g1", "G1", flow, {"n_write": {"value": 42.0}}, logic_depth=4)
+
+        published_event = event_bus.publish.await_args.args[0]
+        assert published_event.logic_depth == 5
 
     @pytest.mark.asyncio
     async def test_execute_graph_ws_error_ignored(self):

--- a/tests/unit/test_influxdb_plugin.py
+++ b/tests/unit/test_influxdb_plugin.py
@@ -40,7 +40,11 @@ def _ts(offset: int = 0) -> datetime:
 
 
 def _make_httpx_mock(status=204, json_body=None):
-    """Return a (ctx, client) pair where ctx is usable as AsyncClient(...)."""
+    """Return a (ctx, client) pair where ctx is usable as AsyncClient(...).
+
+    The Influx plugin uses AsyncClient directly for writes and as an async
+    context manager for queries/pings, so the mock supports both styles.
+    """
     resp = mock.MagicMock()
     resp.status_code = status
     resp.raise_for_status = mock.MagicMock()
@@ -52,6 +56,10 @@ def _make_httpx_mock(status=204, json_body=None):
     client.get = mock.AsyncMock(return_value=resp)
 
     ctx = mock.MagicMock()
+    ctx.post = client.post
+    ctx.get = client.get
+    ctx.aclose = mock.AsyncMock()
+    ctx.is_closed = False
     ctx.__aenter__ = mock.AsyncMock(return_value=client)
     ctx.__aexit__ = mock.AsyncMock(return_value=False)
     return ctx, client
@@ -251,17 +259,45 @@ class TestInfluxDBWrite:
         resp = mock.MagicMock()
         resp.raise_for_status = mock.MagicMock(side_effect=Exception("HTTP 500"))
         ctx = mock.MagicMock()
-        ctx.__aenter__ = mock.AsyncMock(return_value=mock.MagicMock(post=mock.AsyncMock(return_value=resp)))
-        ctx.__aexit__ = mock.AsyncMock(return_value=False)
+        ctx.post = mock.AsyncMock(return_value=resp)
+        ctx.aclose = mock.AsyncMock()
+        ctx.is_closed = False
         with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
             with pytest.raises(Exception, match="HTTP 500"):
                 await _plugin().write(uuid.uuid4(), 1.0, None, "ok", ts=_ts())
+        ctx.aclose.assert_awaited_once()
 
     async def test_write_without_ts_uses_now(self):
         ctx, client = _make_httpx_mock(status=204)
         with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
             await _plugin().write(uuid.uuid4(), 1.0, None, "ok")
         client.post.assert_awaited_once()
+
+    async def test_write_reuses_single_client(self):
+        ctx, client = _make_httpx_mock(status=204)
+        plugin = _plugin()
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx) as client_factory:
+            await plugin.write(uuid.uuid4(), 1.0, None, "ok", ts=_ts())
+            await plugin.write(uuid.uuid4(), 2.0, None, "ok", ts=_ts())
+        assert client_factory.call_count == 1
+        assert client.post.await_count == 2
+
+    async def test_write_backoff_suppresses_followup_attempt(self):
+        resp = mock.MagicMock()
+        resp.raise_for_status = mock.MagicMock(side_effect=Exception("HTTP 500"))
+        ctx = mock.MagicMock()
+        ctx.post = mock.AsyncMock(return_value=resp)
+        ctx.aclose = mock.AsyncMock()
+        ctx.is_closed = False
+
+        plugin = _plugin()
+        with mock.patch("obs.history.influxdb_plugin.httpx.AsyncClient", return_value=ctx):
+            with pytest.raises(Exception, match="HTTP 500"):
+                await plugin.write(uuid.uuid4(), 1.0, None, "ok", ts=_ts())
+            await plugin.write(uuid.uuid4(), 2.0, None, "ok", ts=_ts())
+
+        ctx.post.assert_awaited_once()
+        ctx.aclose.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the memory/FD exhaustion scenarios investigated in #861.

- add a `logic_depth` field to `DataValueEvent` and stop logic cascades once they reach depth 10
- propagate incremented logic depth from `datapoint_write` events emitted by logic graphs
- reuse a single InfluxDB write `httpx.AsyncClient` per plugin instance instead of creating one per value
- add exponential InfluxDB write backoff after failures to avoid connection storms while InfluxDB is down
- cap `avg_multi` retained samples at 100,000 in addition to the existing 365-day time window
- add unit coverage for the loop guard, InfluxDB client reuse/backoff, and avg_multi sample cap

## Tests

- `tools/with-venv ./tools/lint.sh --check`
- `tools/with-venv pytest tests/unit tests/adapters tests/contracts -q`
- `tools/with-venv pytest tests/unit tests/adapters tests/contracts --cov=obs --cov-report=term-missing`
