### PR TITLE
Fix case-insensitive value maps

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -285,7 +285,7 @@ Optional: eine Tabelle, die Rohwerte auf andere Werte abbildet — nützlich z. 
 { "value_map": { "0": "Aus", "1": "Ein", "2": "Standby" } }
 ```
 
-Der Schlüssel ist immer ein String (der Rohwert wird intern umgewandelt). Gibt es keinen passenden Eintrag, wird der Originalwert unverändert weitergegeben. `value_map` wird nach `value_formula` angewendet.
+Der Schlüssel ist immer ein String (der Rohwert wird intern umgewandelt). Die Zuordnung prüft zuerst den exakten Schlüssel und danach ohne Beachtung der Gross-/Kleinschreibung, sodass `OFF` auch einen Eintrag wie `"off"` trifft. Gibt es keinen passenden Eintrag, wird der Originalwert unverändert weitergegeben. `value_map` wird nach `value_formula` angewendet.
 
 **Sendefilter** (nur für DEST/BOTH, werden der Reihe nach geprüft):
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Optional: a table that maps raw values to other values — useful for enumeratio
 { "value_map": { "0": "Off", "1": "On", "2": "Standby" } }
 ```
 
-The key is always a string (the raw value is converted internally). If no matching entry exists, the original value is passed through unchanged. `value_map` is applied after `value_formula`.
+The key is always a string (the raw value is converted internally). Matching first tries the exact key and then a case-insensitive key, so `OFF` matches a map entry like `"off"`. If no matching entry exists, the original value is passed through unchanged. `value_map` is applied after `value_formula`.
 
 **Send filters** (DEST/BOTH only, checked in order):
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -15,6 +15,7 @@
 * Visu: Editor grid limits extended — columns up to 120, cell size down to 10 px, enabling fullscreen/dense layouts. https://github.com/abeggled/openbridgeserver/issues/842
 
 ### Fixes 🐞
+* Backend/Frontend: `value_map` transformations now match string keys case-insensitively after exact lookup, so values such as `OFF`, `oN`, `TRUE`, and `FALSE` work with built-in presets and custom maps. https://github.com/abeggled/openbridgeserver/issues/834
 * Visu: Rolladen-Widget — Beschriftungen der Statusindikatoren 1–4 wurden als roher i18n-Key angezeigt statt als übersetzter Text (fehlende doppelte geschweifte Klammern in der Config-Komponente).
 * Backend: High-volume third-party DEBUG loggers (e.g. `aiosqlite`, which logs two lines per SQL operation) are now floored at INFO, so enabling DEBUG globally no longer floods the logs and saturates a CPU core. https://github.com/abeggled/openbridgeserver/issues/798
 * Backend: Logic-Executor verschluckt Node-Fehler still (result = {}) — kein sichtbares Feedback. https://github.com/abeggled/openbridgeserver/issues/788

--- a/frontend/src/utils/transformation.test.ts
+++ b/frontend/src/utils/transformation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyValueMap } from './transformation'
+
+describe('applyValueMap', () => {
+  it('matches string keys case-insensitively after exact lookup misses', () => {
+    expect(applyValueMap({ on: 'true', off: 'false' }, 'OFF')).toBe('false')
+    expect(applyValueMap({ on: 'true', off: 'false' }, 'On')).toBe('true')
+  })
+
+  it('prefers exact keys over case-insensitive fallback keys', () => {
+    expect(applyValueMap({ off: 'lowercase', OFF: 'uppercase' }, 'OFF')).toBe('uppercase')
+  })
+
+  it('falls back from boolean keys to numeric keys', () => {
+    expect(applyValueMap({ '1': 'on', '0': 'off' }, true)).toBe('on')
+    expect(applyValueMap({ '1': 'on', '0': 'off' }, false)).toBe('off')
+  })
+
+  it('matches uppercase boolean text keys case-insensitively', () => {
+    expect(applyValueMap({ TRUE: 'on', FALSE: 'off' }, true)).toBe('on')
+    expect(applyValueMap({ TRUE: 'on', FALSE: 'off' }, false)).toBe('off')
+  })
+
+  it('prefers case-insensitive boolean text keys over numeric fallback keys', () => {
+    expect(applyValueMap({ '1': 'numeric', TRUE: 'text' }, true)).toBe('text')
+  })
+
+  it('returns the original value when no key matches', () => {
+    expect(applyValueMap({ off: 'false' }, 'standby')).toBe('standby')
+  })
+})

--- a/frontend/src/utils/transformation.ts
+++ b/frontend/src/utils/transformation.ts
@@ -17,7 +17,9 @@ export function applyFormula(formula: string, value: number): number {
 
 /**
  * Applies a value map (enum substitution) to any value.
- * Booleans are normalized to lowercase ("true" / "false").
+ * Booleans are normalized to lowercase ("true" / "false"). Exact keys win,
+ * then string keys are matched case-insensitively. Boolean values also fall
+ * back to numeric keys ("1" / "0").
  * Returns the original value if no match is found.
  */
 export function applyValueMap(
@@ -25,6 +27,19 @@ export function applyValueMap(
   value: unknown,
 ): unknown {
   if (!valueMap || Object.keys(valueMap).length === 0) return value
-  const key = typeof value === 'boolean' ? String(value) : String(value)
-  return Object.prototype.hasOwnProperty.call(valueMap, key) ? valueMap[key] : value
+  const keys = typeof value === 'boolean'
+    ? [String(value), value ? '1' : '0']
+    : [String(value)]
+
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(valueMap, key)) return valueMap[key]
+
+    const foldedKey = key.toLowerCase()
+    const fallbackKey = Object.keys(valueMap).find(
+      mapKey => mapKey.toLowerCase() === foldedKey,
+    )
+    if (fallbackKey !== undefined) return valueMap[fallbackKey]
+  }
+
+  return value
 }

