### PR TITLE
feat(logic): retractable sections and collapsible palette column (#875)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,7 @@
 * Visu: Licht widget: the EIN/AUS state label can now be hidden via "show_state_text". https://github.com/abeggled/openbridgeserver/issues/840
 * Visu: Link widget now supports hiding the icon via the "show_icon" option. https://github.com/abeggled/openbridgeserver/issues/839
 * Visu: Editor grid limits extended — columns up to 120, cell size down to 10 px, enabling fullscreen/dense layouts. https://github.com/abeggled/openbridgeserver/issues/842
+* Admin GUI: Logic editor block palette — individual block sections (Logic, Objects, Math, …) can now be collapsed and expanded by clicking the section header; the entire palette column can also be collapsed to a slim rail and restored the same way. Both states persist across page reloads. https://github.com/abeggled/openbridgeserver/issues/875
 
 ### Fixes 🐞
 * Visu: Rolladen-Widget — Beschriftungen der Statusindikatoren 1–4 wurden als roher i18n-Key angezeigt statt als übersetzter Text (fehlende doppelte geschweifte Klammern in der Config-Komponente).

--- a/gui/src/components/logic/NodePalette.vue
+++ b/gui/src/components/logic/NodePalette.vue
@@ -1,33 +1,78 @@
 <template>
-  <div class="h-full flex flex-col bg-surface-800 border-r border-slate-200 dark:border-slate-700/60 w-56">
-    <div class="px-3 py-2 border-b border-slate-200 dark:border-slate-700/60">
-      <h3 class="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">{{ $t('logic.palette.title') }}</h3>
-    </div>
-    <div class="flex-1 overflow-y-auto p-2 flex flex-col gap-3">
-      <div v-for="cat in categories" :key="cat.id">
-        <div class="text-xs text-slate-400 dark:text-slate-500 uppercase tracking-wider px-1 mb-1">{{ cat.label }}</div>
-        <div
-          v-for="nt in cat.types" :key="nt.type"
-          draggable="true"
-          @dragstart="onDragStart($event, nt)"
-          class="flex items-center gap-2 px-2 py-1.5 rounded cursor-grab hover:bg-slate-100 dark:hover:bg-slate-700/50 transition-colors select-none"
-        >
-          <span class="w-2 h-2 rounded-full flex-shrink-0" :style="{ background: nt.color }"></span>
-          <span class="text-xs text-slate-700 dark:text-slate-200">{{ $te('logic.nodeTypes.' + nt.type) ? $t('logic.nodeTypes.' + nt.type) : nt.label }}</span>
+  <div :class="['h-full flex flex-col bg-surface-800 border-r border-slate-200 dark:border-slate-700/60 transition-all duration-300 flex-shrink-0', collapsed ? 'w-8' : 'w-56']">
+
+    <!-- Collapsed: single expand button -->
+    <template v-if="collapsed">
+      <button
+        @click="$emit('toggle')"
+        class="h-full w-full flex items-center justify-center hover:bg-slate-700/40 transition-colors"
+        :title="$t('logic.palette.expand')"
+      >
+        <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+        </svg>
+      </button>
+    </template>
+
+    <!-- Expanded -->
+    <template v-else>
+      <!-- Header -->
+      <button
+        @click="$emit('toggle')"
+        class="px-3 py-2 border-b border-slate-200 dark:border-slate-700/60 flex items-center justify-between flex-shrink-0 w-full hover:bg-slate-700/40 transition-colors"
+        :title="$t('logic.palette.collapse')"
+      >
+        <h3 class="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">{{ $t('logic.palette.title') }}</h3>
+        <svg class="w-3.5 h-3.5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+      </button>
+
+      <!-- Categories -->
+      <div class="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
+        <div v-for="cat in categories" :key="cat.id">
+          <!-- Section header -->
+          <button
+            @click="toggleCategory(cat.id)"
+            class="w-full flex items-center justify-between px-1 py-1 text-xs text-slate-400 dark:text-slate-500 uppercase tracking-wider hover:bg-slate-700/40 hover:text-slate-200 dark:hover:text-slate-300 transition-colors rounded"
+          >
+            <span>{{ cat.label }}</span>
+            <svg
+              :class="['w-3 h-3 transition-transform duration-200', collapsedCategories.has(cat.id) ? '-rotate-90' : '']"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+          </button>
+
+          <!-- Block list -->
+          <div v-show="!collapsedCategories.has(cat.id)" class="flex flex-col gap-0.5 mb-1">
+            <div
+              v-for="nt in cat.types" :key="nt.type"
+              draggable="true"
+              @dragstart="onDragStart($event, nt)"
+              class="flex items-center gap-2 px-2 py-1.5 rounded cursor-grab hover:bg-slate-100 dark:hover:bg-slate-700/50 transition-colors select-none"
+            >
+              <span class="w-2 h-2 rounded-full flex-shrink-0" :style="{ background: nt.color }"></span>
+              <span class="text-xs text-slate-700 dark:text-slate-200">{{ $te('logic.nodeTypes.' + nt.type) ? $t('logic.nodeTypes.' + nt.type) : nt.label }}</span>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+    </template>
+
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
-  nodeTypes: { type: Array, default: () => [] }
+  nodeTypes: { type: Array, default: () => [] },
+  collapsed: { type: Boolean, default: false },
 })