--- a/obs/core/transformation.py
+++ b/obs/core/transformation.py
@@ -159,6 +159,7 @@ def apply_value_map(value: Any, value_map: dict[str, Any] | None) -> Any:
     - bool  → lowercase "true"/"false"  (JSON convention)
     - float with no fractional part (e.g. 5.0) → int string "5"
     - all other types → str(value)
+    - if no exact key matches, string keys are compared case-insensitively
 
     This allows N-entry maps like {"0": "Aus", "1": "Init", …, "10": "Standby"}
     to work even when values arrive as floats from Modbus or similar adapters.
@@ -176,14 +177,23 @@ def apply_value_map(value: Any, value_map: dict[str, Any] | None) -> Any:
     if not value_map:
         return value
     if isinstance(value, bool):
-        key = str(value).lower()  # "true" or "false"
+        keys = [str(value).lower()]  # "true" or "false"
         # Fall back to numeric "1"/"0" when the bool key is not in the map.
         # This allows numeric maps like {"0": "1", "1": "0"} to work with
         # boolean inputs (e.g. KNX DPT1.x decodes to Python bool).
-        if key not in value_map:
-            key = "1" if value else "0"
+        keys.append("1" if value else "0")
     elif isinstance(value, float) and value.is_integer():
-        key = str(int(value))
+        keys = [str(int(value))]
     else:
-        key = str(value)
-    return value_map.get(key, value)
+        keys = [str(value)]
+
+    for key in keys:
+        if key in value_map:
+            return value_map[key]
+
+        folded_key = key.casefold()
+        for map_key, mapped_value in value_map.items():
+            if str(map_key).casefold() == folded_key:
+                return mapped_value
+
+    return value

--- a/tests/adapters/test_mqtt_adapter.py
+++ b/tests/adapters/test_mqtt_adapter.py
@@ -167,6 +167,18 @@ class TestOnMessageValueMap:
         assert event.value == "on"
 
     @pytest.mark.asyncio
+    async def test_value_map_matches_case_insensitive_string_payload(self, adapter, mock_bus):
+        binding = make_binding(
+            {"topic": "t"},
+            value_map={"on": "true", "off": "false"},
+        )
+        adapter._topic_map["t"] = [binding]
+
+        await adapter._on_message("t", b"OFF")
+        event = mock_bus.publish.call_args[0][0]
+        assert event.value == "false"
+
+    @pytest.mark.asyncio
     async def test_value_map_no_match_passthrough(self, adapter, mock_bus):
         binding = make_binding(
             {"topic": "t"},

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -717,6 +717,11 @@ class TestDatapointNodes:
         out = run_single("datapoint_read", {"value_map": m}, {"value": 99})
         assert out["value"] == 99
 
+    def test_read_value_map_string_lookup_is_case_insensitive(self):
+        m = {"on": "true", "off": "false"}
+        out = run_single("datapoint_read", {"value_map": m}, {"value": "OFF"})
+        assert out["value"] == "false"
+
     def test_read_formula_then_value_map(self):
         # Formula runs first: x*2 → 2; then map: "2" → "Zwei"
         m = {"2": "Zwei"}

--- a/tests/unit/test_transformation.py
+++ b/tests/unit/test_transformation.py
@@ -116,6 +116,13 @@ class TestApplyValueMapBoolNormalisation:
         # If both "true" and "1" exist, "true" wins (bool key has priority)
         assert apply_value_map(True, {"true": "bool-on", "1": "num-on"}) == "bool-on"
 
+    def test_bool_true_prefers_case_insensitive_true_key_over_numeric(self):
+        assert apply_value_map(True, {"1": "num-on", "TRUE": "bool-on"}) == "bool-on"
+
+    def test_bool_text_key_lookup_is_case_insensitive(self):
+        assert apply_value_map(True, {"TRUE": "on"}) == "on"
+        assert apply_value_map(False, {"FALSE": "off"}) == "off"
+
     def test_bool_no_match_returns_original(self):
         # Neither "true" nor "1" in map → original value returned
         assert apply_value_map(True, {"foo": "bar"}) is True
@@ -143,6 +150,15 @@ class TestApplyValueMapStringValues:
         m = {"0": "1", "1": "0"}
         assert apply_value_map(0, m) == "1"
         assert apply_value_map(1, m) == "0"
+
+    def test_string_lookup_is_case_insensitive(self):
+        m = {"on": "true", "off": "false"}
+        assert apply_value_map("OFF", m) == "false"
+        assert apply_value_map("On", m) == "true"
+
+    def test_exact_key_wins_before_case_insensitive_fallback(self):
+        m = {"off": "lowercase", "OFF": "uppercase"}
+        assert apply_value_map("OFF", m) == "uppercase"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Fix value_map lookups so exact keys win, then case-insensitive keys are matched
- Preserve boolean text precedence before numeric boolean fallback
- Align the frontend transformation helper with backend behavior
- Document value_map key matching in English and German README files

## Root cause
value_map converted incoming values to string keys and only performed exact dictionary lookups. Payloads such as OFF did not match configured entries such as off.

## Impact
Built-in presets and custom JSON value maps now handle mixed-case payloads such as oN, oFF, TRUE, and FALSE consistently across backend runtime and frontend helper logic.

Fixes #834

## Validation
- .venv/bin/pytest tests/unit/test_transformation.py tests/unit/test_executor.py tests/adapters/test_mqtt_adapter.py
- npm test -- transformation.test.ts