-const emit = defineEmits(['drag-start'])
+const emit = defineEmits(['drag-start', 'toggle'])
 
 const { t } = useI18n()
 
@@ -42,6 +87,18 @@ const categories = computed(() =>
     }))
     .filter(cat => cat.types.length > 0)
 )
+
+const CATS_KEY = 'logic_palette_collapsed_cats'
+const savedCats = JSON.parse(localStorage.getItem(CATS_KEY) ?? '[]')
+const collapsedCategories = ref(new Set(savedCats))
+
+function toggleCategory(id) {
+  const next = new Set(collapsedCategories.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  collapsedCategories.value = next
+  localStorage.setItem(CATS_KEY, JSON.stringify([...next]))
+}
 
 function onDragStart(event, nodeType) {
   event.dataTransfer.setData('application/vueflow-node-type', nodeType.type)

--- a/gui/src/components/logic/NodePalette.vue
+++ b/gui/src/components/logic/NodePalette.vue
@@ -89,8 +89,12 @@ const categories = computed(() =>
 )
 
 const CATS_KEY = 'logic_palette_collapsed_cats'
-const savedCats = JSON.parse(localStorage.getItem(CATS_KEY) ?? '[]')
-const collapsedCategories = ref(new Set(savedCats))
+let _savedCats = []
+try {
+  const _parsed = JSON.parse(localStorage.getItem(CATS_KEY) ?? '[]')
+  if (Array.isArray(_parsed)) _savedCats = _parsed
+} catch { /* ignore malformed storage */ }
+const collapsedCategories = ref(new Set(_savedCats))
 
 function toggleCategory(id) {
   const next = new Set(collapsedCategories.value)

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -1321,6 +1321,8 @@
     "negatePort": "{id} negieren",
     "palette": {
       "title": "Blöcke",
+      "collapse": "Blockpalette einklappen",
+      "expand": "Blockpalette ausklappen",
       "categories": {
         "logic": "Logik",
         "datapoint": "Objekte",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -1321,6 +1321,8 @@
     "negatePort": "Negate {id}",
     "palette": {
       "title": "Blocks",
+      "collapse": "Collapse block palette",
+      "expand": "Expand block palette",
       "categories": {
         "logic": "Logic",
         "datapoint": "Objects",

--- a/gui/src/views/LogicView.vue
+++ b/gui/src/views/LogicView.vue
@@ -61,7 +61,12 @@
     <!-- Main area -->
     <div class="flex flex-1 overflow-hidden">
       <!-- Node Palette -->
-      <NodePalette v-if="auth.isAdmin" :node-types="store.nodeTypes" />
+      <NodePalette
+        v-if="auth.isAdmin"
+        :node-types="store.nodeTypes"
+        :collapsed="paletteCollapsed"
+        @toggle="paletteCollapsed = !paletteCollapsed"
+      />
 
       <!-- Canvas -->
       <div class="flex-1 relative" ref="canvasWrapper"
@@ -266,6 +271,9 @@ watch(() => activeGraph.value?.enabled, (enabled) => {
     },
   }))
 })
+const paletteCollapsed = ref(localStorage.getItem('logic_palette_collapsed') === '1')
+watch(paletteCollapsed, v => localStorage.setItem('logic_palette_collapsed', v ? '1' : '0'))
+
 const saving        = ref(false)
 const statusMsg     = ref(null)
 const canvasWrapper = ref(null)

--- a/gui/tests/components/logic/NodePalette.spec.js
+++ b/gui/tests/components/logic/NodePalette.spec.js
@@ -76,6 +76,20 @@ describe('NodePalette — expanded', () => {
     expect(wrapper.html()).toContain('display: none')
   })
 
+  it('falls back to no collapsed categories when localStorage value is malformed JSON', () => {
+    mockStorage({ logic_palette_collapsed_cats: 'not-json{{{' })
+    const wrapper = mountPalette()
+    expect(wrapper.findAll('.cursor-grab')).toHaveLength(3)
+    expect(wrapper.html()).not.toContain('display: none')
+  })
+
+  it('falls back to no collapsed categories when localStorage value is non-array JSON', () => {
+    mockStorage({ logic_palette_collapsed_cats: '"logic"' })
+    const wrapper = mountPalette()
+    expect(wrapper.findAll('.cursor-grab')).toHaveLength(3)
+    expect(wrapper.html()).not.toContain('display: none')
+  })
+
   it('emits drag-start and sets dataTransfer on dragstart', () => {
     const wrapper = mountPalette()
     const block = wrapper.findAll('.cursor-grab')[0]

--- a/gui/tests/components/logic/NodePalette.spec.js
+++ b/gui/tests/components/logic/NodePalette.spec.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NodePalette from '@/components/logic/NodePalette.vue'
+
+const NODE_TYPES = [
+  { type: 'and',          label: 'AND',     category: 'logic', color: '#4ade80' },
+  { type: 'or',           label: 'OR',      category: 'logic', color: '#4ade80' },
+  { type: 'math_formula', label: 'Formula', category: 'math',  color: '#60a5fa' },
+]
+
+function mockStorage(initial = {}) {
+  const store = { ...initial }
+  const storage = {
+    getItem:    vi.fn(k => store[k] ?? null),
+    setItem:    vi.fn((k, v) => { store[k] = v }),
+    removeItem: vi.fn(k => { delete store[k] }),
+    clear:      vi.fn(),
+  }
+  Object.defineProperty(window,      'localStorage', { value: storage, configurable: true })
+  Object.defineProperty(globalThis,  'localStorage', { value: storage, configurable: true })
+  return storage
+}
+
+function mountPalette(props = {}) {
+  return mount(NodePalette, { props: { nodeTypes: NODE_TYPES, ...props } })
+}
+
+// ── Expanded state ─────────────────────────────────────────────────────────
+
+describe('NodePalette — expanded', () => {
+  beforeEach(() => mockStorage())
+
+  it('renders all block items', () => {
+    const wrapper = mountPalette()
+    expect(wrapper.findAll('.cursor-grab')).toHaveLength(3)
+    expect(wrapper.text()).toContain('AND')
+    expect(wrapper.text()).toContain('OR')
+  })
+
+  it('emits toggle when the column header is clicked', async () => {
+    const wrapper = mountPalette()
+    await wrapper.findAll('button')[0].trigger('click')
+    expect(wrapper.emitted('toggle')).toHaveLength(1)
+  })
+
+  it('adds display:none to the block list when a section header is clicked', async () => {
+    const wrapper = mountPalette()
+    expect(wrapper.html()).not.toContain('display: none')
+
+    await wrapper.findAll('button')[1].trigger('click')
+
+    expect(wrapper.html()).toContain('display: none')
+  })
+
+  it('removes display:none when the same section header is clicked again', async () => {
+    const wrapper = mountPalette()
+    const sectionBtn = wrapper.findAll('button')[1]
+    await sectionBtn.trigger('click')
+    await sectionBtn.trigger('click')
+    expect(wrapper.html()).not.toContain('display: none')
+  })
+
+  it('persists collapsed category ids to localStorage', async () => {
+    const storage = mockStorage()
+    const wrapper = mountPalette()
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'logic_palette_collapsed_cats',
+      expect.stringContaining('logic')
+    )
+  })
+
+  it('restores previously collapsed categories from localStorage', () => {
+    mockStorage({ logic_palette_collapsed_cats: '["logic"]' })
+    const wrapper = mountPalette()
+    expect(wrapper.html()).toContain('display: none')
+  })
+
+  it('emits drag-start and sets dataTransfer on dragstart', () => {
+    const wrapper = mountPalette()
+    const block = wrapper.findAll('.cursor-grab')[0]
+    const dt = { setData: vi.fn(), effectAllowed: null }
+    block.trigger('dragstart', { dataTransfer: dt })
+    expect(dt.setData).toHaveBeenCalledWith('application/vueflow-node-type', 'and')
+    expect(wrapper.emitted('drag-start')).toBeTruthy()
+  })
+})
+
+// ── Collapsed state ────────────────────────────────────────────────────────
+
+describe('NodePalette — collapsed column', () => {
+  beforeEach(() => mockStorage())
+
+  it('does not render block items when collapsed', () => {
+    const wrapper = mountPalette({ collapsed: true })
+    expect(wrapper.findAll('.cursor-grab')).toHaveLength(0)
+  })
+
+  it('emits toggle when the expand button is clicked', async () => {
+    const wrapper = mountPalette({ collapsed: true })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('toggle')).toHaveLength(1)
+  })
+})

--- a/gui/tests/views/LogicView.auth.spec.js
+++ b/gui/tests/views/LogicView.auth.spec.js
@@ -574,6 +574,28 @@ describe('LogicView operation error handling', () => {
   })
 })
 
+describe('LogicView palette collapse', () => {
+  it('initialises paletteCollapsed from localStorage and persists changes', async () => {
+    const store = { logic_palette_collapsed: '1' }
+    const storage = {
+      getItem: vi.fn(k => store[k] ?? null),
+      setItem: vi.fn((k, v) => { store[k] = v }),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    }
+    Object.defineProperty(window,     'localStorage', { value: storage, configurable: true })
+    Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+
+    const { wrapper } = await mountLogicView({ isAdmin: true })
+
+    expect(wrapper.vm.paletteCollapsed).toBe(true)
+
+    wrapper.vm.paletteCollapsed = false
+    await flushPromises()
+    expect(storage.setItem).toHaveBeenCalledWith('logic_palette_collapsed', '0')
+  })
+})
+
 describe('LogicView import edge cases', () => {
   it('opens rename dialog when imported graph name already exists', async () => {
     const graph = makeGraph('graph-1')


### PR DESCRIPTION
Individual block sections (Logic, Objects, Math, …) can now be collapsed and expanded by clicking the section header. The entire palette column can also be collapsed to a slim rail by clicking the column header, and restored the same way. Both states persist across page reloads via localStorage.

Closes #875

<img width="560" height="490" alt="CleanShot 2026-06-26 at 21 02 13@2x" src="https://github.com/user-attachments/assets/3109699b-6133-456e-a378-ef62d48f1609" />
<img width="578" height="662" alt="CleanShot 2026-06-26 at 21 02 33@2x" src="https://github.com/user-attachments/assets/f94fbcec-e94e-46e2-a018-5614005672d0" />
<img width="482" height="1232" alt="CleanShot 2026-06-26 at 21 02 49@2x" src="https://github.com/user-attachments/assets/1ab56889-868c-4958-a0f4-134d9599d441" />
