### PR TITLE
[codex] Add MESSAGE notification adapter

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1223,6 +1223,37 @@ Verbindet sich mit einem **externen** MQTT-Broker (getrennt vom internen Mosquit
 
 ---
 
+### MESSAGE-Adapter
+
+Sendet Benachrichtigungen, wenn sich ein verknüpfter Datenpunkt ändert und die Bedingung der Verknüpfung erfüllt ist. Der Adapter ist als lesende Verknüpfung (`SOURCE`) konfiguriert, weil er Wertänderungen beobachtet und daraus Nachrichten auslöst.
+
+**Unterstützte Provider:**
+
+| Provider | Instanz-Felder | Ziel-Felder |
+|---|---|---|
+| `pushover` | `api_token` | `user_key` |
+| `telegram` | `bot_token` | `chat_id` |
+| `seven.io` | `api_key`, optional `sender` | `to`, `channel` (`sms`/`voice`) |
+
+**Verknüpfungs-Konfiguration:**
+
+| Feld | Beschreibung |
+|---|---|
+| `operator` | Bedingung: `any`, `==`, `!=`, `<`, `<=`, `>`, `>=`, `contains`, `contains not`, `starts with`, `ends with` |
+| `compare_value` | Vergleichswert; bei `any` nicht nötig |
+| `message` | Nachrichtenvorlage mit Platzhaltern |
+| `title` | Optionaler Nachrichtentitel |
+| `providers` | Liste aus Provider und Zielname, an die gesendet wird |
+| `send_on_change` | Sendet nur beim Wechsel in den erfüllten Zustand; bei `any` nur bei geändertem Wert |
+| `cooldown_seconds` | Mindestabstand zwischen zwei gesendeten Nachrichten |
+| `enabled` | Aktiviert/deaktiviert die Verknüpfung |
+
+Platzhalter in der Nachricht: `###DP###` = Wert, `###DPU###` = Einheit, `###DPN###` = Datenpunktname, `###DPI###` = Datenpunkt-ID, `###TS###` = Zeitstempel.
+
+> **Hinweis:** Signal wird im MESSAGE-Adapter vorerst nicht angeboten, weil dafür ein separater Signal-Gateway-Dienst betrieben werden müsste.
+
+---
+
 ### Home-Assistant-Adapter
 
 Verbindet **open bridge server** bidirektional mit einer Home-Assistant-Instanz. Empfängt Zustandsänderungen in Echtzeit über WebSocket (`state_changed`-Ereignisse) und schreibt Werte über die HA-REST-API (Dienst-Aufrufe).

--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,37 @@ Connects to an **external** MQTT broker (separate from the internal Mosquitto).
 
 ---
 
+### MESSAGE adapter
+
+Sends notifications when a linked data point changes and the binding condition is fulfilled. The binding uses the read direction (`SOURCE`) because the adapter observes value changes and turns them into messages.
+
+**Supported providers:**
+
+| Provider | Instance fields | Target fields |
+|---|---|---|
+| `pushover` | `api_token` | `user_key` |
+| `telegram` | `bot_token` | `chat_id` |
+| `seven.io` | `api_key`, optional `sender` | `to`, `channel` (`sms`/`voice`) |
+
+**Binding configuration:**
+
+| Field | Description |
+|---|---|
+| `operator` | Condition: `any`, `==`, `!=`, `<`, `<=`, `>`, `>=`, `contains`, `contains not`, `starts with`, `ends with` |
+| `compare_value` | Comparison value; not required for `any` |
+| `message` | Message template with placeholders |
+| `title` | Optional message title |
+| `providers` | List of provider and target name to send to |
+| `send_on_change` | Sends only when entering the fulfilled state; for `any`, only when the value changes |
+| `cooldown_seconds` | Minimum delay between two sent messages |
+| `enabled` | Enables/disables the binding |
+
+Message placeholders: `###DP###` = value, `###DPU###` = unit, `###DPN###` = data point name, `###DPI###` = data point ID, `###TS###` = timestamp.
+
+> **Note:** Signal is not offered by the MESSAGE adapter for now because it would require operating a separate Signal gateway service.
+
+---
+
 ### Home Assistant adapter
 
 Connects **open bridge server** bidirectionally to a Home Assistant instance. Receives state changes in real time via WebSocket (`state_changed` events) and writes values via the HA REST API (service calls).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,6 +19,7 @@
 * Visu: Link widget now supports hiding the icon via the "show_icon" option. https://github.com/abeggled/openbridgeserver/issues/839
 * Visu: Editor grid limits extended — columns up to 120, cell size down to 10 px, enabling fullscreen/dense layouts. https://github.com/abeggled/openbridgeserver/issues/842
 * Visu: Link and ButtonGroup widgets now support "preserve_icon_color" per widget/button — when enabled, SVG icons retain their original colors instead of being forced to black/white. https://github.com/abeggled/openbridgeserver/issues/845
+* Adapter/Admin GUI: New MESSAGE notification adapter sends messages on data point value changes with configurable conditions, `any` matching, cooldowns, templates, and targets. Supported providers are Pushover, Telegram, and seven.io SMS/Voice; Signal is intentionally not included for now because it would require a separate gateway service. https://github.com/abeggled/openbridgeserver/issues/882
 * Admin GUI: Logic editor block palette — individual block sections (Logic, Objects, Math, …) can now be collapsed and expanded by clicking the section header; the entire palette column can also be collapsed to a slim rail and restored the same way. Both states persist across page reloads. https://github.com/abeggled/openbridgeserver/issues/875
 * Admin GUI: The minimap in the logic editor can now be dragged to any position within the canvas; the position is saved and restored across page reloads. https://github.com/abeggled/openbridgeserver/issues/879
 

--- a/gui/src/components/adapters/MessageConfigForm.vue
+++ b/gui/src/components/adapters/MessageConfigForm.vue
@@ -6,7 +6,7 @@
           <input type="checkbox" :checked="providerConfig(provider.key).enabled" class="w-4 h-4 rounded" @change="setProvider(provider.key, { enabled: $event.target.checked })" />
           {{ provider.label }}
         </label>
-        <button type="button" class="btn-secondary btn-sm" @click="addTarget(provider.key)">
+        <button v-if="providerConfig(provider.key).enabled" type="button" class="btn-secondary btn-sm" @click="addTarget(provider.key)">
           {{ $t('adapters.message.addTarget') }}
         </button>
       </div>

--- a/gui/src/components/adapters/MessageConfigForm.vue
+++ b/gui/src/components/adapters/MessageConfigForm.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <div v-for="provider in PROVIDERS" :key="provider.key" class="border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+      <div class="flex items-center justify-between gap-3">
+        <label class="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+          <input type="checkbox" :checked="providerConfig(provider.key).enabled" class="w-4 h-4 rounded" @change="setProvider(provider.key, { enabled: $event.target.checked })" />
+          {{ provider.label }}
+        </label>
+        <button type="button" class="btn-secondary btn-sm" @click="addTarget(provider.key)">
+          {{ $t('adapters.message.addTarget') }}
+        </button>
+      </div>
+
+      <div v-if="providerConfig(provider.key).enabled" class="mt-3 flex flex-col gap-3">
+        <div class="grid grid-cols-2 gap-3">
+          <div v-for="field in provider.fields" :key="field.key" class="form-group">
+            <label class="label">{{ field.label }}</label>
+            <input
+              :type="field.secret ? 'password' : 'text'"
+              :value="providerConfig(provider.key)[field.key] ?? ''"
+              class="input"
+              @input="setProvider(provider.key, { [field.key]: $event.target.value })"
+            />
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <div
+            v-for="target in targetEntries(provider.key)"
+            :key="target.name"
+            class="grid gap-2 items-end"
+            :class="provider.key === 'seven.io' ? 'grid-cols-[1fr_1.3fr_0.8fr_auto]' : 'grid-cols-[1fr_1.5fr_auto]'"
+          >
+            <div class="form-group">
+              <label class="label">{{ $t('adapters.message.targetName') }}</label>
+              <input :value="target.name" class="input" @change="renameTarget(provider.key, target.name, $event.target.value)" />
+            </div>
+            <div class="form-group">
+              <label class="label">{{ targetLabel(provider.key) }}</label>
+              <input
+                :type="targetSecret(provider.key) ? 'password' : 'text'"
+                :value="targetValue(provider.key, target.config)"
+                class="input"
+                @input="setTargetValue(provider.key, target.name, $event.target.value)"
+              />
+            </div>
+            <div v-if="provider.key === 'seven.io'" class="form-group">
+              <label class="label">{{ $t('adapters.message.channel') }}</label>
+              <select :value="target.config.channel ?? 'sms'" class="input" @change="setTarget(provider.key, target.name, { channel: $event.target.value })">
+                <option value="sms">SMS</option>
+                <option value="voice">Voice</option>
+              </select>
+            </div>
+            <button type="button" class="btn-danger btn-sm mb-0.5" @click="removeTarget(provider.key, target.name)">
+              {{ $t('common.delete') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: { type: Object, default: () => ({}) },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const PROVIDERS = [
+  { key: 'pushover', label: 'Pushover', fields: [{ key: 'api_token', label: 'API Token', secret: true }] },
+  { key: 'telegram', label: 'Telegram', fields: [{ key: 'bot_token', label: 'Bot Token', secret: true }] },
+  {
+    key: 'seven.io',
+    label: 'seven.io',
+    fields: [
+      { key: 'api_key', label: 'API Key', secret: true },
+      { key: 'sender', label: 'Sender', secret: false },
+    ],
+  },
+]
+
+function cloneConfig() {
+  return {
+    ...props.modelValue,
+    providers: { ...(props.modelValue.providers ?? {}) },
+  }
+}
+
+function providerConfig(provider) {
+  return props.modelValue.providers?.[provider] ?? { enabled: false, targets: {} }
+}
+
+function setProvider(provider, patch) {
+  const next = cloneConfig()
+  next.providers[provider] = {
+    enabled: false,
+    targets: {},
+    ...(next.providers[provider] ?? {}),
+    ...patch,
+  }
+  emit('update:modelValue', next)
+}
+
+function targetEntries(provider) {
+  const targets = providerConfig(provider).targets ?? {}
+  return Object.entries(targets).map(([name, config]) => ({ name, config: config ?? {} }))
+}
+
+function targetLabel(provider) {
+  if (provider === 'pushover') return 'User Key'
+  if (provider === 'telegram') return 'Chat ID'
+  if (provider === 'seven.io') return 'To'
+  return 'Recipient'
+}
+
+function targetSecret(provider) {
+  return provider === 'pushover'
+}
+
+function targetValue(provider, config) {
+  if (provider === 'pushover') return config.user_key ?? ''
+  if (provider === 'telegram') return config.chat_id ?? ''
+  if (provider === 'seven.io') return config.to ?? ''
+  return config.recipient ?? ''
+}
+
+function targetValuePatch(provider, value) {
+  if (provider === 'pushover') return { user_key: value }
+  if (provider === 'telegram') return { chat_id: value }
+  if (provider === 'seven.io') return { to: value }
+  return { recipient: value }
+}
+
+function setTarget(provider, target, patch) {
+  const cfg = providerConfig(provider)
+  setProvider(provider, {
+    targets: {
+      ...(cfg.targets ?? {}),
+      [target]: {
+        ...((cfg.targets ?? {})[target] ?? {}),
+        ...patch,
+      },
+    },
+  })
+}
+
+function setTargetValue(provider, target, value) {
+  setTarget(provider, target, targetValuePatch(provider, value))
+}
+
+function addTarget(provider) {
+  const cfg = providerConfig(provider)
+  let name = 'default'
+  let n = 2
+  while ((cfg.targets ?? {})[name]) {
+    name = `target_${n}`
+    n += 1
+  }
+  const defaults = provider === 'seven.io' ? { channel: 'sms' } : {}
+  setTarget(provider, name, defaults)
+}
+
+function renameTarget(provider, oldName, rawName) {
+  const newName = String(rawName || '').trim()
+  if (!newName || newName === oldName) return
+  const cfg = providerConfig(provider)
+  const targets = { ...(cfg.targets ?? {}) }
+  if (targets[newName]) return
+  targets[newName] = targets[oldName]
+  delete targets[oldName]
+  setProvider(provider, { targets })
+}
+
+function removeTarget(provider, target) {
+  const cfg = providerConfig(provider)
+  const targets = { ...(cfg.targets ?? {}) }
+  delete targets[target]
+  setProvider(provider, { targets })
+}
+</script>

--- a/gui/src/components/adapters/MessageConfigForm.vue
+++ b/gui/src/components/adapters/MessageConfigForm.vue
@@ -172,6 +172,7 @@ function renameTarget(provider, oldName, rawName) {
   const targets = { ...(cfg.targets ?? {}) }
   if (targets[newName]) return
   targets[newName] = targets[oldName]
+  delete targets[oldName]
   setProvider(provider, { targets })
 }
 

--- a/gui/src/components/adapters/MessageConfigForm.vue
+++ b/gui/src/components/adapters/MessageConfigForm.vue
@@ -172,7 +172,6 @@ function renameTarget(provider, oldName, rawName) {
   const targets = { ...(cfg.targets ?? {}) }
   if (targets[newName]) return
   targets[newName] = targets[oldName]
-  delete targets[oldName]
   setProvider(provider, { targets })
 }
 

--- a/gui/src/components/adapters/MessageConfigForm.vue
+++ b/gui/src/components/adapters/MessageConfigForm.vue
@@ -62,23 +62,27 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 const props = defineProps({
   modelValue: { type: Object, default: () => ({}) },
 })
 const emit = defineEmits(['update:modelValue'])
+const { t } = useI18n()
 
-const PROVIDERS = [
-  { key: 'pushover', label: 'Pushover', fields: [{ key: 'api_token', label: 'API Token', secret: true }] },
-  { key: 'telegram', label: 'Telegram', fields: [{ key: 'bot_token', label: 'Bot Token', secret: true }] },
+const PROVIDERS = computed(() => [
+  { key: 'pushover', label: 'Pushover', fields: [{ key: 'api_token', label: t('adapters.message.apiToken'), secret: true }] },
+  { key: 'telegram', label: 'Telegram', fields: [{ key: 'bot_token', label: t('adapters.message.botToken'), secret: true }] },
   {
     key: 'seven.io',
     label: 'seven.io',
     fields: [
-      { key: 'api_key', label: 'API Key', secret: true },
-      { key: 'sender', label: 'Sender', secret: false },
+      { key: 'api_key', label: t('adapters.message.apiKey'), secret: true },
+      { key: 'sender', label: t('adapters.message.sender'), secret: false },
     ],
   },
-]
+])
 
 function cloneConfig() {
   return {
@@ -108,10 +112,10 @@ function targetEntries(provider) {
 }
 
 function targetLabel(provider) {
-  if (provider === 'pushover') return 'User Key'
-  if (provider === 'telegram') return 'Chat ID'
-  if (provider === 'seven.io') return 'To'
-  return 'Recipient'
+  if (provider === 'pushover') return t('adapters.message.userKey')
+  if (provider === 'telegram') return t('adapters.message.chatId')
+  if (provider === 'seven.io') return t('adapters.message.to')
+  return t('adapters.message.recipient')
 }
 
 function targetSecret(provider) {

--- a/gui/src/components/datapoints/BindingForm.vue
+++ b/gui/src/components/datapoints/BindingForm.vue
@@ -31,7 +31,7 @@
             </optgroup>
           </select>
         </div>
-        <div v-if="selectedAdapterType !== 'ANWESENHEITSSIMULATION'" class="form-group">
+        <div v-if="selectedAdapterType !== 'ANWESENHEITSSIMULATION' && selectedAdapterType !== 'MESSAGE'" class="form-group">
           <label class="label">{{ $t('adapters.bindingForm.directionLabel') }}</label>
           <select
             v-model="form.direction"
@@ -160,6 +160,13 @@
           :snmp-walk-error="snmpWalkError"
           :snmp-walk-has-more="snmpWalkHasMore"
           @snmp-walk="snmpWalk"
+        />
+
+      <!-- MESSAGE -->
+      <BindingFormMessage
+        v-if="selectedAdapterType === 'MESSAGE'"
+          :cfg="cfg"
+          :selected-instance="selectedInstance"
         />
 
       <div v-if="!selectedAdapterType && !props.initial" class="p-3 bg-slate-100/80 dark:bg-slate-800/40 rounded-lg text-sm text-slate-500 text-center">
@@ -306,6 +313,7 @@ import BindingFormIoBroker from '@/components/datapoints/binding-form/BindingFor
 import BindingFormTimer from '@/components/datapoints/binding-form/BindingFormTimer.vue'
 import BindingFormPresenceSimulation from '@/components/datapoints/binding-form/BindingFormPresenceSimulation.vue'
 import BindingFormSnmp from '@/components/datapoints/binding-form/BindingFormSnmp.vue'
+import BindingFormMessage from '@/components/datapoints/binding-form/BindingFormMessage.vue'
 
 const props = defineProps({
   dpId:           { type: String,  required: true },
@@ -379,6 +387,15 @@ const cfg = reactive({
   data_type: 'auto',
   timeout: 5.0,
   retries: 1,
+  // MESSAGE
+  operator: '==',
+  compare_value: '',
+  message: '###DPN###: ###DP### ###DPU###',
+  title: '',
+  providers: [],
+  priority: null,
+  cooldown_seconds: 0,
+  send_on_change: true,
   // ZEITSCHALTUHR
   timer_type: 'daily', meta_type: 'none',
   weekdays: [0,1,2,3,4,5,6], months: [], day_of_month: 0,
@@ -506,10 +523,11 @@ const currentInstanceName = computed(() => {
 })
 
 const selectedInstanceId = computed(() => props.initial?.adapter_instance_id || form.adapter_instance_id)
+const selectedInstance = computed(() => allInstances.value.find(i => String(i.id) === String(selectedInstanceId.value)) ?? null)
 
 const visibleTabs = computed(() => {
   const tabs = [{ id: 'conn', label: t('logic.nodeConfig.tabs.connection'), badge: false }]
-  if (selectedAdapterType.value && selectedAdapterType.value !== 'ZEITSCHALTUHR' && selectedAdapterType.value !== 'ANWESENHEITSSIMULATION') {
+  if (selectedAdapterType.value && !['ZEITSCHALTUHR', 'ANWESENHEITSSIMULATION', 'MESSAGE'].includes(selectedAdapterType.value)) {
     if (selectedAdapterType.value === 'IOBROKER' && !showAdvancedTabs.value) return tabs
     const hasFormula = !!form.value_formula?.trim() || !!form.value_map_preset
     tabs.push({ id: 'transform', label: t('logic.nodeConfig.tabs.transform'), badge: hasFormula })
@@ -634,6 +652,15 @@ watch(() => props.initial, val => {
   if (cfg.data_type == null) cfg.data_type = 'auto'
   if (cfg.timeout  == null) cfg.timeout  = 5.0
   if (cfg.retries  == null) cfg.retries  = 1
+  // MESSAGE defaults when loading
+  if (cfg.operator == null) cfg.operator = '=='
+  if (cfg.compare_value == null) cfg.compare_value = ''
+  if (cfg.message == null) cfg.message = '###DPN###: ###DP### ###DPU###'
+  if (cfg.title == null) cfg.title = ''
+  if (cfg.providers == null) cfg.providers = []
+  if (cfg.priority === undefined) cfg.priority = null
+  if (cfg.cooldown_seconds == null) cfg.cooldown_seconds = 0
+  if (cfg.send_on_change == null) cfg.send_on_change = true
   {
     const ANW_PRESETS = ['1', '7', '14']
     if (cfg.offset_override != null) {
@@ -843,9 +870,9 @@ watch(() => cfg.source_data_type, sdt => {
   if (sdt === 'json' || sdt === 'xml') loadMqttSample()
 })
 
-// Force direction to SOURCE when ZEITSCHALTUHR is selected
+// Force direction to SOURCE for adapters that observe values instead of writing.
 watch(selectedAdapterType, type => {
-  if (type === 'ZEITSCHALTUHR') form.direction = 'SOURCE'
+  if (type === 'ZEITSCHALTUHR' || type === 'MESSAGE') form.direction = 'SOURCE'
   if (type === 'IOBROKER') {
     activeTab.value = 'conn'
     showAdvancedTabs.value = false
@@ -1198,6 +1225,19 @@ function buildConfig() {
     if (cfg.retries !== undefined && cfg.retries !== 1) c.retries = cfg.retries
     return c
   }
+  if (type === 'MESSAGE') {
+    const c = {
+      operator: cfg.operator || '==',
+      compare_value: cfg.compare_value,
+      message: cfg.message || '###DPN###: ###DP### ###DPU###',
+      providers: [...(cfg.providers ?? [])],
+      send_on_change: cfg.send_on_change ?? true,
+      cooldown_seconds: cfg.cooldown_seconds ?? 0,
+    }
+    if (cfg.title?.trim()) c.title = cfg.title.trim()
+    if (cfg.priority != null) c.priority = cfg.priority
+    return c
+  }
   return {}
 }
 
@@ -1206,7 +1246,7 @@ async function submit() {
   saving.value = true
   try {
     const config     = buildConfig()
-    const effectiveDirection = selectedAdapterType.value === 'ANWESENHEITSSIMULATION' ? 'SOURCE' : form.direction
+    const effectiveDirection = ['ANWESENHEITSSIMULATION', 'MESSAGE'].includes(selectedAdapterType.value) ? 'SOURCE' : form.direction
     const throttleMs = form.throttle_value > 0
       ? Math.round(form.throttle_value * THROTTLE_FACTORS[form.throttle_unit]) : null
     let resolvedValueMap = null

--- a/gui/src/components/datapoints/BindingForm.vue
+++ b/gui/src/components/datapoints/BindingForm.vue
@@ -880,6 +880,12 @@ watch(selectedAdapterType, type => {
   if (type === 'SNMP' && !cfg.poll_interval) cfg.poll_interval = 30.0
 })
 
+watch(selectedInstanceId, (newId, oldId) => {
+  if (oldId && newId !== oldId && selectedAdapterType.value === 'MESSAGE') {
+    cfg.providers = []
+  }
+})
+
 // Zeitschaltuhr helpers
 function ztToggleWeekday(idx) {
   const i = cfg.weekdays.indexOf(idx)

--- a/gui/src/components/datapoints/binding-form/BindingFormMessage.vue
+++ b/gui/src/components/datapoints/binding-form/BindingFormMessage.vue
@@ -65,10 +65,18 @@ const props = defineProps({
 
 const OPERATORS = ['any', '=', '==', '<', '<=', '>', '>=', '!=', 'contains', 'contains not', 'starts with', 'ends with']
 
+function providerEnabled(config) {
+  if (config?.enabled === true || config?.enabled === 1) return true
+  if (typeof config?.enabled === 'string') {
+    return ['true', '1', 'yes', 'on'].includes(config.enabled.trim().toLowerCase())
+  }
+  return false
+}
+
 const providerOptions = computed(() => {
   const providers = props.selectedInstance?.config?.providers ?? {}
   return Object.entries(providers)
-    .filter(([, config]) => config?.enabled)
+    .filter(([, config]) => providerEnabled(config))
     .map(([provider, config]) => ({ provider, targets: Object.keys(config.targets ?? {}) }))
     .filter((entry) => entry.targets.length > 0)
 })

--- a/gui/src/components/datapoints/binding-form/BindingFormMessage.vue
+++ b/gui/src/components/datapoints/binding-form/BindingFormMessage.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="section-header">{{ $t('adapters.bindingForm.messageSection') }}</div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div class="form-group">
+      <label class="label">{{ $t('adapters.bindingForm.operatorLabel') }}</label>
+      <select v-model="cfg.operator" class="input">
+        <option v-for="op in OPERATORS" :key="op" :value="op">{{ op }}</option>
+      </select>
+    </div>
+    <div v-if="cfg.operator !== 'any'" class="form-group">
+      <label class="label">{{ $t('adapters.bindingForm.compareValueLabel') }}</label>
+      <input v-model="cfg.compare_value" class="input" />
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div class="form-group">
+      <label class="label">{{ $t('adapters.bindingForm.titleLabel') }}</label>
+      <input v-model="cfg.title" class="input" />
+    </div>
+    <div class="form-group">
+      <label class="label">{{ $t('adapters.bindingForm.cooldownSecondsLabel') }}</label>
+      <input v-model.number="cfg.cooldown_seconds" type="number" min="0" step="1" class="input" />
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="label">{{ $t('adapters.bindingForm.messageTemplateLabel') }}</label>
+    <textarea v-model="cfg.message" class="input min-h-24 font-mono text-sm resize-y" />
+    <p class="hint">###DP### · ###DPU### · ###DPN### · ###DPI### · ###TS###</p>
+  </div>
+
+  <div class="form-group">
+    <label class="label">{{ $t('adapters.bindingForm.targetsLabel') }}</label>
+    <div class="flex flex-col gap-2">
+      <div v-for="(_, idx) in cfg.providers" :key="idx" class="grid grid-cols-[1fr_1fr_auto] gap-2 items-center">
+        <select v-model="cfg.providers[idx].provider" class="input" @change="cfg.providers[idx].target = firstTarget(cfg.providers[idx].provider)">
+          <option v-for="provider in providerOptions" :key="provider.provider" :value="provider.provider">{{ provider.provider }}</option>
+        </select>
+        <select v-model="cfg.providers[idx].target" class="input">
+          <option v-for="target in targetsFor(cfg.providers[idx].provider)" :key="target" :value="target">{{ target }}</option>
+        </select>
+        <button type="button" class="btn-danger btn-sm" @click="cfg.providers.splice(idx, 1)">{{ $t('common.delete') }}</button>
+      </div>
+      <button type="button" class="btn-secondary btn-sm self-start" :disabled="providerOptions.length === 0" @click="addProviderTarget">
+        {{ $t('adapters.bindingForm.addTarget') }}
+      </button>
+    </div>
+  </div>
+
+  <label class="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+    <input type="checkbox" v-model="cfg.send_on_change" class="w-4 h-4 rounded" />
+    {{ $t('adapters.bindingForm.messageSendOnChange') }}
+  </label>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  cfg: { type: Object, required: true },
+  selectedInstance: { type: Object, default: null },
+})
+
+const OPERATORS = ['any', '=', '==', '<', '<=', '>', '>=', '!=', 'contains', 'contains not', 'starts with', 'ends with']
+
+const providerOptions = computed(() => {
+  const providers = props.selectedInstance?.config?.providers ?? {}
+  return Object.entries(providers)
+    .filter(([, config]) => config?.enabled)
+    .map(([provider, config]) => ({ provider, targets: Object.keys(config.targets ?? {}) }))
+    .filter((entry) => entry.targets.length > 0)
+})
+
+function targetsFor(provider) {
+  return providerOptions.value.find((entry) => entry.provider === provider)?.targets ?? []
+}
+
+function firstTarget(provider) {
+  return targetsFor(provider)[0] ?? ''
+}
+
+function addProviderTarget() {
+  const first = providerOptions.value[0]
+  if (!first) return
+  props.cfg.providers.push({ provider: first.provider, target: first.targets[0] })
+}
+</script>

--- a/gui/src/components/datapoints/binding-form/BindingFormMessage.vue
+++ b/gui/src/components/datapoints/binding-form/BindingFormMessage.vue
@@ -43,7 +43,7 @@
         </select>
         <button type="button" class="btn-danger btn-sm" @click="cfg.providers.splice(idx, 1)">{{ $t('common.delete') }}</button>
       </div>
-      <button type="button" class="btn-secondary btn-sm self-start" :disabled="providerOptions.length === 0" @click="addProviderTarget">
+      <button type="button" class="btn-secondary btn-sm self-start" :disabled="unusedProviderTargets.length === 0" @click="addProviderTarget">
         {{ $t('adapters.bindingForm.addTarget') }}
       </button>
     </div>
@@ -73,6 +73,20 @@ const providerOptions = computed(() => {
     .filter((entry) => entry.targets.length > 0)
 })
 
+const selectedPairs = computed(() => new Set((props.cfg.providers ?? []).map((ref) => `${ref.provider}\u0000${ref.target}`)))
+
+const unusedProviderTargets = computed(() => {
+  const unused = []
+  for (const option of providerOptions.value) {
+    for (const target of option.targets) {
+      if (!selectedPairs.value.has(`${option.provider}\u0000${target}`)) {
+        unused.push({ provider: option.provider, target })
+      }
+    }
+  }
+  return unused
+})
+
 function targetsFor(provider) {
   return providerOptions.value.find((entry) => entry.provider === provider)?.targets ?? []
 }
@@ -82,8 +96,8 @@ function firstTarget(provider) {
 }
 
 function addProviderTarget() {
-  const first = providerOptions.value[0]
+  const first = unusedProviderTargets.value[0]
   if (!first) return
-  props.cfg.providers.push({ provider: first.provider, target: first.targets[0] })
+  props.cfg.providers.push({ provider: first.provider, target: first.target })
 }
 </script>

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -258,7 +258,15 @@
     "message": {
       "addTarget": "Ziel hinzufügen",
       "targetName": "Zielname",
-      "channel": "Kanal"
+      "channel": "Kanal",
+      "apiToken": "API-Token",
+      "botToken": "Bot-Token",
+      "apiKey": "API-Schlüssel",
+      "sender": "Absender",
+      "userKey": "User-Key",
+      "chatId": "Chat-ID",
+      "to": "Empfänger",
+      "recipient": "Empfänger"
     },
     "anwesenheit": {
       "modalTitle": "Anwesenheitssimulation",
@@ -1003,7 +1011,9 @@
       "knxNoTunnelingInterfaces": "Keine Tunneling-Interfaces im Keyfile gefunden — bitte Individual Address im Keyfile prüfen.",
       "knxTunnelOverload": "KNX-Tunnel-Slot wahrscheinlich von anderem Client belegt — Gateway-Pool überlastet.",
       "knxTunnelStable": "Tunnel-Pool wieder stabil.",
-      "invalidBindingsSkipped": "{count} ungültige Verknüpfung(en) übersprungen ({examples})"
+      "invalidBindingsSkipped": "{count} ungültige Verknüpfung(en) übersprungen ({examples})",
+      "messageProviderFailures": "MESSAGE-Provider-Fehler: {count} Ziel(e)",
+      "messageSent": "MESSAGE gesendet"
     },
     "testResult": {
       "typeNotRegistered": "Adapter-Typ '{type}' nicht registriert",

--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -255,6 +255,11 @@
       "result": "{migrated} Verknüpfungen migriert, {skipped} übersprungen.",
       "failed": "Migration fehlgeschlagen"
     },
+    "message": {
+      "addTarget": "Ziel hinzufügen",
+      "targetName": "Zielname",
+      "channel": "Kanal"
+    },
     "anwesenheit": {
       "modalTitle": "Anwesenheitssimulation",
       "modalTitleFull": "Anwesenheitssimulation — {name}",
@@ -552,6 +557,15 @@
       "anwSetValuePlaceholder": "z.B. 0 / 1 / false / true / 21.5",
       "anwOnPresenceHint": "Leer = Verhalten aus der Adapter-Konfiguration verwenden.",
       "snmpSection": "SNMP Binding",
+      "messageSection": "MESSAGE Binding",
+      "operatorLabel": "Operator",
+      "compareValueLabel": "Vergleichswert",
+      "titleLabel": "Titel",
+      "cooldownSecondsLabel": "Cooldown (Sekunden)",
+      "messageTemplateLabel": "Nachrichtenvorlage",
+      "targetsLabel": "Ziele",
+      "addTarget": "Ziel hinzufügen",
+      "messageSendOnChange": "Nur beim Wechsel in den erfüllten Zustand senden",
       "snmpHostLabel": "Gerät (IP/DNS) *",
       "snmpHostPlaceholder": "z.B. 192.168.1.100 oder switch.local",
       "snmpPortLabel": "UDP-Port",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -258,7 +258,15 @@
     "message": {
       "addTarget": "Add target",
       "targetName": "Target name",
-      "channel": "Channel"
+      "channel": "Channel",
+      "apiToken": "API token",
+      "botToken": "Bot token",
+      "apiKey": "API key",
+      "sender": "Sender",
+      "userKey": "User key",
+      "chatId": "Chat ID",
+      "to": "Recipient",
+      "recipient": "Recipient"
     },
     "anwesenheit": {
       "modalTitle": "Presence simulation",
@@ -1003,7 +1011,9 @@
       "knxNoTunnelingInterfaces": "No tunneling interfaces found in keyfile — please check the individual address in the keyfile.",
       "knxTunnelOverload": "KNX tunnel slot likely occupied by another client — gateway pool overloaded.",
       "knxTunnelStable": "Tunnel pool stable again.",
-      "invalidBindingsSkipped": "{count} invalid binding(s) skipped ({examples})"
+      "invalidBindingsSkipped": "{count} invalid binding(s) skipped ({examples})",
+      "messageProviderFailures": "MESSAGE provider failures: {count} target(s)",
+      "messageSent": "MESSAGE sent"
     },
     "testResult": {
       "typeNotRegistered": "Adapter type '{type}' not registered",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -255,6 +255,11 @@
       "result": "{migrated} bindings migrated, {skipped} skipped.",
       "failed": "Migration failed"
     },
+    "message": {
+      "addTarget": "Add target",
+      "targetName": "Target name",
+      "channel": "Channel"
+    },
     "anwesenheit": {
       "modalTitle": "Presence simulation",
       "modalTitleFull": "Presence simulation — {name}",
@@ -552,6 +557,15 @@
       "anwSetValuePlaceholder": "e.g. 0 / 1 / false / true / 21.5",
       "anwOnPresenceHint": "Empty = use behavior from adapter configuration.",
       "snmpSection": "SNMP binding",
+      "messageSection": "MESSAGE binding",
+      "operatorLabel": "Operator",
+      "compareValueLabel": "Compare value",
+      "titleLabel": "Title",
+      "cooldownSecondsLabel": "Cooldown (seconds)",
+      "messageTemplateLabel": "Message template",
+      "targetsLabel": "Targets",
+      "addTarget": "Add target",
+      "messageSendOnChange": "Send only when the condition changes to fulfilled",
       "snmpHostLabel": "Device (IP/DNS) *",
       "snmpHostPlaceholder": "e.g. 192.168.1.100 or switch.local",
       "snmpPortLabel": "UDP port",

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -216,7 +216,7 @@
           </div>
 
           <div v-if="!isDemo" class="flex gap-3 flex-wrap">
-            <button v-if="a.adapter_type !== 'ANWESENHEITSSIMULATION' && a.adapter_type !== 'SNMP'" @click="testConnection(a)" class="btn-secondary btn-sm" :disabled="busy[a.id] === 'test'"
+            <button v-if="a.adapter_type !== 'ANWESENHEITSSIMULATION' && a.adapter_type !== 'SNMP' && a.adapter_type !== 'MESSAGE'" @click="testConnection(a)" class="btn-secondary btn-sm" :disabled="busy[a.id] === 'test'"
               :title="$t('adapters.testConnectionTitle')">
               <Spinner v-if="busy[a.id] === 'test'" size="xs" color="slate" />
               {{ $t('adapters.testConnection') }}

--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -58,6 +58,10 @@
               v-else-if="newForm.adapter_type === 'KNX'"
               v-model="newForm.config"
             />
+            <MessageConfigForm
+              v-else-if="newForm.adapter_type === 'MESSAGE'"
+              v-model="newForm.config"
+            />
             <template v-else>
               <SchemaForm
                 :schema="newSchema"
@@ -169,6 +173,10 @@
               />
               <KnxConfigForm
                 v-else-if="a.adapter_type === 'KNX'"
+                v-model="drafts[a.id].config"
+              />
+              <MessageConfigForm
+                v-else-if="a.adapter_type === 'MESSAGE'"
                 v-model="drafts[a.id].config"
               />
               <template v-else>
@@ -402,6 +410,7 @@ import ZeitschaltuhrCustomHolidaysEditor from '@/components/adapters/Zeitschaltu
 import AnwesenheitDatapointSelector from '@/components/adapters/AnwesenheitDatapointSelector.vue'
 import AnwesenheitConfigForm from '@/components/adapters/AnwesenheitConfigForm.vue'
 import KnxConfigForm        from '@/components/adapters/KnxConfigForm.vue'
+import MessageConfigForm    from '@/components/adapters/MessageConfigForm.vue'
 import Modal         from '@/components/ui/Modal.vue'
 import { adapterDotClass as dotClass, adapterBadgeVariant as statusBadgeVariant, adapterStatusLabel as statusLabel, adapterStatusDetailText } from '@/utils/adapterStatus'
 

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -120,8 +120,8 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2">
                 <span class="text-sm font-medium text-slate-700 dark:text-slate-200">{{ b.adapter_type }}</span>
-                <Badge :variant="b.direction === 'SOURCE' ? 'info' : b.direction === 'DEST' ? 'warning' : 'success'" size="xs">
-                  {{ b.direction === 'SOURCE' ? $t('datapoints.detail.bindingRead') : b.direction === 'DEST' ? $t('datapoints.detail.bindingWrite') : $t('datapoints.detail.bindingReadWrite') }}
+                <Badge :variant="bindingBadgeVariant(b)" size="xs">
+                  {{ bindingDirectionLabel(b) }}
                 </Badge>
                 <Badge v-if="!b.enabled" variant="danger" size="xs">{{ $t('datapoints.detail.bindingDisabled') }}</Badge>
               </div>
@@ -235,7 +235,7 @@ const displayVal = computed(() => {
 })
 const activeBindings = computed(() => bindings.value.filter(b => b.enabled))
 const canWriteValue = computed(() =>
-  bindingsLoaded.value && (activeBindings.value.length === 0 || activeBindings.value.some(b => ['DEST', 'BOTH'].includes(b.direction)))
+  bindingsLoaded.value && (activeBindings.value.length === 0 || activeBindings.value.some(b => b.adapter_type !== 'MESSAGE' && ['DEST', 'BOTH'].includes(b.direction)))
 )
 watch(currentRawValue, (value) => {
   if (!writeBusy.value && value !== undefined && value !== null) writeDraft.value = String(value)
@@ -253,6 +253,17 @@ onMounted(async () => {
   await Promise.all([loadBindings(), loadLogicUsages()])
 })
 onUnmounted(() => unsubWs?.())
+
+function bindingBadgeVariant(binding) {
+  if (binding.adapter_type === 'MESSAGE') return 'info'
+  return binding.direction === 'SOURCE' ? 'info' : binding.direction === 'DEST' ? 'warning' : 'success'
+}
+
+function bindingDirectionLabel(binding) {
+  if (binding.direction === 'SOURCE') return t('datapoints.detail.bindingRead')
+  if (binding.direction === 'DEST') return t('datapoints.detail.bindingWrite')
+  return t('datapoints.detail.bindingReadWrite')
+}
 
 async function loadBindings() {
   bindingsLoading.value = true

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -234,8 +234,9 @@ const displayVal = computed(() => {
   return dp.value?.unit ? `${v} ${dp.value.unit}` : String(v)
 })
 const activeBindings = computed(() => bindings.value.filter(b => b.enabled))
+const activeWritableBindings = computed(() => activeBindings.value.filter(b => b.adapter_type !== 'MESSAGE'))
 const canWriteValue = computed(() =>
-  bindingsLoaded.value && (activeBindings.value.length === 0 || activeBindings.value.some(b => b.adapter_type !== 'MESSAGE' && ['DEST', 'BOTH'].includes(b.direction)))
+  bindingsLoaded.value && (activeWritableBindings.value.length === 0 || activeWritableBindings.value.some(b => ['DEST', 'BOTH'].includes(b.direction)))
 )
 watch(currentRawValue, (value) => {
   if (!writeBusy.value && value !== undefined && value !== null) writeDraft.value = String(value)

--- a/gui/tests/components/adapters/MessageConfigForm.spec.js
+++ b/gui/tests/components/adapters/MessageConfigForm.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import MessageConfigForm from '@/components/adapters/MessageConfigForm.vue'
+
+function mountForm(initial = {}) {
+  let model = {
+    providers: {},
+    ...initial,
+  }
+  let wrapper
+  wrapper = mount(MessageConfigForm, {
+    props: {
+      modelValue: model,
+      'onUpdate:modelValue': async (next) => {
+        model = next
+        await wrapper.setProps({ modelValue: model })
+      },
+    },
+  })
+  return { wrapper, getModel: () => model }
+}
+
+describe('MessageConfigForm', () => {
+  it('enables a provider and updates provider fields', async () => {
+    const { wrapper, getModel } = mountForm()
+
+    await wrapper.find('input[type="checkbox"]').setChecked(true)
+    await flushPromises()
+    await wrapper.find('input[type="password"]').setValue('pushover-token')
+
+    expect(getModel().providers.pushover.enabled).toBe(true)
+    expect(getModel().providers.pushover.api_token).toBe('pushover-token')
+  })
+
+  it('adds, renames, updates, and removes a Pushover target', async () => {
+    const { wrapper, getModel } = mountForm()
+
+    await wrapper.find('input[type="checkbox"]').setChecked(true)
+    await flushPromises()
+    await wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
+    await flushPromises()
+
+    const targetInputs = wrapper.findAll('input').filter(input => input.attributes('type') !== 'checkbox')
+    await targetInputs[1].setValue('home')
+    await targetInputs[1].trigger('change')
+    await flushPromises()
+    await wrapper.findAll('input[type="password"]')[1].setValue('user-key')
+
+    expect(getModel().providers.pushover.targets.home.user_key).toBe('user-key')
+
+    await wrapper.findAll('button').find(button => button.text() === 'Löschen').trigger('click')
+    await flushPromises()
+    expect(getModel().providers.pushover.targets.home).toBeUndefined()
+  })
+
+  it('adds a seven.io target with SMS default and allows changing to voice', async () => {
+    const { wrapper, getModel } = mountForm()
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    const addButtons = wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')
+
+    await checkboxes[2].setChecked(true)
+    await flushPromises()
+    await addButtons[2].trigger('click')
+    await flushPromises()
+    expect(getModel().providers['seven.io'].targets.default.channel).toBe('sms')
+
+    const channelSelect = wrapper.findAll('select').find(select => select.find('option[value="voice"]').exists())
+    await channelSelect.setValue('voice')
+    expect(getModel().providers['seven.io'].targets.default.channel).toBe('voice')
+  })
+})

--- a/gui/tests/components/adapters/MessageConfigForm.spec.js
+++ b/gui/tests/components/adapters/MessageConfigForm.spec.js
@@ -69,6 +69,23 @@ describe('MessageConfigForm', () => {
     expect(getModel().providers['seven.io'].targets.default.channel).toBe('voice')
   })
 
+  it('creates unique seven.io target names and updates recipient', async () => {
+    const { wrapper, getModel } = mountForm({
+      providers: {
+        'seven.io': { enabled: true, targets: { default: { channel: 'sms' } } },
+      },
+    })
+    const addButtons = wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')
+
+    await addButtons[2].trigger('click')
+    await flushPromises()
+    const textInputs = wrapper.findAll('input').filter(input => input.attributes('type') === 'text')
+    await textInputs[textInputs.length - 1].setValue('+4100000000')
+
+    expect(getModel().providers['seven.io'].targets.target_2.channel).toBe('sms')
+    expect(getModel().providers['seven.io'].targets.target_2.to).toBe('+4100000000')
+  })
+
   it('updates a Telegram chat target', async () => {
     const { wrapper, getModel } = mountForm()
     const checkboxes = wrapper.findAll('input[type="checkbox"]')
@@ -85,5 +102,21 @@ describe('MessageConfigForm', () => {
 
     expect(getModel().providers.telegram.bot_token).toBe('bot-token')
     expect(getModel().providers.telegram.targets.default.chat_id).toBe('123456')
+  })
+
+  it('ignores empty and duplicate target renames', async () => {
+    const { wrapper, getModel } = mountForm({
+      providers: {
+        pushover: { enabled: true, targets: { default: {}, other: {} } },
+      },
+    })
+    const targetNameInputs = wrapper.findAll('input').filter(input => input.attributes('type') !== 'checkbox' && input.element.value !== undefined)
+
+    await targetNameInputs[0].setValue('')
+    await targetNameInputs[0].trigger('change')
+    await targetNameInputs[0].setValue('other')
+    await targetNameInputs[0].trigger('change')
+
+    expect(Object.keys(getModel().providers.pushover.targets).sort()).toEqual(['default', 'other'])
   })
 })

--- a/gui/tests/components/adapters/MessageConfigForm.spec.js
+++ b/gui/tests/components/adapters/MessageConfigForm.spec.js
@@ -50,11 +50,14 @@ describe('MessageConfigForm', () => {
     await targetInputs[1].setValue('home')
     await targetInputs[1].trigger('change')
     await flushPromises()
-    await wrapper.findAll('input[type="password"]')[1].setValue('user-key')
+    const passwordInputs = wrapper.findAll('input[type="password"]')
+    await passwordInputs[passwordInputs.length - 1].setValue('user-key')
 
     expect(getModel().providers.pushover.targets.home.user_key).toBe('user-key')
+    expect(getModel().providers.pushover.targets.default).toBeDefined()
 
-    await wrapper.findAll('button').find(button => button.text() === 'Löschen').trigger('click')
+    const deleteButtons = wrapper.findAll('button').filter(button => button.text() === 'Löschen')
+    await deleteButtons[deleteButtons.length - 1].trigger('click')
     await flushPromises()
     expect(getModel().providers.pushover.targets.home).toBeUndefined()
   })

--- a/gui/tests/components/adapters/MessageConfigForm.spec.js
+++ b/gui/tests/components/adapters/MessageConfigForm.spec.js
@@ -54,7 +54,7 @@ describe('MessageConfigForm', () => {
     await passwordInputs[passwordInputs.length - 1].setValue('user-key')
 
     expect(getModel().providers.pushover.targets.home.user_key).toBe('user-key')
-    expect(getModel().providers.pushover.targets.default).toBeDefined()
+    expect(getModel().providers.pushover.targets.default).toBeUndefined()
 
     const deleteButtons = wrapper.findAll('button').filter(button => button.text() === 'Löschen')
     await deleteButtons[deleteButtons.length - 1].trigger('click')

--- a/gui/tests/components/adapters/MessageConfigForm.spec.js
+++ b/gui/tests/components/adapters/MessageConfigForm.spec.js
@@ -68,4 +68,22 @@ describe('MessageConfigForm', () => {
     await channelSelect.setValue('voice')
     expect(getModel().providers['seven.io'].targets.default.channel).toBe('voice')
   })
+
+  it('updates a Telegram chat target', async () => {
+    const { wrapper, getModel } = mountForm()
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    const addButtons = wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')
+
+    await checkboxes[1].setChecked(true)
+    await flushPromises()
+    await wrapper.find('input[type="password"]').setValue('bot-token')
+    await addButtons[1].trigger('click')
+    await flushPromises()
+
+    const textInputs = wrapper.findAll('input').filter(input => input.attributes('type') === 'text')
+    await textInputs[textInputs.length - 1].setValue('123456')
+
+    expect(getModel().providers.telegram.bot_token).toBe('bot-token')
+    expect(getModel().providers.telegram.targets.default.chat_id).toBe('123456')
+  })
 })

--- a/gui/tests/components/adapters/MessageConfigForm.spec.js
+++ b/gui/tests/components/adapters/MessageConfigForm.spec.js
@@ -21,6 +21,12 @@ function mountForm(initial = {}) {
 }
 
 describe('MessageConfigForm', () => {
+  it('hides target buttons for disabled providers', () => {
+    const { wrapper } = mountForm()
+
+    expect(wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')).toHaveLength(0)
+  })
+
   it('enables a provider and updates provider fields', async () => {
     const { wrapper, getModel } = mountForm()
 
@@ -56,11 +62,10 @@ describe('MessageConfigForm', () => {
   it('adds a seven.io target with SMS default and allows changing to voice', async () => {
     const { wrapper, getModel } = mountForm()
     const checkboxes = wrapper.findAll('input[type="checkbox"]')
-    const addButtons = wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')
 
     await checkboxes[2].setChecked(true)
     await flushPromises()
-    await addButtons[2].trigger('click')
+    await wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
     await flushPromises()
     expect(getModel().providers['seven.io'].targets.default.channel).toBe('sms')
 
@@ -75,9 +80,8 @@ describe('MessageConfigForm', () => {
         'seven.io': { enabled: true, targets: { default: { channel: 'sms' } } },
       },
     })
-    const addButtons = wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')
 
-    await addButtons[2].trigger('click')
+    await wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
     await flushPromises()
     const textInputs = wrapper.findAll('input').filter(input => input.attributes('type') === 'text')
     await textInputs[textInputs.length - 1].setValue('+4100000000')
@@ -89,12 +93,11 @@ describe('MessageConfigForm', () => {
   it('updates a Telegram chat target', async () => {
     const { wrapper, getModel } = mountForm()
     const checkboxes = wrapper.findAll('input[type="checkbox"]')
-    const addButtons = wrapper.findAll('button').filter(button => button.text() === 'Ziel hinzufügen')
 
     await checkboxes[1].setChecked(true)
     await flushPromises()
     await wrapper.find('input[type="password"]').setValue('bot-token')
-    await addButtons[1].trigger('click')
+    await wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
     await flushPromises()
 
     const textInputs = wrapper.findAll('input').filter(input => input.attributes('type') === 'text')

--- a/gui/tests/components/datapoints/BindingForm.spec.js
+++ b/gui/tests/components/datapoints/BindingForm.spec.js
@@ -16,7 +16,15 @@ async function mountBindingForm(props) {
   }
   const adapterApi = {
     listInstances: vi.fn().mockResolvedValue({
-      data: [{ id: 'mqtt-inst-1', name: 'MQTT Test', adapter_type: 'MQTT' }],
+      data: [
+        { id: 'mqtt-inst-1', name: 'MQTT Test', adapter_type: 'MQTT' },
+        {
+          id: 'message-inst-1',
+          name: 'Notifications',
+          adapter_type: 'MESSAGE',
+          config: { providers: { pushover: { enabled: true, targets: { phone: {} } } } },
+        },
+      ],
     }),
     knxDpts: vi.fn().mockResolvedValue({ data: [] }),
     mqttBrowseTopics: vi.fn().mockResolvedValue({ data: [] }),
@@ -60,5 +68,15 @@ describe('BindingForm', () => {
     })
     expect(wrapper.find('[data-testid="input-mqtt-topic"]').exists()).toBe(true)
     expect(wrapper.find('#mqtt_retain').exists()).toBe(true)
+  })
+
+  it('zeigt MESSAGE-Felder ohne Richtungsauswahl und ohne Transform-Tabs', async () => {
+    const { wrapper } = await mountBindingForm({})
+    await wrapper.find('[data-testid="select-adapter-instance"]').setValue('message-inst-1')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('MESSAGE Binding')
+    expect(wrapper.find('[data-testid="select-direction"]').exists()).toBe(false)
+    expect(wrapper.findAll('.tab-btn').map(button => button.text())).toEqual(['Verbindung'])
   })
 })

--- a/gui/tests/components/datapoints/BindingForm.submit.spec.js
+++ b/gui/tests/components/datapoints/BindingForm.submit.spec.js
@@ -288,6 +288,40 @@ describe('BindingForm — MESSAGE create submit', () => {
     }))
     w.unmount()
   })
+
+  it('applies MESSAGE fallback defaults for empty optional config values', async () => {
+    const w = await mountForm({
+      initial: {
+        id: 'binding-message-defaults',
+        adapter_type: 'MESSAGE',
+        adapter_instance_id: 'msg-1',
+        direction: 'SOURCE',
+        enabled: true,
+        config: {
+          operator: '',
+          compare_value: null,
+          message: '',
+          providers: null,
+          send_on_change: null,
+          cooldown_seconds: null,
+        },
+      },
+    })
+    await submit(w)
+
+    expect(updateBinding).toHaveBeenCalledWith('dp-1', 'binding-message-defaults', expect.objectContaining({
+      direction: 'SOURCE',
+      config: expect.objectContaining({
+        operator: '==',
+        compare_value: '',
+        message: '###DPN###: ###DP### ###DPU###',
+        providers: [],
+        send_on_change: true,
+        cooldown_seconds: 0,
+      }),
+    }))
+    w.unmount()
+  })
 })
 
 // ─── Submit error handling ────────────────────────────────────────────────────

--- a/gui/tests/components/datapoints/BindingForm.submit.spec.js
+++ b/gui/tests/components/datapoints/BindingForm.submit.spec.js
@@ -20,6 +20,12 @@ const ALL_INSTANCES = [
     adapter_type: 'MESSAGE',
     config: { providers: { pushover: { enabled: true, targets: { phone: {} } } } },
   },
+  {
+    id: 'msg-2',
+    name: 'Message Test 2',
+    adapter_type: 'MESSAGE',
+    config: { providers: { telegram: { enabled: true, targets: { family: {} } } } },
+  },
 ]
 
 beforeEach(() => {
@@ -211,6 +217,27 @@ describe('BindingForm — ANWESENHEITSSIMULATION create submit', () => {
     const call = createBinding.mock.calls[0][1]
     // effectiveDirection for ANWESENHEITSSIMULATION is always 'SOURCE'
     expect(call.direction).toBe('SOURCE')
+    w.unmount()
+  })
+})
+
+// ─── MESSAGE submit ──────────────────────────────────────────────────────────
+
+describe('BindingForm — MESSAGE create submit', () => {
+  it('clears selected targets when the message instance changes', async () => {
+    const w = await mountForm()
+    await selectInstance(w, 'msg-1')
+    await w.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
+    await flushPromises()
+
+    await selectInstance(w, 'msg-2')
+    await submit(w)
+
+    expect(createBinding.mock.calls[0][1]).toEqual(expect.objectContaining({
+      adapter_instance_id: 'msg-2',
+      direction: 'SOURCE',
+      config: expect.objectContaining({ providers: [] }),
+    }))
     w.unmount()
   })
 })

--- a/gui/tests/components/datapoints/BindingForm.submit.spec.js
+++ b/gui/tests/components/datapoints/BindingForm.submit.spec.js
@@ -14,6 +14,12 @@ const ALL_INSTANCES = [
   { id: 'zt-1',     name: 'Timer Test',          adapter_type: 'ZEITSCHALTUHR' },
   { id: 'anw-1',    name: 'Anwesenheit Test',    adapter_type: 'ANWESENHEITSSIMULATION' },
   { id: 'snmp-1',   name: 'SNMP Test',           adapter_type: 'SNMP' },
+  {
+    id: 'msg-1',
+    name: 'Message Test',
+    adapter_type: 'MESSAGE',
+    config: { providers: { pushover: { enabled: true, targets: { phone: {} } } } },
+  },
 ]
 
 beforeEach(() => {
@@ -219,6 +225,66 @@ describe('BindingForm — SNMP create submit', () => {
     expect(createBinding).toHaveBeenCalledWith('dp-1', expect.objectContaining({
       adapter_instance_id: 'snmp-1',
       config:              expect.objectContaining({ host: '192.168.1.1' }),
+    }))
+    w.unmount()
+  })
+})
+
+// ─── MESSAGE submit ──────────────────────────────────────────────────────────
+
+describe('BindingForm — MESSAGE create submit', () => {
+  it('calls createBinding with MESSAGE config and forces SOURCE direction', async () => {
+    const w = await mountForm()
+    await selectInstance(w, 'msg-1')
+    await submit(w)
+
+    expect(createBinding).toHaveBeenCalledWith('dp-1', expect.objectContaining({
+      adapter_instance_id: 'msg-1',
+      direction: 'SOURCE',
+      config: expect.objectContaining({
+        operator: '==',
+        compare_value: '',
+        message: '###DPN###: ###DP### ###DPU###',
+        providers: [],
+        send_on_change: true,
+        cooldown_seconds: 0,
+      }),
+    }))
+    w.unmount()
+  })
+
+  it('preserves MESSAGE title, priority and provider targets in edit mode', async () => {
+    const w = await mountForm({
+      initial: {
+        id: 'binding-message',
+        adapter_type: 'MESSAGE',
+        adapter_instance_id: 'msg-1',
+        direction: 'DEST',
+        enabled: true,
+        config: {
+          operator: 'any',
+          compare_value: null,
+          message: '###DP###',
+          title: '  Alarm  ',
+          priority: 1,
+          providers: [{ provider: 'pushover', target: 'phone' }],
+          send_on_change: false,
+          cooldown_seconds: 30,
+        },
+      },
+    })
+    await submit(w)
+
+    expect(updateBinding).toHaveBeenCalledWith('dp-1', 'binding-message', expect.objectContaining({
+      direction: 'SOURCE',
+      config: expect.objectContaining({
+        operator: 'any',
+        title: 'Alarm',
+        priority: 1,
+        providers: [{ provider: 'pushover', target: 'phone' }],
+        send_on_change: false,
+        cooldown_seconds: 30,
+      }),
     }))
     w.unmount()
   })

--- a/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
+++ b/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
@@ -60,6 +60,23 @@ describe('BindingFormMessage', () => {
     expect(cfg.providers[0]).toEqual({ provider: 'telegram', target: 'family' })
   })
 
+  it('updates editable text and boolean fields', async () => {
+    const cfg = { title: '', cooldown_seconds: 0, message: 'old', send_on_change: true, providers: [] }
+    const wrapper = mk({ cfg })
+    const formCfg = wrapper.props('cfg')
+
+    const inputs = wrapper.findAll('input')
+    await inputs.find(input => input.element.value === '').setValue('Alarm')
+    await wrapper.find('input[type="number"]').setValue(42)
+    await wrapper.find('textarea').setValue('new template')
+    await wrapper.find('input[type="checkbox"]').setChecked(false)
+
+    expect(formCfg.title).toBe('Alarm')
+    expect(formCfg.cooldown_seconds).toBe(42)
+    expect(formCfg.message).toBe('new template')
+    expect(formCfg.send_on_change).toBe(false)
+  })
+
   it('disables add target when no configured provider targets exist', () => {
     const wrapper = mk({ selectedInstance: { config: { providers: {} } } })
 

--- a/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
+++ b/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BindingFormMessage from '@/components/datapoints/binding-form/BindingFormMessage.vue'
+
+function mk({ cfg = {}, selectedInstance = null } = {}) {
+  return mount(BindingFormMessage, {
+    props: {
+      cfg: {
+        operator: '==',
+        compare_value: 'true',
+        title: '',
+        cooldown_seconds: 0,
+        message: '###DPN###: ###DP###',
+        providers: [],
+        send_on_change: true,
+        ...cfg,
+      },
+      selectedInstance: selectedInstance ?? {
+        config: {
+          providers: {
+            pushover: { enabled: true, targets: { phone: {} } },
+            telegram: { enabled: true, targets: { family: {} } },
+            disabled: { enabled: false, targets: { hidden: {} } },
+          },
+        },
+      },
+    },
+  })
+}
+
+describe('BindingFormMessage', () => {
+  it('hides compare value when operator is any', async () => {
+    const wrapper = mk()
+    expect(wrapper.findAll('input').some(input => input.element.value === 'true')).toBe(true)
+
+    await wrapper.find('select').setValue('any')
+
+    expect(wrapper.findAll('input').some(input => input.element.value === 'true')).toBe(false)
+  })
+
+  it('adds and removes provider targets from enabled providers', async () => {
+    const cfg = { providers: [] }
+    const wrapper = mk({ cfg })
+
+    await wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
+
+    expect(cfg.providers).toEqual([{ provider: 'pushover', target: 'phone' }])
+    expect(wrapper.text()).not.toContain('hidden')
+
+    await wrapper.findAll('button').find(button => button.text() === 'Löschen').trigger('click')
+    expect(cfg.providers).toEqual([])
+  })
+
+  it('changes target when provider selection changes', async () => {
+    const cfg = { providers: [{ provider: 'pushover', target: 'phone' }] }
+    const wrapper = mk({ cfg })
+
+    await wrapper.findAll('select')[1].setValue('telegram')
+
+    expect(cfg.providers[0]).toEqual({ provider: 'telegram', target: 'family' })
+  })
+
+  it('disables add target when no configured provider targets exist', () => {
+    const wrapper = mk({ selectedInstance: { config: { providers: {} } } })
+
+    expect(wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').attributes('disabled')).toBeDefined()
+  })
+})

--- a/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
+++ b/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
@@ -51,6 +51,26 @@ describe('BindingFormMessage', () => {
     expect(cfg.providers).toEqual([])
   })
 
+  it('does not expose targets from string-disabled providers', async () => {
+    const cfg = { providers: [] }
+    const wrapper = mk({
+      cfg,
+      selectedInstance: {
+        config: {
+          providers: {
+            pushover: { enabled: 'false', targets: { hidden: {} } },
+            telegram: { enabled: 'true', targets: { family: {} } },
+          },
+        },
+      },
+    })
+
+    await wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen').trigger('click')
+
+    expect(cfg.providers).toEqual([{ provider: 'telegram', target: 'family' }])
+    expect(wrapper.text()).not.toContain('hidden')
+  })
+
   it('does not add duplicate provider target pairs', async () => {
     const cfg = { providers: [] }
     const wrapper = mk({

--- a/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
+++ b/gui/tests/components/datapoints/binding-form/BindingFormMessage.spec.js
@@ -51,6 +51,26 @@ describe('BindingFormMessage', () => {
     expect(cfg.providers).toEqual([])
   })
 
+  it('does not add duplicate provider target pairs', async () => {
+    const cfg = { providers: [] }
+    const wrapper = mk({
+      cfg,
+      selectedInstance: {
+        config: {
+          providers: {
+            pushover: { enabled: true, targets: { phone: {} } },
+          },
+        },
+      },
+    })
+    const addButton = () => wrapper.findAll('button').find(button => button.text() === 'Ziel hinzufügen')
+
+    await addButton().trigger('click')
+
+    expect(cfg.providers).toEqual([{ provider: 'pushover', target: 'phone' }])
+    expect(addButton().attributes('disabled')).toBeDefined()
+  })
+
   it('changes target when provider selection changes', async () => {
     const cfg = { providers: [{ provider: 'pushover', target: 'phone' }] }
     const wrapper = mk({ cfg })

--- a/gui/tests/views/AdaptersView.spec.js
+++ b/gui/tests/views/AdaptersView.spec.js
@@ -147,6 +147,18 @@ describe('AdaptersView — initial render', () => {
     expect(wrapper.text()).toContain('Telegram')
     expect(wrapper.text()).toContain('seven.io')
   })
+
+  it('renders the MESSAGE config form when editing MESSAGE instances', async () => {
+    const { wrapper } = await mountAdapters({
+      instances: [makeInstance({ id: 42, adapter_type: 'MESSAGE', name: 'Notifications', config: { providers: {} } })],
+    })
+    await wrapper.find('[data-testid="btn-expand-42"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Pushover')
+    expect(wrapper.text()).toContain('Telegram')
+    expect(wrapper.text()).toContain('seven.io')
+  })
 })
 
 // ─── Demo mode ───────────────────────────────────────────────────────────────

--- a/gui/tests/views/AdaptersView.spec.js
+++ b/gui/tests/views/AdaptersView.spec.js
@@ -422,6 +422,14 @@ describe('AdaptersView — test connection', () => {
 
     expect(wrapper.text()).toContain('Timeout')
   })
+
+  it('does not show the generic test button for MESSAGE instances', async () => {
+    const { wrapper } = await mountAdapters({ instances: [makeInstance({ adapter_type: 'MESSAGE', name: 'Nachrichten' })] })
+    await wrapper.find('[data-testid="btn-expand-1"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.findAll('button').some(b => b.text() === 'Verbindung testen')).toBe(false)
+  })
 })
 
 // ─── Restart instance ─────────────────────────────────────────────────────────

--- a/gui/tests/views/AdaptersView.spec.js
+++ b/gui/tests/views/AdaptersView.spec.js
@@ -135,6 +135,18 @@ describe('AdaptersView — initial render', () => {
     expect(select.html()).toContain('KNX')
     expect(select.html()).toContain('MQTT')
   })
+
+  it('renders the MESSAGE config form for new MESSAGE instances', async () => {
+    const { wrapper } = await mountAdapters({ types: ['MESSAGE'] })
+    await wrapper.find('[data-testid="btn-new-instance"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="select-adapter-type"]').setValue('MESSAGE')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Pushover')
+    expect(wrapper.text()).toContain('Telegram')
+    expect(wrapper.text()).toContain('seven.io')
+  })
 })
 
 // ─── Demo mode ───────────────────────────────────────────────────────────────

--- a/gui/tests/views/DataPointDetailView.spec.js
+++ b/gui/tests/views/DataPointDetailView.spec.js
@@ -90,6 +90,18 @@ describe('DataPointDetailView', () => {
     expect(wrapper.findAll('button').some(button => button.text() === 'Schreiben')).toBe(false)
   })
 
+  it('does not expose the write form for MESSAGE bindings even when direction is DEST', async () => {
+    apiMocks.dpApi.listBindings.mockResolvedValue({
+      data: [{ id: 'binding-message', enabled: true, direction: 'DEST', adapter_type: 'MESSAGE', config: {} }],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Kein schreibbares Binding vorhanden.')
+    expect(wrapper.find('input[type="text"]').exists()).toBe(false)
+  })
+
   it('does not expose the write form while bindings are still loading', async () => {
     let resolveBindings
     apiMocks.dpApi.listBindings.mockReturnValue(new Promise(resolve => { resolveBindings = resolve }))

--- a/gui/tests/views/DataPointDetailView.spec.js
+++ b/gui/tests/views/DataPointDetailView.spec.js
@@ -90,7 +90,7 @@ describe('DataPointDetailView', () => {
     expect(wrapper.findAll('button').some(button => button.text() === 'Schreiben')).toBe(false)
   })
 
-  it('does not expose the write form for MESSAGE bindings even when direction is DEST', async () => {
+  it('allows writing when only MESSAGE bindings are attached', async () => {
     apiMocks.dpApi.listBindings.mockResolvedValue({
       data: [{ id: 'binding-message', enabled: true, direction: 'DEST', adapter_type: 'MESSAGE', config: {} }],
     })
@@ -98,8 +98,8 @@ describe('DataPointDetailView', () => {
     const wrapper = mountView()
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Kein schreibbares Binding vorhanden.')
-    expect(wrapper.find('input[type="text"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Kein schreibbares Binding vorhanden.')
+    expect(wrapper.find('input[type="text"]').exists()).toBe(true)
   })
 
   it('does not expose the write form while bindings are still loading', async () => {

--- a/obs/adapters/message/__init__.py
+++ b/obs/adapters/message/__init__.py
@@ -1,0 +1,1 @@
+"""MESSAGE notification adapter package."""

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -50,10 +50,9 @@ class MessageAdapterConfig(BaseModel):
             provider = message_providers.get_provider(provider_type)
             if provider is None:
                 raise ValueError(f"Unknown MESSAGE provider: {provider_type}")
-            if provider_config.get("enabled", False):
+            parsed_without_targets = provider.config_schema(**{**provider_config, "targets": {}})
+            if getattr(parsed_without_targets, "enabled", False):
                 provider.config_schema(**provider_config)
-            else:
-                provider.config_schema(**{**provider_config, "targets": {}})
         return self
 
 
@@ -100,7 +99,7 @@ class _BindingState:
 
     def queue_pending_event(self, binding: Any, event: DataValueEvent, coalesce_key: Any = _NO_PENDING_COALESCE) -> None:
         if coalesce_key is not _NO_PENDING_COALESCE:
-            if _values_equal(coalesce_key, self.in_flight_key):
+            if not self.pending_events and _values_equal(coalesce_key, self.in_flight_key):
                 return
             for index, (_binding, _event, pending_key) in enumerate(self.pending_events):
                 if _values_equal(coalesce_key, pending_key):
@@ -345,7 +344,8 @@ class MessageAdapter(AdapterBase):
             results = [MessageSendResult("message", "internal", False, str(exc))]
 
         success = bool(results) and all(result.ok for result in results)
-        if success:
+        partial_success = bool(results) and any(result.ok for result in results)
+        if success or partial_success:
             state.last_sent_monotonic = time.monotonic()
             if state.reset_version == reset_version:
                 state.last_condition = True

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -6,6 +6,7 @@ plugins when a per-binding value condition is fulfilled.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -65,6 +66,7 @@ class _BindingState:
         self.last_condition: bool = False
         self.last_sent_monotonic: float | None = None
         self.last_value: Any = object()
+        self.in_flight: bool = False
 
 
 def _as_number(value: Any) -> float | None:
@@ -169,6 +171,7 @@ class MessageAdapter(AdapterBase):
         self._cfg = MessageAdapterConfig(**self._config)
         self._binding_map: dict[uuid.UUID, list[Any]] = {}
         self._states: dict[uuid.UUID, _BindingState] = {}
+        self._send_tasks: set[asyncio.Task] = set()
         self._subscribed = False
 
     async def connect(self) -> None:
@@ -181,6 +184,11 @@ class MessageAdapter(AdapterBase):
         if self._subscribed:
             self._bus.unsubscribe(DataValueEvent, self._on_value_event)
             self._subscribed = False
+        for task in self._send_tasks:
+            task.cancel()
+        if self._send_tasks:
+            await asyncio.gather(*self._send_tasks, return_exceptions=True)
+            self._send_tasks.clear()
         self._binding_map.clear()
         await self._publish_status(False, "Disconnected", code="disconnected")
 
@@ -252,11 +260,36 @@ class MessageAdapter(AdapterBase):
             datapoint_id=event.datapoint_id,
             ts=event.ts if event.ts.tzinfo else event.ts.replace(tzinfo=UTC),
         )
-        results = await self._send_to_targets(cfg, binding, event, rendered)
-        state.last_condition = True
-        state.last_value = event.value
-        if any(result.ok for result in results):
-            state.last_sent_monotonic = now
+        if state.in_flight and not ignore_repetition:
+            return
+        state.in_flight = True
+        task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, now))
+        self._send_tasks.add(task)
+        task.add_done_callback(self._send_tasks.discard)
+
+    async def _send_and_record(
+        self,
+        binding: Any,
+        event: DataValueEvent,
+        cfg: MessageBindingConfig,
+        rendered: str,
+        state: _BindingState,
+        sent_monotonic: float,
+    ) -> None:
+        try:
+            results = await self._send_to_targets(cfg, binding, event, rendered)
+        except Exception as exc:  # pragma: no cover - defensive guard for unexpected task errors
+            logger.exception("MESSAGE send task failed unexpectedly")
+            results = [MessageSendResult("message", "internal", False, str(exc))]
+        finally:
+            state.in_flight = False
+
+        success = any(result.ok for result in results)
+        if success:
+            state.last_condition = True
+            state.last_value = event.value
+            state.last_sent_monotonic = sent_monotonic
+
         failures = [result for result in results if not result.ok]
         if failures:
             detail = f"MESSAGE provider failures: {len(failures)} target(s)"

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -274,7 +274,7 @@ class MessageAdapter(AdapterBase):
             state.pending_events.append((binding, event))
             return
         state.in_flight = True
-        task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, now, reset_version))
+        task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, reset_version))
         self._send_tasks.add(task)
         task.add_done_callback(self._send_tasks.discard)
 
@@ -285,7 +285,6 @@ class MessageAdapter(AdapterBase):
         cfg: MessageBindingConfig,
         rendered: str,
         state: _BindingState,
-        sent_monotonic: float,
         reset_version: int,
     ) -> None:
         try:
@@ -295,10 +294,11 @@ class MessageAdapter(AdapterBase):
             results = [MessageSendResult("message", "internal", False, str(exc))]
 
         success = bool(results) and all(result.ok for result in results)
-        if success and state.reset_version == reset_version:
-            state.last_condition = True
-            state.last_value = event.value
-            state.last_sent_monotonic = sent_monotonic
+        if success:
+            state.last_sent_monotonic = time.monotonic()
+            if state.reset_version == reset_version:
+                state.last_condition = True
+                state.last_value = event.value
 
         failures = [result for result in results if not result.ok]
         if failures:
@@ -314,7 +314,8 @@ class MessageAdapter(AdapterBase):
             if not self._is_current_binding(pending_binding):
                 continue
             await self._handle_binding_event(pending_binding, pending_event)
-            break
+            if state.in_flight:
+                break
 
     def _is_current_binding(self, binding: Any) -> bool:
         return any(current is binding for current in self._binding_map.get(binding.datapoint_id, []))

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -64,6 +64,12 @@ class MessageBindingConfig(BaseModel):
     cooldown_seconds: int = Field(default=0, ge=0)
     enabled: bool = True
 
+    @model_validator(mode="after")
+    def _validate_targets(self) -> "MessageBindingConfig":
+        if self.enabled and not self.providers:
+            raise ValueError("MESSAGE binding requires at least one target")
+        return self
+
 
 class _BindingState:
     def __init__(self) -> None:
@@ -211,10 +217,9 @@ class MessageAdapter(AdapterBase):
                 continue
             if not cfg.enabled:
                 continue
-            self._binding_map.setdefault(binding.datapoint_id, []).append(binding)
             active_ids.add(binding.id)
-            state = self._states.setdefault(binding.id, _BindingState())
-            state.pending_events.clear()
+            self._binding_map.setdefault(binding.datapoint_id, []).append(binding)
+            self._states[binding.id] = _BindingState()
         for binding_id in list(self._states):
             if binding_id not in active_ids:
                 self._states.pop(binding_id, None)

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -26,6 +26,7 @@ from obs.core.json import json_dumps
 logger = logging.getLogger(__name__)
 
 MessageOperator = Literal["any", "=", "==", "<", "<=", ">", ">=", "!=", "contains", "contains not", "starts with", "ends with"]
+MAX_PENDING_EVENTS_PER_BINDING = 100
 
 
 class ProviderTargetRef(BaseModel):
@@ -79,6 +80,11 @@ class _BindingState:
         self.in_flight: bool = False
         self.reset_version: int = 0
         self.pending_events: deque[tuple[Any, DataValueEvent]] = deque()
+
+    def queue_pending_event(self, binding: Any, event: DataValueEvent) -> None:
+        if len(self.pending_events) >= MAX_PENDING_EVENTS_PER_BINDING:
+            self.pending_events.popleft()
+        self.pending_events.append((binding, event))
 
 
 def _as_number(value: Any) -> float | None:
@@ -276,7 +282,7 @@ class MessageAdapter(AdapterBase):
         )
         reset_version = state.reset_version
         if state.in_flight and not ignore_repetition:
-            state.pending_events.append((binding, event))
+            state.queue_pending_event(binding, event)
             return
         state.in_flight = True
         task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, reset_version))

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -45,7 +45,10 @@ class MessageAdapterConfig(BaseModel):
             provider = message_providers.get_provider(provider_type)
             if provider is None:
                 raise ValueError(f"Unknown MESSAGE provider: {provider_type}")
-            provider.config_schema(**provider_config)
+            if provider_config.get("enabled", False):
+                provider.config_schema(**provider_config)
+            else:
+                provider.config_schema(**{**provider_config, "targets": {}})
         return self
 
 
@@ -240,6 +243,7 @@ class MessageAdapter(AdapterBase):
         if not condition:
             state.last_condition = False
             state.reset_version += 1
+            state.pending_event = None
             return
 
         now = time.monotonic()

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -67,6 +67,8 @@ class _BindingState:
         self.last_sent_monotonic: float | None = None
         self.last_value: Any = object()
         self.in_flight: bool = False
+        self.reset_version: int = 0
+        self.pending_event: tuple[Any, DataValueEvent] | None = None
 
 
 def _as_number(value: Any) -> float | None:
@@ -196,7 +198,7 @@ class MessageAdapter(AdapterBase):
         self._binding_map.clear()
         active_ids: set[uuid.UUID] = set()
         for binding in self._bindings:
-            if binding.direction not in ("SOURCE", "BOTH"):
+            if binding.direction != "SOURCE":
                 continue
             try:
                 cfg = MessageBindingConfig(**binding.config)
@@ -237,6 +239,7 @@ class MessageAdapter(AdapterBase):
         state = self._states.setdefault(binding.id, _BindingState())
         if not condition:
             state.last_condition = False
+            state.reset_version += 1
             return
 
         now = time.monotonic()
@@ -260,10 +263,12 @@ class MessageAdapter(AdapterBase):
             datapoint_id=event.datapoint_id,
             ts=event.ts if event.ts.tzinfo else event.ts.replace(tzinfo=UTC),
         )
+        reset_version = state.reset_version
         if state.in_flight and not ignore_repetition:
+            state.pending_event = (binding, event)
             return
         state.in_flight = True
-        task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, now))
+        task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, now, reset_version))
         self._send_tasks.add(task)
         task.add_done_callback(self._send_tasks.discard)
 
@@ -275,17 +280,16 @@ class MessageAdapter(AdapterBase):
         rendered: str,
         state: _BindingState,
         sent_monotonic: float,
+        reset_version: int,
     ) -> None:
         try:
             results = await self._send_to_targets(cfg, binding, event, rendered)
         except Exception as exc:  # pragma: no cover - defensive guard for unexpected task errors
             logger.exception("MESSAGE send task failed unexpectedly")
             results = [MessageSendResult("message", "internal", False, str(exc))]
-        finally:
-            state.in_flight = False
 
-        success = any(result.ok for result in results)
-        if success:
+        success = bool(results) and all(result.ok for result in results)
+        if success and state.reset_version == reset_version:
             state.last_condition = True
             state.last_value = event.value
             state.last_sent_monotonic = sent_monotonic
@@ -296,6 +300,13 @@ class MessageAdapter(AdapterBase):
             await self._publish_status(True, detail, severity="warning", code="messageProviderFailures", params={"count": len(failures)})
         elif results:
             await self._publish_status(True, "MESSAGE sent", code="messageSent")
+
+        state.in_flight = False
+        pending = state.pending_event
+        state.pending_event = None
+        if pending is not None:
+            pending_binding, pending_event = pending
+            await self._handle_binding_event(pending_binding, pending_event)
 
     async def _send_to_targets(
         self,

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -67,6 +67,8 @@ class MessageBindingConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_targets(self) -> "MessageBindingConfig":
+        if not self.message.strip():
+            raise ValueError("MESSAGE binding message must not be empty")
         if self.enabled and not self.providers:
             raise ValueError("MESSAGE binding requires at least one target")
         seen_targets: set[tuple[str, str]] = set()

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import time
 import uuid
+from collections import deque
 from datetime import UTC, datetime
 from typing import Any, Literal
 
@@ -71,7 +72,7 @@ class _BindingState:
         self.last_value: Any = object()
         self.in_flight: bool = False
         self.reset_version: int = 0
-        self.pending_event: tuple[Any, DataValueEvent] | None = None
+        self.pending_events: deque[tuple[Any, DataValueEvent]] = deque()
 
 
 def _as_number(value: Any) -> float | None:
@@ -212,7 +213,8 @@ class MessageAdapter(AdapterBase):
                 continue
             self._binding_map.setdefault(binding.datapoint_id, []).append(binding)
             active_ids.add(binding.id)
-            self._states.setdefault(binding.id, _BindingState())
+            state = self._states.setdefault(binding.id, _BindingState())
+            state.pending_events.clear()
         for binding_id in list(self._states):
             if binding_id not in active_ids:
                 self._states.pop(binding_id, None)
@@ -243,7 +245,7 @@ class MessageAdapter(AdapterBase):
         if not condition:
             state.last_condition = False
             state.reset_version += 1
-            state.pending_event = None
+            state.pending_events.clear()
             return
 
         now = time.monotonic()
@@ -269,7 +271,7 @@ class MessageAdapter(AdapterBase):
         )
         reset_version = state.reset_version
         if state.in_flight and not ignore_repetition:
-            state.pending_event = (binding, event)
+            state.pending_events.append((binding, event))
             return
         state.in_flight = True
         task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, now, reset_version))
@@ -306,11 +308,16 @@ class MessageAdapter(AdapterBase):
             await self._publish_status(True, "MESSAGE sent", code="messageSent")
 
         state.in_flight = False
-        pending = state.pending_event
-        state.pending_event = None
-        if pending is not None:
+        while state.pending_events:
+            pending = state.pending_events.popleft()
             pending_binding, pending_event = pending
+            if not self._is_current_binding(pending_binding):
+                continue
             await self._handle_binding_event(pending_binding, pending_event)
+            break
+
+    def _is_current_binding(self, binding: Any) -> bool:
+        return any(current is binding for current in self._binding_map.get(binding.datapoint_id, []))
 
     async def _send_to_targets(
         self,

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 MessageOperator = Literal["any", "=", "==", "<", "<=", ">", ">=", "!=", "contains", "contains not", "starts with", "ends with"]
 MAX_PENDING_EVENTS_PER_BINDING = 100
+_NO_PENDING_COALESCE = object()
 
 
 class ProviderTargetRef(BaseModel):
@@ -88,13 +89,21 @@ class _BindingState:
         self.last_sent_monotonic: float | None = None
         self.last_value: Any = object()
         self.in_flight: bool = False
+        self.in_flight_key: Any = _NO_PENDING_COALESCE
         self.reset_version: int = 0
-        self.pending_events: deque[tuple[Any, DataValueEvent]] = deque()
+        self.pending_events: deque[tuple[Any, DataValueEvent, Any]] = deque()
 
-    def queue_pending_event(self, binding: Any, event: DataValueEvent) -> None:
+    def queue_pending_event(self, binding: Any, event: DataValueEvent, coalesce_key: Any = _NO_PENDING_COALESCE) -> None:
+        if coalesce_key is not _NO_PENDING_COALESCE:
+            if _values_equal(coalesce_key, self.in_flight_key):
+                return
+            for index, (_binding, _event, pending_key) in enumerate(self.pending_events):
+                if _values_equal(coalesce_key, pending_key):
+                    self.pending_events[index] = (binding, event, coalesce_key)
+                    return
         if len(self.pending_events) >= MAX_PENDING_EVENTS_PER_BINDING:
             self.pending_events.popleft()
-        self.pending_events.append((binding, event))
+        self.pending_events.append((binding, event, coalesce_key))
 
 
 def _binding_config(binding: Any) -> MessageBindingConfig:
@@ -108,6 +117,19 @@ def _as_number(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _values_equal(left: Any, right: Any) -> bool:
+    try:
+        return left == right
+    except Exception:
+        return False
+
+
+def _pending_coalesce_key(cfg: MessageBindingConfig, event: DataValueEvent) -> Any:
+    if not cfg.send_on_change:
+        return _NO_PENDING_COALESCE
+    return event.value if cfg.operator == "any" else True
 
 
 def _as_bool(value: Any) -> bool | None:
@@ -269,6 +291,7 @@ class MessageAdapter(AdapterBase):
         state = self._states.setdefault(binding.id, _BindingState())
         if not condition:
             state.last_condition = False
+            state.in_flight_key = _NO_PENDING_COALESCE
             state.reset_version += 1
             state.pending_events.clear()
             return
@@ -296,9 +319,10 @@ class MessageAdapter(AdapterBase):
         )
         reset_version = state.reset_version
         if state.in_flight and not ignore_repetition:
-            state.queue_pending_event(binding, event)
+            state.queue_pending_event(binding, event, _pending_coalesce_key(cfg, event))
             return
         state.in_flight = True
+        state.in_flight_key = _pending_coalesce_key(cfg, event) if not ignore_repetition else _NO_PENDING_COALESCE
         task = asyncio.create_task(self._send_and_record(binding, event, cfg, rendered, state, reset_version))
         self._send_tasks.add(task)
         task.add_done_callback(self._send_tasks.discard)
@@ -333,9 +357,10 @@ class MessageAdapter(AdapterBase):
             await self._publish_status(True, "MESSAGE sent", code="messageSent")
 
         state.in_flight = False
+        state.in_flight_key = _NO_PENDING_COALESCE
         while state.pending_events:
             pending = state.pending_events.popleft()
-            pending_binding, pending_event = pending
+            pending_binding, pending_event, _pending_key = pending
             if not self._is_current_binding(pending_binding):
                 continue
             await self._handle_binding_event(pending_binding, pending_event)

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -69,6 +69,12 @@ class MessageBindingConfig(BaseModel):
     def _validate_targets(self) -> "MessageBindingConfig":
         if self.enabled and not self.providers:
             raise ValueError("MESSAGE binding requires at least one target")
+        seen_targets: set[tuple[str, str]] = set()
+        for ref in self.providers:
+            key = (ref.provider, ref.target)
+            if key in seen_targets:
+                raise ValueError(f"Duplicate MESSAGE target: {ref.provider}/{ref.target}")
+            seen_targets.add(key)
         return self
 
 

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -75,6 +75,8 @@ class MessageBindingConfig(BaseModel):
             if key in seen_targets:
                 raise ValueError(f"Duplicate MESSAGE target: {ref.provider}/{ref.target}")
             seen_targets.add(key)
+        if self.priority == 2 and any(ref.provider == "pushover" for ref in self.providers):
+            raise ValueError("Pushover emergency priority is not supported")
         return self
 
 
@@ -91,6 +93,10 @@ class _BindingState:
         if len(self.pending_events) >= MAX_PENDING_EVENTS_PER_BINDING:
             self.pending_events.popleft()
         self.pending_events.append((binding, event))
+
+
+def _binding_config(binding: Any) -> MessageBindingConfig:
+    return MessageBindingConfig(**{**binding.config, "enabled": bool(getattr(binding, "enabled", True))})
 
 
 def _as_number(value: Any) -> float | None:
@@ -223,7 +229,7 @@ class MessageAdapter(AdapterBase):
             if binding.direction != "SOURCE":
                 continue
             try:
-                cfg = MessageBindingConfig(**binding.config)
+                cfg = _binding_config(binding)
             except Exception:
                 logger.warning("Invalid MESSAGE binding config for %s skipped", binding.id)
                 continue
@@ -256,7 +262,7 @@ class MessageAdapter(AdapterBase):
             await self._handle_binding_event(binding, event)
 
     async def _handle_binding_event(self, binding: Any, event: DataValueEvent, *, ignore_repetition: bool = False) -> None:
-        cfg = MessageBindingConfig(**binding.config)
+        cfg = _binding_config(binding)
         condition = evaluate_condition(event.value, cfg.operator, cfg.compare_value)
         state = self._states.setdefault(binding.id, _BindingState())
         if not condition:

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 import uuid
 from collections import deque
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 MessageOperator = Literal["any", "=", "==", "<", "<=", ">", ">=", "!=", "contains", "contains not", "starts with", "ends with"]
 MAX_PENDING_EVENTS_PER_BINDING = 100
 _NO_PENDING_COALESCE = object()
+_PLACEHOLDER_PATTERN = re.compile("###(?:DP|DPU|DPN|DPI|TS)###")
 
 
 class ProviderTargetRef(BaseModel):
@@ -78,8 +80,11 @@ class MessageBindingConfig(BaseModel):
             if key in seen_targets:
                 raise ValueError(f"Duplicate MESSAGE target: {ref.provider}/{ref.target}")
             seen_targets.add(key)
-        if self.priority == 2 and any(ref.provider == "pushover" for ref in self.providers):
-            raise ValueError("Pushover emergency priority is not supported")
+        if self.priority is not None and any(ref.provider == "pushover" for ref in self.providers):
+            if self.priority == 2:
+                raise ValueError("Pushover emergency priority is not supported")
+            if self.priority not in {-2, -1, 0, 1}:
+                raise ValueError("Pushover priority must be one of -2, -1, 0 or 1")
         return self
 
 
@@ -208,10 +213,7 @@ def render_message(template: str, *, value: Any, unit: str | None, name: str, da
         "###DPI###": str(datapoint_id),
         "###TS###": ts.isoformat(),
     }
-    rendered = template
-    for placeholder, replacement in replacements.items():
-        rendered = rendered.replace(placeholder, replacement)
-    return rendered
+    return _PLACEHOLDER_PATTERN.sub(lambda match: replacements[match.group(0)], template)
 
 
 @register

--- a/obs/adapters/message/adapter.py
+++ b/obs/adapters/message/adapter.py
@@ -1,0 +1,334 @@
+"""MESSAGE adapter.
+
+Observes DataValueEvent updates and sends notifications through provider
+plugins when a per-binding value condition is fulfilled.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from obs.adapters.base import AdapterBase
+from obs.adapters.message import providers as message_providers
+from obs.adapters.message.providers.base import MessageSendResult
+from obs.adapters.registry import register
+from obs.core.event_bus import DataValueEvent
+from obs.core.json import json_dumps
+
+logger = logging.getLogger(__name__)
+
+MessageOperator = Literal["any", "=", "==", "<", "<=", ">", ">=", "!=", "contains", "contains not", "starts with", "ends with"]
+
+
+class ProviderTargetRef(BaseModel):
+    provider: str
+    target: str
+
+
+class MessageAdapterConfig(BaseModel):
+    providers: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        title="Provider",
+        description="Provider-Konfigurationen, z. B. pushover, telegram oder seven.io mit targets.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_providers(self) -> "MessageAdapterConfig":
+        for provider_type, provider_config in self.providers.items():
+            provider = message_providers.get_provider(provider_type)
+            if provider is None:
+                raise ValueError(f"Unknown MESSAGE provider: {provider_type}")
+            provider.config_schema(**provider_config)
+        return self
+
+
+class MessageBindingConfig(BaseModel):
+    operator: MessageOperator = Field(default="==")
+    compare_value: Any = None
+    message: str = Field(default="###DPN###: ###DP### ###DPU###")
+    title: str | None = None
+    providers: list[ProviderTargetRef] = Field(default_factory=list)
+    priority: int | None = None
+    send_on_change: bool = True
+    cooldown_seconds: int = Field(default=0, ge=0)
+    enabled: bool = True
+
+
+class _BindingState:
+    def __init__(self) -> None:
+        self.last_condition: bool = False
+        self.last_sent_monotonic: float | None = None
+        self.last_value: Any = object()
+
+
+def _as_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return None
+
+
+def evaluate_condition(value: Any, operator: str, compare_value: Any) -> bool:
+    """Evaluate a MESSAGE binding condition without raising for bad input."""
+    op = "==" if operator == "=" else operator
+    if op == "any":
+        return True
+    if op in {"==", "!="}:
+        left_bool = _as_bool(value)
+        right_bool = _as_bool(compare_value)
+        if left_bool is not None and right_bool is not None:
+            equal = left_bool is right_bool
+        else:
+            left_number = _as_number(value)
+            right_number = _as_number(compare_value)
+            if left_number is not None and right_number is not None:
+                equal = left_number == right_number
+            else:
+                equal = str(value) == str(compare_value)
+        return equal if op == "==" else not equal
+
+    if op in {"<", "<=", ">", ">="}:
+        left_number = _as_number(value)
+        right_number = _as_number(compare_value)
+        if left_number is None or right_number is None:
+            return False
+        if op == "<":
+            return left_number < right_number
+        if op == "<=":
+            return left_number <= right_number
+        if op == ">":
+            return left_number > right_number
+        return left_number >= right_number
+
+    left = "" if value is None else str(value)
+    right = "" if compare_value is None else str(compare_value)
+    if op == "contains":
+        return right in left
+    if op == "contains not":
+        return right not in left
+    if op == "starts with":
+        return left.startswith(right)
+    if op == "ends with":
+        return left.endswith(right)
+    return False
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json_dumps(value)
+
+
+def render_message(template: str, *, value: Any, unit: str | None, name: str, datapoint_id: uuid.UUID, ts: datetime) -> str:
+    replacements = {
+        "###DP###": _format_value(value),
+        "###DPU###": unit or "",
+        "###DPN###": name,
+        "###DPI###": str(datapoint_id),
+        "###TS###": ts.isoformat(),
+    }
+    rendered = template
+    for placeholder, replacement in replacements.items():
+        rendered = rendered.replace(placeholder, replacement)
+    return rendered
+
+
+@register
+class MessageAdapter(AdapterBase):
+    adapter_type = "MESSAGE"
+    config_schema = MessageAdapterConfig
+    binding_config_schema = MessageBindingConfig
+
+    def __init__(self, event_bus: Any, config: dict | None = None, **kwargs) -> None:
+        super().__init__(event_bus, config, **kwargs)
+        self._cfg = MessageAdapterConfig(**self._config)
+        self._binding_map: dict[uuid.UUID, list[Any]] = {}
+        self._states: dict[uuid.UUID, _BindingState] = {}
+        self._subscribed = False
+
+    async def connect(self) -> None:
+        if not self._subscribed:
+            self._bus.subscribe(DataValueEvent, self._on_value_event)
+            self._subscribed = True
+        await self._publish_status(True, "MESSAGE adapter ready", code="connected")
+
+    async def disconnect(self) -> None:
+        if self._subscribed:
+            self._bus.unsubscribe(DataValueEvent, self._on_value_event)
+            self._subscribed = False
+        self._binding_map.clear()
+        await self._publish_status(False, "Disconnected", code="disconnected")
+
+    async def _on_bindings_reloaded(self) -> None:
+        self._binding_map.clear()
+        active_ids: set[uuid.UUID] = set()
+        for binding in self._bindings:
+            if binding.direction not in ("SOURCE", "BOTH"):
+                continue
+            try:
+                cfg = MessageBindingConfig(**binding.config)
+            except Exception:
+                logger.warning("Invalid MESSAGE binding config for %s skipped", binding.id)
+                continue
+            if not cfg.enabled:
+                continue
+            self._binding_map.setdefault(binding.datapoint_id, []).append(binding)
+            active_ids.add(binding.id)
+            self._states.setdefault(binding.id, _BindingState())
+        for binding_id in list(self._states):
+            if binding_id not in active_ids:
+                self._states.pop(binding_id, None)
+
+    async def read(self, binding: Any) -> Any:
+        return None
+
+    async def write(self, binding: Any, value: Any) -> None:
+        event = DataValueEvent(
+            datapoint_id=binding.datapoint_id,
+            value=value,
+            quality="good",
+            source_adapter=self.adapter_type,
+            binding_id=binding.id,
+        )
+        await self._handle_binding_event(binding, event, ignore_repetition=True)
+
+    async def _on_value_event(self, event: DataValueEvent) -> None:
+        if event.quality != "good":
+            return
+        for binding in self._binding_map.get(event.datapoint_id, []):
+            await self._handle_binding_event(binding, event)
+
+    async def _handle_binding_event(self, binding: Any, event: DataValueEvent, *, ignore_repetition: bool = False) -> None:
+        cfg = MessageBindingConfig(**binding.config)
+        condition = evaluate_condition(event.value, cfg.operator, cfg.compare_value)
+        state = self._states.setdefault(binding.id, _BindingState())
+        if not condition:
+            state.last_condition = False
+            return
+
+        now = time.monotonic()
+        if not ignore_repetition:
+            if cfg.send_on_change and cfg.operator == "any" and event.value == state.last_value:
+                return
+            if cfg.send_on_change and cfg.operator != "any" and state.last_condition:
+                return
+            if cfg.cooldown_seconds and state.last_sent_monotonic is not None:
+                elapsed = now - state.last_sent_monotonic
+                if elapsed < cfg.cooldown_seconds:
+                    state.last_condition = True
+                    return
+
+        dp = _lookup_datapoint(event.datapoint_id)
+        rendered = render_message(
+            cfg.message,
+            value=event.value,
+            unit=getattr(dp, "unit", None),
+            name=getattr(dp, "name", str(event.datapoint_id)),
+            datapoint_id=event.datapoint_id,
+            ts=event.ts if event.ts.tzinfo else event.ts.replace(tzinfo=UTC),
+        )
+        results = await self._send_to_targets(cfg, binding, event, rendered)
+        state.last_condition = True
+        state.last_value = event.value
+        if any(result.ok for result in results):
+            state.last_sent_monotonic = now
+        failures = [result for result in results if not result.ok]
+        if failures:
+            detail = f"MESSAGE provider failures: {len(failures)} target(s)"
+            await self._publish_status(True, detail, severity="warning", code="messageProviderFailures", params={"count": len(failures)})
+        elif results:
+            await self._publish_status(True, "MESSAGE sent", code="messageSent")
+
+    async def _send_to_targets(
+        self,
+        cfg: MessageBindingConfig,
+        binding: Any,
+        event: DataValueEvent,
+        rendered: str,
+    ) -> list[MessageSendResult]:
+        results: list[MessageSendResult] = []
+        context = {
+            "datapoint_id": str(event.datapoint_id),
+            "binding_id": str(binding.id),
+            "value": event.value,
+            "ts": event.ts.isoformat(),
+            "priority": cfg.priority,
+        }
+        for ref in cfg.providers:
+            provider = message_providers.get_provider(ref.provider)
+            if provider is None:
+                logger.warning("MESSAGE provider '%s' is not registered", ref.provider)
+                results.append(MessageSendResult(ref.provider, ref.target, False, "provider not registered"))
+                continue
+            provider_config = self._cfg.providers.get(ref.provider)
+            if not provider_config:
+                results.append(MessageSendResult(ref.provider, ref.target, False, "provider not configured"))
+                continue
+            try:
+                parsed_provider_config = provider.config_schema(**provider_config)
+            except Exception:
+                logger.exception("MESSAGE provider '%s' config is invalid", ref.provider)
+                results.append(MessageSendResult(ref.provider, ref.target, False, "provider config invalid"))
+                continue
+            if not getattr(parsed_provider_config, "enabled", False):
+                results.append(MessageSendResult(ref.provider, ref.target, False, "provider disabled"))
+                continue
+            targets = getattr(parsed_provider_config, "targets", {}) or {}
+            target_config = targets.get(ref.target)
+            if target_config is None:
+                results.append(MessageSendResult(ref.provider, ref.target, False, "target not configured"))
+                continue
+            try:
+                result = await provider.send(
+                    provider_config=provider_config,
+                    target_name=ref.target,
+                    target_config=_model_dump(target_config),
+                    title=cfg.title,
+                    message=rendered,
+                    context=context,
+                )
+                results.append(result)
+            except Exception:
+                logger.exception("MESSAGE provider '%s' target '%s' failed", ref.provider, ref.target)
+                results.append(MessageSendResult(ref.provider, ref.target, False, "send failed"))
+        return results
+
+
+def _model_dump(value: Any) -> dict[str, Any]:
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    return dict(value)
+
+
+def _lookup_datapoint(datapoint_id: uuid.UUID) -> Any | None:
+    try:
+        from obs.core.registry import get_registry
+
+        return get_registry().get(datapoint_id)
+    except Exception:
+        return None

--- a/obs/adapters/message/providers/__init__.py
+++ b/obs/adapters/message/providers/__init__.py
@@ -1,0 +1,19 @@
+"""Built-in MESSAGE provider registrations."""
+
+from obs.adapters.message.providers.pushover import PushoverProvider
+from obs.adapters.message.providers.sevenio import SevenIoProvider
+from obs.adapters.message.providers.telegram import TelegramProvider
+from obs.adapters.message.providers.registry import all_providers, get_provider, register_provider
+
+register_provider(PushoverProvider())
+register_provider(TelegramProvider())
+register_provider(SevenIoProvider())
+
+__all__ = [
+    "PushoverProvider",
+    "SevenIoProvider",
+    "TelegramProvider",
+    "all_providers",
+    "get_provider",
+    "register_provider",
+]

--- a/obs/adapters/message/providers/base.py
+++ b/obs/adapters/message/providers/base.py
@@ -1,0 +1,34 @@
+"""Provider protocol and shared result models for the MESSAGE adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from pydantic import BaseModel
+
+
+@dataclass(frozen=True)
+class MessageSendResult:
+    provider: str
+    target: str
+    ok: bool
+    detail: str = ""
+
+
+class MessageProvider(Protocol):
+    provider_type: str
+    config_schema: type[BaseModel]
+    target_schema: type[BaseModel]
+
+    async def send(
+        self,
+        *,
+        provider_config: dict[str, Any],
+        target_name: str,
+        target_config: dict[str, Any],
+        title: str | None,
+        message: str,
+        context: dict[str, Any],
+    ) -> MessageSendResult:
+        """Send a notification to one provider target."""

--- a/obs/adapters/message/providers/pushover.py
+++ b/obs/adapters/message/providers/pushover.py
@@ -58,4 +58,26 @@ class PushoverProvider:
             response = await client.post("https://api.pushover.net/1/messages.json", data=payload)
         if response.status_code >= 400:
             return MessageSendResult("pushover", target_name, False, f"HTTP {response.status_code}")
+        ok, detail = _pushover_response_ok(response)
+        if not ok:
+            return MessageSendResult("pushover", target_name, False, detail)
         return MessageSendResult("pushover", target_name, True)
+
+
+def _pushover_response_ok(response: httpx.Response) -> tuple[bool, str]:
+    try:
+        body = response.json()
+    except Exception:
+        return True, ""
+
+    if not isinstance(body, dict) or "status" not in body:
+        return True, ""
+
+    status = body["status"]
+    if status is True or status == 1 or (isinstance(status, str) and status.strip().lower() in {"1", "true"}):
+        return True, ""
+
+    errors = body.get("errors")
+    if isinstance(errors, list) and errors:
+        return False, "; ".join(str(error) for error in errors)
+    return False, f"pushover status={status}"

--- a/obs/adapters/message/providers/pushover.py
+++ b/obs/adapters/message/providers/pushover.py
@@ -1,0 +1,61 @@
+"""Pushover MESSAGE provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from obs.adapters.message.providers.base import MessageSendResult
+
+
+class PushoverConfig(BaseModel):
+    enabled: bool = False
+    api_token: str = Field(default="", json_schema_extra={"format": "password"})
+    targets: dict[str, "PushoverTarget"] = Field(default_factory=dict)
+
+
+class PushoverTarget(BaseModel):
+    user_key: str = Field(default="", json_schema_extra={"format": "password"})
+    device: str | None = None
+    sound: str | None = None
+
+
+class PushoverProvider:
+    provider_type = "pushover"
+    config_schema = PushoverConfig
+    target_schema = PushoverTarget
+
+    async def send(
+        self,
+        *,
+        provider_config: dict[str, Any],
+        target_name: str,
+        target_config: dict[str, Any],
+        title: str | None,
+        message: str,
+        context: dict[str, Any],
+    ) -> MessageSendResult:
+        cfg = PushoverConfig(**provider_config)
+        target = PushoverTarget(**target_config)
+        payload: dict[str, Any] = {
+            "token": cfg.api_token,
+            "user": target.user_key,
+            "message": message,
+        }
+        if title:
+            payload["title"] = title
+        if target.device:
+            payload["device"] = target.device
+        if target.sound:
+            payload["sound"] = target.sound
+        priority = context.get("priority")
+        if priority is not None:
+            payload["priority"] = priority
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post("https://api.pushover.net/1/messages.json", data=payload)
+        if response.status_code >= 400:
+            return MessageSendResult("pushover", target_name, False, f"HTTP {response.status_code}")
+        return MessageSendResult("pushover", target_name, True)

--- a/obs/adapters/message/providers/pushover.py
+++ b/obs/adapters/message/providers/pushover.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from obs.adapters.message.providers.base import MessageSendResult
 
@@ -15,11 +15,23 @@ class PushoverConfig(BaseModel):
     api_token: str = Field(default="", json_schema_extra={"format": "password"})
     targets: dict[str, "PushoverTarget"] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def _validate_enabled_provider(self) -> "PushoverConfig":
+        if self.enabled and not self.api_token.strip():
+            raise ValueError("Pushover api_token is required when provider is enabled")
+        return self
+
 
 class PushoverTarget(BaseModel):
     user_key: str = Field(default="", json_schema_extra={"format": "password"})
     device: str | None = None
     sound: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "PushoverTarget":
+        if not self.user_key.strip():
+            raise ValueError("Pushover user_key is required")
+        return self
 
 
 class PushoverProvider:

--- a/obs/adapters/message/providers/pushover.py
+++ b/obs/adapters/message/providers/pushover.py
@@ -64,6 +64,8 @@ class PushoverProvider:
             payload["sound"] = target.sound
         priority = context.get("priority")
         if priority is not None:
+            if priority == 2:
+                return MessageSendResult("pushover", target_name, False, "pushover priority=2 requires retry and expire")
             payload["priority"] = priority
 
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/obs/adapters/message/providers/registry.py
+++ b/obs/adapters/message/providers/registry.py
@@ -1,0 +1,22 @@
+"""Provider registry for the MESSAGE adapter."""
+
+from __future__ import annotations
+
+from obs.adapters.message.providers.base import MessageProvider
+
+_providers: dict[str, MessageProvider] = {}
+
+
+def register_provider(provider: MessageProvider) -> MessageProvider:
+    if not provider.provider_type:
+        raise ValueError("MESSAGE provider_type must not be empty")
+    _providers[provider.provider_type] = provider
+    return provider
+
+
+def get_provider(provider_type: str) -> MessageProvider | None:
+    return _providers.get(provider_type)
+
+
+def all_providers() -> dict[str, MessageProvider]:
+    return dict(_providers)

--- a/obs/adapters/message/providers/sevenio.py
+++ b/obs/adapters/message/providers/sevenio.py
@@ -53,7 +53,7 @@ class SevenIoProvider:
         if sender:
             payload["from"] = sender
         endpoint = "voice" if target.channel == SevenIoChannel.VOICE else "sms"
-        headers = {"X-Api-Key": cfg.api_key}
+        headers = {"X-Api-Key": cfg.api_key, "Accept": "application/json"}
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(f"https://gateway.seven.io/api/{endpoint}", data=payload, headers=headers)
         if response.status_code >= 400:
@@ -71,10 +71,12 @@ def _sevenio_response_ok(response: httpx.Response) -> tuple[bool, str]:
         body_text = (getattr(response, "text", "") or "").strip()
         if not body_text:
             return True, ""
+        code = body_text.split()[0].strip()
+        if code in {"1", "100"}:
+            return True, ""
         try:
             body = json.loads(body_text)
         except json.JSONDecodeError:
-            code = body_text.split()[0].strip()
             return (code == "100", f"seven.io code {code}" if code != "100" else "")
 
     if not isinstance(body, dict | list):

--- a/obs/adapters/message/providers/sevenio.py
+++ b/obs/adapters/message/providers/sevenio.py
@@ -107,7 +107,16 @@ def _is_success_value(value: Any) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, int | float):
-        return value != 0
+        return value == 100
     if isinstance(value, str):
-        return value.strip().lower() not in {"", "0", "false", "no", "failed", "error"}
+        normalized = value.strip().lower()
+        if normalized == "100":
+            return True
+        if normalized in {"true", "ok", "success"}:
+            return True
+        if normalized in {"", "0", "false", "no", "failed", "error"}:
+            return False
+        if normalized.isdecimal():
+            return False
+        return True
     return bool(value)

--- a/obs/adapters/message/providers/sevenio.py
+++ b/obs/adapters/message/providers/sevenio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from enum import Enum
 from typing import Any
 
@@ -57,4 +58,56 @@ class SevenIoProvider:
             response = await client.post(f"https://gateway.seven.io/api/{endpoint}", data=payload, headers=headers)
         if response.status_code >= 400:
             return MessageSendResult("seven.io", target_name, False, f"HTTP {response.status_code}")
+        ok, detail = _sevenio_response_ok(response)
+        if not ok:
+            return MessageSendResult("seven.io", target_name, False, detail)
         return MessageSendResult("seven.io", target_name, True)
+
+
+def _sevenio_response_ok(response: httpx.Response) -> tuple[bool, str]:
+    try:
+        body = response.json()
+    except Exception:
+        body_text = (getattr(response, "text", "") or "").strip()
+        if not body_text:
+            return True, ""
+        try:
+            body = json.loads(body_text)
+        except json.JSONDecodeError:
+            code = body_text.split()[0].strip()
+            return (code == "100", f"seven.io code {code}" if code != "100" else "")
+
+    if not isinstance(body, dict | list):
+        code = str(body).strip()
+        return (code == "100", f"seven.io code {code}" if code != "100" else "")
+
+    success_values = _collect_success_values(body)
+    if success_values and not all(_is_success_value(value) for value in success_values):
+        return False, "seven.io response success=false"
+    return True, ""
+
+
+def _collect_success_values(value: Any) -> list[Any]:
+    if isinstance(value, dict):
+        values = []
+        if "success" in value:
+            values.append(value["success"])
+        for nested in value.values():
+            values.extend(_collect_success_values(nested))
+        return values
+    if isinstance(value, list):
+        values = []
+        for nested in value:
+            values.extend(_collect_success_values(nested))
+        return values
+    return []
+
+
+def _is_success_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() not in {"", "0", "false", "no", "failed", "error"}
+    return bool(value)

--- a/obs/adapters/message/providers/sevenio.py
+++ b/obs/adapters/message/providers/sevenio.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from obs.adapters.message.providers.base import MessageSendResult
 
@@ -23,11 +23,23 @@ class SevenIoConfig(BaseModel):
     sender: str | None = None
     targets: dict[str, "SevenIoTarget"] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def _validate_enabled_provider(self) -> "SevenIoConfig":
+        if self.enabled and not self.api_key.strip():
+            raise ValueError("seven.io api_key is required when provider is enabled")
+        return self
+
 
 class SevenIoTarget(BaseModel):
     to: str
     channel: SevenIoChannel = SevenIoChannel.SMS
     sender: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "SevenIoTarget":
+        if not self.to.strip():
+            raise ValueError("seven.io to is required")
+        return self
 
 
 class SevenIoProvider:

--- a/obs/adapters/message/providers/sevenio.py
+++ b/obs/adapters/message/providers/sevenio.py
@@ -1,0 +1,60 @@
+"""seven.io SMS and Voice MESSAGE provider."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from obs.adapters.message.providers.base import MessageSendResult
+
+
+class SevenIoChannel(str, Enum):
+    SMS = "sms"
+    VOICE = "voice"
+
+
+class SevenIoConfig(BaseModel):
+    enabled: bool = False
+    api_key: str = Field(default="", json_schema_extra={"format": "password"})
+    sender: str | None = None
+    targets: dict[str, "SevenIoTarget"] = Field(default_factory=dict)
+
+
+class SevenIoTarget(BaseModel):
+    to: str
+    channel: SevenIoChannel = SevenIoChannel.SMS
+    sender: str | None = None
+
+
+class SevenIoProvider:
+    provider_type = "seven.io"
+    config_schema = SevenIoConfig
+    target_schema = SevenIoTarget
+
+    async def send(
+        self,
+        *,
+        provider_config: dict[str, Any],
+        target_name: str,
+        target_config: dict[str, Any],
+        title: str | None,
+        message: str,
+        context: dict[str, Any],
+    ) -> MessageSendResult:
+        cfg = SevenIoConfig(**provider_config)
+        target = SevenIoTarget(**target_config)
+        text = f"{title}: {message}" if title else message
+        payload: dict[str, Any] = {"to": target.to, "text": text}
+        sender = target.sender or cfg.sender
+        if sender:
+            payload["from"] = sender
+        endpoint = "voice" if target.channel == SevenIoChannel.VOICE else "sms"
+        headers = {"X-Api-Key": cfg.api_key}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(f"https://gateway.seven.io/api/{endpoint}", data=payload, headers=headers)
+        if response.status_code >= 400:
+            return MessageSendResult("seven.io", target_name, False, f"HTTP {response.status_code}")
+        return MessageSendResult("seven.io", target_name, True)

--- a/obs/adapters/message/providers/telegram.py
+++ b/obs/adapters/message/providers/telegram.py
@@ -1,0 +1,52 @@
+"""Telegram Bot API MESSAGE provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from obs.adapters.message.providers.base import MessageSendResult
+
+
+class TelegramConfig(BaseModel):
+    enabled: bool = False
+    bot_token: str = Field(default="", json_schema_extra={"format": "password"})
+    targets: dict[str, "TelegramTarget"] = Field(default_factory=dict)
+
+
+class TelegramTarget(BaseModel):
+    chat_id: str
+    disable_notification: bool = False
+
+
+class TelegramProvider:
+    provider_type = "telegram"
+    config_schema = TelegramConfig
+    target_schema = TelegramTarget
+
+    async def send(
+        self,
+        *,
+        provider_config: dict[str, Any],
+        target_name: str,
+        target_config: dict[str, Any],
+        title: str | None,
+        message: str,
+        context: dict[str, Any],
+    ) -> MessageSendResult:
+        cfg = TelegramConfig(**provider_config)
+        target = TelegramTarget(**target_config)
+        text = f"{title}\n{message}" if title else message
+        payload = {
+            "chat_id": target.chat_id,
+            "text": text,
+            "disable_notification": target.disable_notification,
+        }
+        url = f"https://api.telegram.org/bot{cfg.bot_token}/sendMessage"
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(url, json=payload)
+        if response.status_code >= 400:
+            return MessageSendResult("telegram", target_name, False, f"HTTP {response.status_code}")
+        return MessageSendResult("telegram", target_name, True)

--- a/obs/adapters/message/providers/telegram.py
+++ b/obs/adapters/message/providers/telegram.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from obs.adapters.message.providers.base import MessageSendResult
 
@@ -15,10 +15,22 @@ class TelegramConfig(BaseModel):
     bot_token: str = Field(default="", json_schema_extra={"format": "password"})
     targets: dict[str, "TelegramTarget"] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def _validate_enabled_provider(self) -> "TelegramConfig":
+        if self.enabled and not self.bot_token.strip():
+            raise ValueError("Telegram bot_token is required when provider is enabled")
+        return self
+
 
 class TelegramTarget(BaseModel):
     chat_id: str
     disable_notification: bool = False
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "TelegramTarget":
+        if not self.chat_id.strip():
+            raise ValueError("Telegram chat_id is required")
+        return self
 
 
 class TelegramProvider:

--- a/obs/adapters/message/providers/telegram.py
+++ b/obs/adapters/message/providers/telegram.py
@@ -49,4 +49,24 @@ class TelegramProvider:
             response = await client.post(url, json=payload)
         if response.status_code >= 400:
             return MessageSendResult("telegram", target_name, False, f"HTTP {response.status_code}")
+        ok, detail = _telegram_response_ok(response)
+        if not ok:
+            return MessageSendResult("telegram", target_name, False, detail)
         return MessageSendResult("telegram", target_name, True)
+
+
+def _telegram_response_ok(response: httpx.Response) -> tuple[bool, str]:
+    try:
+        body = response.json()
+    except Exception:
+        return True, ""
+
+    if not isinstance(body, dict) or "ok" not in body:
+        return True, ""
+    if body["ok"] is True:
+        return True, ""
+
+    description = body.get("description")
+    if description:
+        return False, str(description)
+    return False, "telegram ok=false"

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -457,7 +457,7 @@ async def migrate_instance_bindings(
     if source_row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Quell-Instanz nicht gefunden")
 
-    target_row = await db.fetchone("SELECT id, adapter_type FROM adapter_instances WHERE id=?", (target_id,))
+    target_row = await db.fetchone("SELECT id, adapter_type, config FROM adapter_instances WHERE id=?", (target_id,))
     if target_row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Ziel-Instanz nicht gefunden")
 
@@ -468,7 +468,7 @@ async def migrate_instance_bindings(
         )
 
     source_bindings = await db.fetchall(
-        "SELECT id, datapoint_id FROM adapter_bindings WHERE adapter_instance_id=? ORDER BY created_at",
+        "SELECT id, datapoint_id, direction, config, enabled FROM adapter_bindings WHERE adapter_instance_id=? ORDER BY created_at",
         (source_id,),
     )
     target_bindings = await db.fetchall(
@@ -481,11 +481,20 @@ async def migrate_instance_bindings(
     skipped = 0
     total_source_bindings = len(source_bindings)
     now = datetime.now(UTC).isoformat()
+    target_message_config = _json_config(target_row["config"]) if target_row["adapter_type"] == "MESSAGE" else None
 
     for binding_row in source_bindings:
         if binding_row["datapoint_id"] in target_datapoint_ids:
             skipped += 1
             continue
+        if target_message_config is not None:
+            _validate_adapter_binding(
+                "MESSAGE",
+                binding_row["direction"],
+                _json_config(binding_row["config"]),
+                enabled=bool(binding_row["enabled"]),
+                instance_config=target_message_config,
+            )
         await db.execute(
             "UPDATE adapter_bindings SET adapter_instance_id=?, updated_at=? WHERE id=?",
             (target_id, now, binding_row["id"]),

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -483,6 +483,7 @@ async def migrate_instance_bindings(
     now = datetime.now(UTC).isoformat()
     target_message_config = _json_config(target_row["config"]) if target_row["adapter_type"] == "MESSAGE" else None
 
+    bindings_to_migrate = []
     for binding_row in source_bindings:
         if binding_row["datapoint_id"] in target_datapoint_ids:
             skipped += 1
@@ -495,6 +496,9 @@ async def migrate_instance_bindings(
                 enabled=bool(binding_row["enabled"]),
                 instance_config=target_message_config,
             )
+        bindings_to_migrate.append(binding_row)
+
+    for binding_row in bindings_to_migrate:
         await db.execute(
             "UPDATE adapter_bindings SET adapter_instance_id=?, updated_at=? WHERE id=?",
             (target_id, now, binding_row["id"]),

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel
 from obs.adapters import registry as adapter_registry
 from obs.adapters.knx.dpt_registry import DPTRegistry
 from obs.api.auth import get_admin_user, get_current_user
+from obs.api.v1.bindings import _json_config, _validate_adapter_binding
 from obs.db.database import Database, get_db
 
 router = APIRouter(tags=["adapters"])
@@ -190,6 +191,26 @@ def _instance_out(row: Any, instance: Any | None) -> AdapterInstanceOut:
     )
 
 
+async def _validate_message_config_preserves_binding_targets(
+    instance_id: str,
+    config: dict[str, Any],
+    db: Database,
+) -> None:
+    rows = await db.fetchall(
+        """SELECT direction, config, enabled FROM adapter_bindings
+           WHERE adapter_instance_id=? AND adapter_type='MESSAGE'""",
+        (instance_id,),
+    )
+    for binding_row in rows:
+        _validate_adapter_binding(
+            "MESSAGE",
+            binding_row["direction"],
+            _json_config(binding_row["config"]),
+            enabled=bool(binding_row["enabled"]),
+            instance_config=config,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Instanz-Routen  (WICHTIG: vor /{adapter_type}/... registrieren!)
 # ---------------------------------------------------------------------------
@@ -303,6 +324,8 @@ async def update_instance(
                     status.HTTP_422_UNPROCESSABLE_CONTENT,
                     f"Config-Validierungsfehler: {exc}",
                 ) from exc
+        if row["adapter_type"] == "MESSAGE":
+            await _validate_message_config_preserves_binding_targets(str(instance_id), body.config, db)
         config_raw = json.dumps(body.config)
 
     now = datetime.now(UTC).isoformat()

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -253,7 +253,7 @@ async def update_binding(
         row["adapter_type"],
         direction,
         config,
-        validate_schema="config" in updates or "enabled" in updates,
+        validate_schema="config" in updates or (row["adapter_type"] == "MESSAGE" and "enabled" in updates),
         enabled=bool(enabled),
     )
 

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -88,6 +88,7 @@ def _validate_adapter_binding(
     *,
     validate_schema: bool = True,
     enabled: bool = True,
+    instance_config: dict[str, Any] | None = None,
 ) -> None:
     if adapter_type == "MESSAGE" and direction != "SOURCE":
         raise HTTPException(
@@ -103,12 +104,39 @@ def _validate_adapter_binding(
     if cls and hasattr(cls, "binding_config_schema"):
         try:
             schema_config = {**config, "enabled": enabled} if adapter_type == "MESSAGE" else config
-            cls.binding_config_schema(**schema_config)
+            binding_config = cls.binding_config_schema(**schema_config)
+            if adapter_type == "MESSAGE" and enabled and instance_config is not None:
+                _validate_message_target_refs(binding_config, instance_config)
         except Exception as exc:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_CONTENT,
                 f"Ungültige Binding-Config: {exc}",
             ) from exc
+
+
+def _json_config(raw: Any) -> dict[str, Any]:
+    if raw is None or raw == "":
+        return {}
+    if isinstance(raw, str):
+        return json.loads(raw)
+    if isinstance(raw, dict):
+        return raw
+    return dict(raw)
+
+
+def _validate_message_target_refs(binding_config: Any, instance_config: dict[str, Any]) -> None:
+    from obs.adapters.message.adapter import MessageAdapterConfig
+
+    adapter_config = MessageAdapterConfig(**instance_config)
+    for ref in binding_config.providers:
+        provider_config = adapter_config.providers.get(ref.provider)
+        if provider_config is None:
+            raise ValueError(f"MESSAGE provider not configured: {ref.provider}")
+        if not provider_config.get("enabled", False):
+            raise ValueError(f"MESSAGE provider is disabled: {ref.provider}")
+        targets = provider_config.get("targets") or {}
+        if ref.target not in targets:
+            raise ValueError(f"MESSAGE target not configured: {ref.provider}/{ref.target}")
 
 
 def _row_out(row: Any, name_map: dict[str, str] | None = None) -> BindingOut:
@@ -123,7 +151,7 @@ def _row_out(row: Any, name_map: dict[str, str] | None = None) -> BindingOut:
         adapter_instance_id=uuid.UUID(instance_id) if instance_id else None,
         instance_name=name_map.get(instance_id) if name_map and instance_id else None,
         direction=row["direction"],
-        config=json.loads(row["config"]),
+        config=_json_config(row["config"]),
         enabled=bool(row["enabled"]),
         send_throttle_ms=int(throttle) if throttle is not None else None,
         send_on_change=bool(row["send_on_change"]),
@@ -175,7 +203,13 @@ async def create_binding(
         )
     adapter_type = instance_row["adapter_type"]
 
-    _validate_adapter_binding(adapter_type, body.direction, body.config, enabled=body.enabled)
+    _validate_adapter_binding(
+        adapter_type,
+        body.direction,
+        body.config,
+        enabled=body.enabled,
+        instance_config=_json_config(instance_row["config"]) if adapter_type == "MESSAGE" else None,
+    )
 
     # Formel validieren
     if body.value_formula:
@@ -238,7 +272,7 @@ async def update_binding(
     now = datetime.now(UTC).isoformat()
 
     direction = updates.get("direction", row["direction"])
-    config = updates.get("config", json.loads(row["config"]))
+    config = updates.get("config", _json_config(row["config"]))
     config_val = json.dumps(config)
     enabled = int(updates.get("enabled", bool(row["enabled"])))
     throttle_ms = updates.get("send_throttle_ms", row["send_throttle_ms"])
@@ -248,6 +282,12 @@ async def update_binding(
     formula = updates.get("value_formula", row["value_formula"]) or None
     value_map_new = updates.get("value_map", json.loads(row["value_map"]) if row["value_map"] else None)
     value_map_json = json.dumps(value_map_new) if value_map_new else None
+    instance_config: dict[str, Any] | None = None
+    if row["adapter_type"] == "MESSAGE" and row["adapter_instance_id"]:
+        instance_row = await db.fetchone("SELECT config FROM adapter_instances WHERE id=?", (row["adapter_instance_id"],))
+        if instance_row is None:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "MESSAGE adapter instance not found")
+        instance_config = _json_config(instance_row["config"])
 
     _validate_adapter_binding(
         row["adapter_type"],
@@ -255,6 +295,7 @@ async def update_binding(
         config,
         validate_schema="config" in updates or (row["adapter_type"] == "MESSAGE" and "enabled" in updates),
         enabled=bool(enabled),
+        instance_config=instance_config,
     )
 
     # Formel validieren

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -87,6 +87,7 @@ def _validate_adapter_binding(
     config: dict[str, Any],
     *,
     validate_schema: bool = True,
+    enabled: bool = True,
 ) -> None:
     if adapter_type == "MESSAGE" and direction != "SOURCE":
         raise HTTPException(
@@ -101,7 +102,8 @@ def _validate_adapter_binding(
     cls = get_class(adapter_type)
     if cls and hasattr(cls, "binding_config_schema"):
         try:
-            cls.binding_config_schema(**config)
+            schema_config = {**config, "enabled": enabled} if adapter_type == "MESSAGE" else config
+            cls.binding_config_schema(**schema_config)
         except Exception as exc:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -173,7 +175,7 @@ async def create_binding(
         )
     adapter_type = instance_row["adapter_type"]
 
-    _validate_adapter_binding(adapter_type, body.direction, body.config)
+    _validate_adapter_binding(adapter_type, body.direction, body.config, enabled=body.enabled)
 
     # Formel validieren
     if body.value_formula:
@@ -247,7 +249,13 @@ async def update_binding(
     value_map_new = updates.get("value_map", json.loads(row["value_map"]) if row["value_map"] else None)
     value_map_json = json.dumps(value_map_new) if value_map_new else None
 
-    _validate_adapter_binding(row["adapter_type"], direction, config, validate_schema="config" in updates)
+    _validate_adapter_binding(
+        row["adapter_type"],
+        direction,
+        config,
+        validate_schema="config" in updates or "enabled" in updates,
+        enabled=bool(enabled),
+    )
 
     # Formel validieren
     if formula:

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -126,15 +126,20 @@ def _json_config(raw: Any) -> dict[str, Any]:
 
 def _validate_message_target_refs(binding_config: Any, instance_config: dict[str, Any]) -> None:
     from obs.adapters.message.adapter import MessageAdapterConfig
+    from obs.adapters.message.providers.registry import get_provider
 
     adapter_config = MessageAdapterConfig(**instance_config)
     for ref in binding_config.providers:
         provider_config = adapter_config.providers.get(ref.provider)
         if provider_config is None:
             raise ValueError(f"MESSAGE provider not configured: {ref.provider}")
-        if not provider_config.get("enabled", False):
+        provider = get_provider(ref.provider)
+        if provider is None:
+            raise ValueError(f"MESSAGE provider not registered: {ref.provider}")
+        parsed_provider_config = provider.config_schema(**provider_config)
+        if not getattr(parsed_provider_config, "enabled", False):
             raise ValueError(f"MESSAGE provider is disabled: {ref.provider}")
-        targets = provider_config.get("targets") or {}
+        targets = getattr(parsed_provider_config, "targets", {}) or {}
         if ref.target not in targets:
             raise ValueError(f"MESSAGE target not configured: {ref.provider}/{ref.target}")
 

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -81,6 +81,26 @@ async def _reload_adapter_instance(instance_id: str, db: Database) -> None:
     await adapter_registry.reload_instance_bindings(instance_id, db)
 
 
+def _validate_adapter_binding(adapter_type: str, direction: str, config: dict[str, Any]) -> None:
+    if adapter_type == "MESSAGE" and direction != "SOURCE":
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "MESSAGE-Bindings unterstützen nur Richtung SOURCE",
+        )
+
+    from obs.adapters.registry import get_class
+
+    cls = get_class(adapter_type)
+    if cls and hasattr(cls, "binding_config_schema"):
+        try:
+            cls.binding_config_schema(**config)
+        except Exception as exc:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                f"Ungültige Binding-Config: {exc}",
+            ) from exc
+
+
 def _row_out(row: Any, name_map: dict[str, str] | None = None) -> BindingOut:
     instance_id = row["adapter_instance_id"]
     throttle = row["send_throttle_ms"]
@@ -145,18 +165,7 @@ async def create_binding(
         )
     adapter_type = instance_row["adapter_type"]
 
-    # Binding-Config gegen Schema validieren
-    from obs.adapters.registry import get_class
-
-    cls = get_class(adapter_type)
-    if cls and hasattr(cls, "binding_config_schema"):
-        try:
-            cls.binding_config_schema(**body.config)
-        except Exception as exc:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                f"Ungültige Binding-Config: {exc}",
-            ) from exc
+    _validate_adapter_binding(adapter_type, body.direction, body.config)
 
     # Formel validieren
     if body.value_formula:
@@ -219,7 +228,8 @@ async def update_binding(
     now = datetime.now(UTC).isoformat()
 
     direction = updates.get("direction", row["direction"])
-    config_val = json.dumps(updates.get("config", json.loads(row["config"])))
+    config = updates.get("config", json.loads(row["config"]))
+    config_val = json.dumps(config)
     enabled = int(updates.get("enabled", bool(row["enabled"])))
     throttle_ms = updates.get("send_throttle_ms", row["send_throttle_ms"])
     on_change = int(updates.get("send_on_change", bool(row["send_on_change"])))
@@ -228,6 +238,8 @@ async def update_binding(
     formula = updates.get("value_formula", row["value_formula"]) or None
     value_map_new = updates.get("value_map", json.loads(row["value_map"]) if row["value_map"] else None)
     value_map_json = json.dumps(value_map_new) if value_map_new else None
+
+    _validate_adapter_binding(row["adapter_type"], direction, config)
 
     # Formel validieren
     if formula:

--- a/obs/api/v1/bindings.py
+++ b/obs/api/v1/bindings.py
@@ -81,12 +81,20 @@ async def _reload_adapter_instance(instance_id: str, db: Database) -> None:
     await adapter_registry.reload_instance_bindings(instance_id, db)
 
 
-def _validate_adapter_binding(adapter_type: str, direction: str, config: dict[str, Any]) -> None:
+def _validate_adapter_binding(
+    adapter_type: str,
+    direction: str,
+    config: dict[str, Any],
+    *,
+    validate_schema: bool = True,
+) -> None:
     if adapter_type == "MESSAGE" and direction != "SOURCE":
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             "MESSAGE-Bindings unterstützen nur Richtung SOURCE",
         )
+    if adapter_type != "MESSAGE" and not validate_schema:
+        return
 
     from obs.adapters.registry import get_class
 
@@ -239,7 +247,7 @@ async def update_binding(
     value_map_new = updates.get("value_map", json.loads(row["value_map"]) if row["value_map"] else None)
     value_map_json = json.dumps(value_map_new) if value_map_new else None
 
-    _validate_adapter_binding(row["adapter_type"], direction, config)
+    _validate_adapter_binding(row["adapter_type"], direction, config, validate_schema="config" in updates)
 
     # Formel validieren
     if formula:

--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -22,7 +22,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from obs.api.auth import get_admin_user
-from obs.api.v1.bindings import _validate_adapter_binding
+from obs.api.v1.bindings import _json_config, _validate_adapter_binding
 from obs.core.formula import validate_formula
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -636,7 +636,19 @@ async def import_config(
                 err = validate_formula(formula)
                 if err:
                     raise ValueError(f"Ungültige Formel: {err}")
-            _validate_adapter_binding(b_data.adapter_type, b_data.direction, b_data.config, enabled=b_data.enabled)
+            instance_config = None
+            if b_data.adapter_type == "MESSAGE" and b_data.adapter_instance_id:
+                instance_row = await db.fetchone("SELECT config FROM adapter_instances WHERE id=?", (b_data.adapter_instance_id,))
+                if instance_row is None:
+                    raise ValueError(f"MESSAGE adapter instance not found: {b_data.adapter_instance_id}")
+                instance_config = _json_config(instance_row["config"])
+            _validate_adapter_binding(
+                b_data.adapter_type,
+                b_data.direction,
+                b_data.config,
+                enabled=b_data.enabled,
+                instance_config=instance_config,
+            )
             row = await db.fetchone("SELECT id FROM adapter_bindings WHERE id=?", (b_id,))
             if row:
                 await db.execute_and_commit(

--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -84,6 +84,76 @@ class ExportedAdapterConfig(BaseModel):
     enabled: bool
 
 
+def _message_binding_row(
+    *,
+    binding_id: str,
+    direction: str,
+    config: dict,
+    enabled: bool,
+    instance_id: str | None,
+) -> dict:
+    return {
+        "id": binding_id,
+        "direction": direction,
+        "config": config,
+        "enabled": enabled,
+        "adapter_instance_id": instance_id,
+    }
+
+
+async def _validate_import_message_instance_configs(
+    instances: list[ExportedAdapterInstance],
+    bindings: list[ExportedBinding],
+    db: Database,
+) -> dict[str, str]:
+    message_instances = {instance.id: instance for instance in instances if instance.adapter_type == "MESSAGE"}
+    if not message_instances:
+        return {}
+
+    message_import_bindings = [binding for binding in bindings if binding.adapter_type == "MESSAGE"]
+    invalid: dict[str, str] = {}
+    for instance_id, instance in message_instances.items():
+        rows = await db.fetchall(
+            """SELECT id, adapter_instance_id, direction, config, enabled
+               FROM adapter_bindings
+               WHERE adapter_instance_id=? AND adapter_type='MESSAGE'""",
+            (instance_id,),
+        )
+        proposed = {
+            row["id"]: _message_binding_row(
+                binding_id=row["id"],
+                direction=row["direction"],
+                config=_json_config(row["config"]),
+                enabled=bool(row["enabled"]),
+                instance_id=row["adapter_instance_id"],
+            )
+            for row in rows
+        }
+        for binding in message_import_bindings:
+            if binding.id in proposed and binding.adapter_instance_id != instance_id:
+                proposed.pop(binding.id)
+            if binding.adapter_instance_id == instance_id:
+                proposed[binding.id] = _message_binding_row(
+                    binding_id=binding.id,
+                    direction=binding.direction,
+                    config=binding.config,
+                    enabled=binding.enabled,
+                    instance_id=binding.adapter_instance_id,
+                )
+        try:
+            for binding in proposed.values():
+                _validate_adapter_binding(
+                    "MESSAGE",
+                    binding["direction"],
+                    binding["config"],
+                    enabled=binding["enabled"],
+                    instance_config=instance.config,
+                )
+        except Exception as exc:
+            invalid[instance_id] = str(exc)
+    return invalid
+
+
 class ExportedLogicGraph(BaseModel):
     id: str
     name: str
@@ -604,8 +674,12 @@ async def import_config(
                 ),
             )
 
+    invalid_message_instances = await _validate_import_message_instance_configs(instances_to_upsert, body.bindings, db)
+
     for ai in instances_to_upsert:
         try:
+            if ai.id in invalid_message_instances:
+                raise ValueError(invalid_message_instances[ai.id])
             await db.execute_and_commit(
                 """INSERT INTO adapter_instances
                    (id, adapter_type, name, config, enabled, created_at, updated_at)

--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -636,7 +636,7 @@ async def import_config(
                 err = validate_formula(formula)
                 if err:
                     raise ValueError(f"Ungültige Formel: {err}")
-            _validate_adapter_binding(b_data.adapter_type, b_data.direction, b_data.config)
+            _validate_adapter_binding(b_data.adapter_type, b_data.direction, b_data.config, enabled=b_data.enabled)
             row = await db.fetchone("SELECT id FROM adapter_bindings WHERE id=?", (b_id,))
             if row:
                 await db.execute_and_commit(

--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -111,6 +111,15 @@ async def _validate_import_message_instance_configs(
         return {}
 
     message_import_bindings = [binding for binding in bindings if binding.adapter_type == "MESSAGE"]
+    existing_import_bindings: dict[str, dict] = {}
+    for binding in message_import_bindings:
+        row = await db.fetchone(
+            "SELECT id, adapter_instance_id, adapter_type FROM adapter_bindings WHERE id=?",
+            (binding.id,),
+        )
+        if row is not None and row["adapter_type"] == "MESSAGE":
+            existing_import_bindings[binding.id] = row
+
     invalid: dict[str, str] = {}
     for instance_id, instance in message_instances.items():
         rows = await db.fetchall(
@@ -130,15 +139,17 @@ async def _validate_import_message_instance_configs(
             for row in rows
         }
         for binding in message_import_bindings:
-            if binding.id in proposed and binding.adapter_instance_id != instance_id:
+            existing = existing_import_bindings.get(binding.id)
+            effective_instance_id = existing["adapter_instance_id"] if existing is not None else binding.adapter_instance_id
+            if binding.id in proposed and effective_instance_id != instance_id:
                 proposed.pop(binding.id)
-            if binding.adapter_instance_id == instance_id:
+            if effective_instance_id == instance_id:
                 proposed[binding.id] = _message_binding_row(
                     binding_id=binding.id,
                     direction=binding.direction,
                     config=binding.config,
                     enabled=binding.enabled,
-                    instance_id=binding.adapter_instance_id,
+                    instance_id=effective_instance_id,
                 )
         try:
             for binding in proposed.values():
@@ -705,26 +716,33 @@ async def import_config(
     for b_data in body.bindings:
         try:
             b_id = b_data.id
+            existing_binding = await db.fetchone(
+                "SELECT id, adapter_type, adapter_instance_id FROM adapter_bindings WHERE id=?",
+                (b_id,),
+            )
+            effective_adapter_type = existing_binding["adapter_type"] if existing_binding is not None else b_data.adapter_type
+            effective_instance_id = existing_binding["adapter_instance_id"] if existing_binding is not None else b_data.adapter_instance_id
             formula = (b_data.value_formula or "").strip() or None
             if formula:
                 err = validate_formula(formula)
                 if err:
                     raise ValueError(f"Ungültige Formel: {err}")
             instance_config = None
-            if b_data.adapter_type == "MESSAGE" and b_data.adapter_instance_id:
-                instance_row = await db.fetchone("SELECT config FROM adapter_instances WHERE id=?", (b_data.adapter_instance_id,))
+            if effective_adapter_type == "MESSAGE" and effective_instance_id:
+                if effective_instance_id in invalid_message_instances:
+                    raise ValueError(invalid_message_instances[effective_instance_id])
+                instance_row = await db.fetchone("SELECT config FROM adapter_instances WHERE id=?", (effective_instance_id,))
                 if instance_row is None:
-                    raise ValueError(f"MESSAGE adapter instance not found: {b_data.adapter_instance_id}")
+                    raise ValueError(f"MESSAGE adapter instance not found: {effective_instance_id}")
                 instance_config = _json_config(instance_row["config"])
             _validate_adapter_binding(
-                b_data.adapter_type,
+                effective_adapter_type,
                 b_data.direction,
                 b_data.config,
                 enabled=b_data.enabled,
                 instance_config=instance_config,
             )
-            row = await db.fetchone("SELECT id FROM adapter_bindings WHERE id=?", (b_id,))
-            if row:
+            if existing_binding:
                 await db.execute_and_commit(
                     """UPDATE adapter_bindings
                        SET direction=?, config=?, enabled=?,

--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -22,6 +22,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from obs.api.auth import get_admin_user
+from obs.api.v1.bindings import _validate_adapter_binding
 from obs.core.formula import validate_formula
 from obs.core.registry import get_registry
 from obs.db.database import Database, get_db
@@ -635,6 +636,7 @@ async def import_config(
                 err = validate_formula(formula)
                 if err:
                     raise ValueError(f"Ungültige Formel: {err}")
+            _validate_adapter_binding(b_data.adapter_type, b_data.direction, b_data.config)
             row = await db.fetchone("SELECT id FROM adapter_bindings WHERE id=?", (b_id,))
             if row:
                 await db.execute_and_commit(

--- a/obs/api/v1/config.py
+++ b/obs/api/v1/config.py
@@ -141,8 +141,6 @@ async def _validate_import_message_instance_configs(
         for binding in message_import_bindings:
             existing = existing_import_bindings.get(binding.id)
             effective_instance_id = existing["adapter_instance_id"] if existing is not None else binding.adapter_instance_id
-            if binding.id in proposed and effective_instance_id != instance_id:
-                proposed.pop(binding.id)
             if effective_instance_id == instance_id:
                 proposed[binding.id] = _message_binding_row(
                     binding_id=binding.id,

--- a/obs/api/v1/support.py
+++ b/obs/api/v1/support.py
@@ -62,6 +62,7 @@ _SENSITIVE_KEYS = {
     "backbone_key",
     "community",
     "knxkeys_file_path",
+    "to",
     "priv_key",
     "user_key",
 }

--- a/obs/api/v1/support.py
+++ b/obs/api/v1/support.py
@@ -63,6 +63,7 @@ _SENSITIVE_KEYS = {
     "community",
     "knxkeys_file_path",
     "priv_key",
+    "user_key",
 }
 _PASSTHROUGH_KEYS = {
     "auth_protocol",

--- a/obs/api/v1/support.py
+++ b/obs/api/v1/support.py
@@ -61,6 +61,7 @@ _SENSITIVE_KEY_PARTS = (
 _SENSITIVE_KEYS = {
     "backbone_key",
     "community",
+    "chat_id",
     "knxkeys_file_path",
     "to",
     "priv_key",

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -158,14 +158,15 @@ class WriteRouter:
             return
 
         rows = await self._db.fetchall(
-            """SELECT direction, enabled FROM adapter_bindings
+            """SELECT direction, enabled, adapter_type FROM adapter_bindings
                WHERE datapoint_id=?""",
             (str(dp_id),),
         )
-        has_bindings = bool(rows)
         active_rows = [row for row in rows if _row_is_enabled(row)]
-        has_writable_bindings = any(_row_value(row, "direction") in {"DEST", "BOTH"} for row in active_rows)
-        if has_bindings and not has_writable_bindings:
+        write_semantic_rows = [row for row in active_rows if _row_value(row, "adapter_type") != "MESSAGE"]
+        has_write_semantic_bindings = any(_row_value(row, "adapter_type") != "MESSAGE" for row in rows)
+        has_writable_bindings = any(_row_value(row, "direction") in {"DEST", "BOTH"} for row in write_semantic_rows)
+        if has_write_semantic_bindings and not has_writable_bindings:
             logger.warning("Write request for non-writable DataPoint %s — ignored", dp_id)
             return
 
@@ -267,7 +268,7 @@ class WriteRouter:
 
         rows = await self._db.fetchall(
             """SELECT * FROM adapter_bindings
-               WHERE datapoint_id=? AND direction IN ('DEST','BOTH') AND enabled=1""",
+               WHERE datapoint_id=? AND direction IN ('DEST','BOTH') AND enabled=1 AND adapter_type <> 'MESSAGE'""",
             (str(dp_id),),
         )
         if not rows:
@@ -288,6 +289,9 @@ class WriteRouter:
                 continue
             if skip_binding_id and binding.id == skip_binding_id:
                 logger.debug("WriteRouter: skipping originating binding %s", binding.id)
+                continue
+            if binding.adapter_type == "MESSAGE":
+                logger.debug("WriteRouter: skipping MESSAGE observer binding %s", binding.id)
                 continue
 
             # Phase 5: Lookup per Instance-ID (bevorzugt), Fallback auf Typ

--- a/obs/core/write_router.py
+++ b/obs/core/write_router.py
@@ -164,7 +164,7 @@ class WriteRouter:
         )
         active_rows = [row for row in rows if _row_is_enabled(row)]
         write_semantic_rows = [row for row in active_rows if _row_value(row, "adapter_type") != "MESSAGE"]
-        has_write_semantic_bindings = any(_row_value(row, "adapter_type") != "MESSAGE" for row in rows)
+        has_write_semantic_bindings = bool(write_semantic_rows)
         has_writable_bindings = any(_row_value(row, "direction") in {"DEST", "BOTH"} for row in write_semantic_rows)
         if has_write_semantic_bindings and not has_writable_bindings:
             logger.warning("Write request for non-writable DataPoint %s — ignored", dp_id)

--- a/obs/main.py
+++ b/obs/main.py
@@ -138,6 +138,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     import obs.adapters.knx.adapter
     import obs.adapters.modbus_rtu.adapter
     import obs.adapters.modbus_tcp.adapter
+    import obs.adapters.message.adapter
     import obs.adapters.mqtt.adapter
     import obs.adapters.onewire.adapter
     import obs.adapters.snmp.adapter  # noqa: F401

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -549,9 +549,9 @@ async def test_send_to_targets_reports_missing_disabled_and_unknown_providers(bu
 @pytest.mark.asyncio
 async def test_pushover_provider_posts_payload(monkeypatch):
     _FakeAsyncClient.calls = []
-    _FakeAsyncClient.json_body = None
+    _FakeAsyncClient.json_body = {"status": 1}
     _FakeAsyncClient.status_code = 200
-    _FakeAsyncClient.text = "100"
+    _FakeAsyncClient.text = ""
     monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await PushoverProvider().send(
@@ -600,6 +600,27 @@ async def test_pushover_provider_reports_http_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pushover_provider_reports_body_failure(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = {"status": 0, "errors": ["application token is invalid"]}
+    _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = ""
+    monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await PushoverProvider().send(
+        provider_config={"enabled": True, "api_token": "app", "targets": {}},
+        target_name="phone",
+        target_config={"user_key": "user"},
+        title=None,
+        message="Body",
+        context={},
+    )
+
+    assert result.ok is False
+    assert result.detail == "application token is invalid"
+
+
+@pytest.mark.asyncio
 async def test_telegram_provider_posts_message(monkeypatch):
     _FakeAsyncClient.calls = []
     _FakeAsyncClient.json_body = None
@@ -642,7 +663,7 @@ async def test_sevenio_provider_posts_voice_payload(monkeypatch):
     assert result.ok is True
     url, kwargs, _timeout = _FakeAsyncClient.calls[0]
     assert url == "https://gateway.seven.io/api/voice"
-    assert kwargs["headers"] == {"X-Api-Key": "key"}
+    assert kwargs["headers"] == {"X-Api-Key": "key", "Accept": "application/json"}
     assert kwargs["data"] == {"to": "+4100000000", "text": "Alarm: Door", "from": "Home"}
 
 

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -149,6 +149,12 @@ def test_disabled_provider_allows_incomplete_hidden_targets():
     assert cfg.providers["telegram"]["enabled"] is False
 
 
+def test_string_disabled_provider_allows_incomplete_hidden_targets():
+    cfg = MessageAdapterConfig(providers={"telegram": {"enabled": "false", "targets": {"default": {}}}})
+
+    assert cfg.providers["telegram"]["enabled"] == "false"
+
+
 @pytest.mark.parametrize(
     ("provider", "config", "error"),
     [
@@ -433,6 +439,49 @@ async def test_any_operator_continues_draining_after_suppressed_pending_duplicat
 
 
 @pytest.mark.asyncio
+async def test_any_operator_preserves_return_to_in_flight_value_after_change(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
+    release = asyncio.Event()
+    messages: list[str] = []
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-any-return"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            messages.append(kwargs["message"])
+            await release.wait()
+            return MessageSendResult("slow-any-return", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-any-return": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        operator="any",
+        compare_value=None,
+        message="###DP###",
+        providers=[{"provider": "slow-any-return", "target": "default"}],
+    )
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="B", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert messages == ["A", "B", "A"]
+
+
+@pytest.mark.asyncio
 async def test_send_on_change_coalesces_duplicate_pending_failure_retries(bus, monkeypatch):
     dp_id = uuid.uuid4()
     monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
@@ -645,7 +694,7 @@ async def test_complete_provider_failure_is_retried_for_same_condition(bus, dumm
 
 
 @pytest.mark.asyncio
-async def test_partial_provider_failure_is_retried_for_same_condition(bus, dummy_provider, monkeypatch):
+async def test_partial_provider_failure_records_condition_for_same_value(bus, dummy_provider, monkeypatch):
     dp_id = uuid.uuid4()
     monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
     dummy_provider.send.side_effect = [
@@ -673,7 +722,7 @@ async def test_partial_provider_failure_is_retried_for_same_condition(bus, dummy
     await adapter._on_value_event(event)
     await _drain_sends(adapter)
 
-    assert dummy_provider.send.await_count == 4
+    assert dummy_provider.send.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -15,7 +15,10 @@ from obs.adapters.message.adapter import (
     render_message,
 )
 from obs.adapters.message.providers.base import MessageSendResult
+from obs.adapters.message.providers.pushover import PushoverProvider
 from obs.adapters.message.providers.registry import register_provider
+from obs.adapters.message.providers.sevenio import SevenIoProvider
+from obs.adapters.message.providers.telegram import TelegramProvider
 from obs.core.event_bus import DataValueEvent
 from tests.adapters.conftest import make_binding
 
@@ -47,6 +50,29 @@ class _Registry:
 
     def get(self, dp_id: uuid.UUID) -> _Dp | None:
         return self._dp if dp_id == self._dp.id else None
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+
+
+class _FakeAsyncClient:
+    calls: list[tuple[str, dict, float | None]] = []
+    status_code = 200
+
+    def __init__(self, timeout: float | None = None) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, **kwargs):
+        self.calls.append((url, kwargs, self.timeout))
+        return _FakeResponse(self.status_code)
 
 
 @pytest.mark.parametrize(
@@ -210,3 +236,192 @@ async def test_any_operator_sends_for_each_changed_value(bus, dummy_provider, mo
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=True, quality="good", source_adapter="test"))
 
     assert dummy_provider.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_write_path_sends_message_to_provider(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, operator="any")
+
+    await adapter.write(binding, "manual")
+
+    dummy_provider.send.assert_awaited_once()
+    assert dummy_provider.send.await_args.kwargs["message"] == "Temperatur kritisch: manual "
+
+
+@pytest.mark.asyncio
+async def test_bad_quality_event_is_ignored(bus, dummy_provider):
+    dp_id = uuid.uuid4()
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id)
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="bad", source_adapter="test"))
+
+    dummy_provider.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disabled_binding_is_not_reloaded(bus, dummy_provider):
+    dp_id = uuid.uuid4()
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, enabled=False)
+
+    await adapter.reload_bindings([binding])
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+
+    dummy_provider.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_failures_publish_warning(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    dummy_provider.send.return_value = MessageSendResult("dummy", "default", False, "boom")
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, send_on_change=False)
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+
+    assert any(getattr(call.args[0], "severity", None) == "warning" for call in bus.publish.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_send_to_targets_reports_missing_disabled_and_unknown_providers(bus):
+    dp_id = uuid.uuid4()
+    disabled = _DummyProvider()
+    disabled.provider_type = "disabled"
+    missing = _DummyProvider()
+    missing.provider_type = "missing"
+    register_provider(disabled)
+    register_provider(missing)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={
+            "providers": {
+                "disabled": {"enabled": False, "targets": {"default": {}}},
+                "missing": {"enabled": True, "targets": {}},
+            },
+        },
+    )
+    cfg = _message_binding(
+        dp_id,
+        providers=[
+            {"provider": "unknown", "target": "default"},
+            {"provider": "disabled", "target": "default"},
+            {"provider": "missing", "target": "default"},
+        ],
+    ).config
+    binding = _message_binding(dp_id)
+    event = DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test")
+
+    results = await adapter._send_to_targets(adapter.binding_config_schema(**cfg), binding, event, "body")
+
+    assert [result.detail for result in results] == ["provider not registered", "provider disabled", "target not configured"]
+
+
+@pytest.mark.asyncio
+async def test_pushover_provider_posts_payload(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 200
+    monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await PushoverProvider().send(
+        provider_config={"enabled": True, "api_token": "app", "targets": {}},
+        target_name="phone",
+        target_config={"user_key": "user", "device": "iphone", "sound": "pushover"},
+        title="Alarm",
+        message="Window open",
+        context={"priority": 1},
+    )
+
+    assert result.ok is True
+    url, kwargs, timeout = _FakeAsyncClient.calls[0]
+    assert url == "https://api.pushover.net/1/messages.json"
+    assert timeout == 10.0
+    assert kwargs["data"] == {
+        "token": "app",
+        "user": "user",
+        "message": "Window open",
+        "title": "Alarm",
+        "device": "iphone",
+        "sound": "pushover",
+        "priority": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_pushover_provider_reports_http_error(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 500
+    monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await PushoverProvider().send(
+        provider_config={"enabled": True, "api_token": "app", "targets": {}},
+        target_name="phone",
+        target_config={"user_key": "user"},
+        title=None,
+        message="Body",
+        context={},
+    )
+
+    assert result.ok is False
+    assert result.detail == "HTTP 500"
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_posts_message(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 200
+    monkeypatch.setattr("obs.adapters.message.providers.telegram.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await TelegramProvider().send(
+        provider_config={"enabled": True, "bot_token": "secret", "targets": {}},
+        target_name="chat",
+        target_config={"chat_id": "123", "disable_notification": True},
+        title="OBS",
+        message="Hello",
+        context={},
+    )
+
+    assert result.ok is True
+    url, kwargs, _timeout = _FakeAsyncClient.calls[0]
+    assert url == "https://api.telegram.org/botsecret/sendMessage"
+    assert kwargs["json"] == {"chat_id": "123", "text": "OBS\nHello", "disable_notification": True}
+
+
+@pytest.mark.asyncio
+async def test_sevenio_provider_posts_voice_payload(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 200
+    monkeypatch.setattr("obs.adapters.message.providers.sevenio.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await SevenIoProvider().send(
+        provider_config={"enabled": True, "api_key": "key", "sender": "OBS", "targets": {}},
+        target_name="voice",
+        target_config={"to": "+4100000000", "channel": "voice", "sender": "Home"},
+        title="Alarm",
+        message="Door",
+        context={},
+    )
+
+    assert result.ok is True
+    url, kwargs, _timeout = _FakeAsyncClient.calls[0]
+    assert url == "https://gateway.seven.io/api/voice"
+    assert kwargs["headers"] == {"X-Api-Key": "key"}
+    assert kwargs["data"] == {"to": "+4100000000", "text": "Alarm: Door", "from": "Home"}

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -127,6 +127,22 @@ def test_render_message_replaces_value_unit_and_metadata():
     assert rendered == f"Temperatur {dp_id} 29.4 °C 2026-06-28T12:00:00+00:00"
 
 
+def test_render_message_does_not_reprocess_inserted_placeholder_text():
+    dp_id = uuid.uuid4()
+    ts = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+
+    rendered = render_message(
+        "value=###DP### ts=###TS###",
+        value="###TS###",
+        unit=None,
+        name="Sensor",
+        datapoint_id=dp_id,
+        ts=ts,
+    )
+
+    assert rendered == "value=###TS### ts=2026-06-28T12:00:00+00:00"
+
+
 def test_disabled_provider_allows_incomplete_hidden_targets():
     cfg = MessageAdapterConfig(providers={"telegram": {"enabled": False, "targets": {"default": {}}}})
 
@@ -180,6 +196,14 @@ def test_binding_rejects_pushover_emergency_priority_without_required_fields():
     with pytest.raises(ValueError, match="Pushover emergency priority"):
         MessageBindingConfig(
             priority=2,
+            providers=[{"provider": "pushover", "target": "default"}],
+        )
+
+
+def test_binding_rejects_out_of_range_pushover_priority():
+    with pytest.raises(ValueError, match="Pushover priority"):
+        MessageBindingConfig(
+            priority=3,
             providers=[{"provider": "pushover", "target": "default"}],
         )
 

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -166,6 +166,7 @@ def _message_binding(dp_id: uuid.UUID, **config):
 async def _drain_sends(adapter: MessageAdapter) -> None:
     while adapter._send_tasks:
         await asyncio.gather(*list(adapter._send_tasks))
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
@@ -267,6 +268,49 @@ async def test_any_operator_sends_for_each_changed_value(bus, dummy_provider, mo
     await _drain_sends(adapter)
 
     assert dummy_provider.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_any_operator_queues_each_changed_value_during_in_flight_send(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
+    release = asyncio.Event()
+    messages: list[str] = []
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-any"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            messages.append(kwargs["message"])
+            await release.wait()
+            return MessageSendResult("slow-any", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-any": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        operator="any",
+        compare_value=None,
+        message="###DP###",
+        providers=[{"provider": "slow-any", "target": "default"}],
+    )
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="B", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="C", quality="good", source_adapter="test"))
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert messages == ["A", "B", "C"]
 
 
 @pytest.mark.asyncio
@@ -513,6 +557,44 @@ async def test_condition_reset_clears_pending_in_flight_send(bus, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_binding_reload_drops_stale_pending_in_flight_send(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    release = asyncio.Event()
+    calls = 0
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-reload"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            return MessageSendResult("slow-reload", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-reload": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, providers=[{"provider": "slow-reload", "target": "default"}])
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=100, quality="good", source_adapter="test"))
+    await adapter.reload_bindings([])
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
 async def test_send_to_targets_reports_missing_disabled_and_unknown_providers(bus):
     dp_id = uuid.uuid4()
     disabled = _DummyProvider()
@@ -623,9 +705,9 @@ async def test_pushover_provider_reports_body_failure(monkeypatch):
 @pytest.mark.asyncio
 async def test_telegram_provider_posts_message(monkeypatch):
     _FakeAsyncClient.calls = []
-    _FakeAsyncClient.json_body = None
+    _FakeAsyncClient.json_body = {"ok": True}
     _FakeAsyncClient.status_code = 200
-    _FakeAsyncClient.text = "100"
+    _FakeAsyncClient.text = ""
     monkeypatch.setattr("obs.adapters.message.providers.telegram.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await TelegramProvider().send(
@@ -641,6 +723,27 @@ async def test_telegram_provider_posts_message(monkeypatch):
     url, kwargs, _timeout = _FakeAsyncClient.calls[0]
     assert url == "https://api.telegram.org/botsecret/sendMessage"
     assert kwargs["json"] == {"chat_id": "123", "text": "OBS\nHello", "disable_notification": True}
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_reports_body_failure(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = {"ok": False, "description": "Bad Request: chat not found"}
+    _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = ""
+    monkeypatch.setattr("obs.adapters.message.providers.telegram.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await TelegramProvider().send(
+        provider_config={"enabled": True, "bot_token": "secret", "targets": {}},
+        target_name="chat",
+        target_config={"chat_id": "123"},
+        title=None,
+        message="Hello",
+        context={},
+    )
+
+    assert result.ok is False
+    assert result.detail == "Bad Request: chat not found"
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -168,6 +168,14 @@ def test_binding_rejects_duplicate_message_targets():
         )
 
 
+def test_binding_rejects_pushover_emergency_priority_without_required_fields():
+    with pytest.raises(ValueError, match="Pushover emergency priority"):
+        MessageBindingConfig(
+            priority=2,
+            providers=[{"provider": "pushover", "target": "default"}],
+        )
+
+
 @pytest.fixture
 def dummy_provider():
     provider = _DummyProvider()
@@ -479,11 +487,30 @@ async def test_disabled_binding_is_not_reloaded(bus, dummy_provider):
         config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
     )
     binding = _message_binding(dp_id, enabled=False)
+    binding.enabled = False
 
     await adapter.reload_bindings([binding])
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
 
     dummy_provider.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_binding_reload_uses_top_level_enabled_flag(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, enabled=False)
+    binding.enabled = True
+
+    await adapter.reload_bindings([binding])
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
+
+    dummy_provider.send.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -888,6 +915,28 @@ async def test_pushover_provider_reports_body_failure(monkeypatch):
 
     assert result.ok is False
     assert result.detail == "application token is invalid"
+
+
+@pytest.mark.asyncio
+async def test_pushover_provider_rejects_priority_two_before_posting(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = {"status": 1}
+    _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = ""
+    monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await PushoverProvider().send(
+        provider_config={"enabled": True, "api_token": "app", "targets": {}},
+        target_name="phone",
+        target_config={"user_key": "user"},
+        title=None,
+        message="Body",
+        context={"priority": 2},
+    )
+
+    assert result.ok is False
+    assert result.detail == "pushover priority=2 requires retry and expire"
+    assert _FakeAsyncClient.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -53,13 +54,22 @@ class _Registry:
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int = 200) -> None:
+    def __init__(self, status_code: int = 200, text: str = "100", json_body=None) -> None:
         self.status_code = status_code
+        self.text = text
+        self._json_body = json_body
+
+    def json(self):
+        if self._json_body is None:
+            raise ValueError("not json")
+        return self._json_body
 
 
 class _FakeAsyncClient:
     calls: list[tuple[str, dict, float | None]] = []
+    json_body = None
     status_code = 200
+    text = "100"
 
     def __init__(self, timeout: float | None = None) -> None:
         self.timeout = timeout
@@ -72,7 +82,7 @@ class _FakeAsyncClient:
 
     async def post(self, url: str, **kwargs):
         self.calls.append((url, kwargs, self.timeout))
-        return _FakeResponse(self.status_code)
+        return _FakeResponse(self.status_code, self.text, self.json_body)
 
 
 @pytest.mark.parametrize(
@@ -146,6 +156,11 @@ def _message_binding(dp_id: uuid.UUID, **config):
     return binding
 
 
+async def _drain_sends(adapter: MessageAdapter) -> None:
+    if adapter._send_tasks:
+        await asyncio.gather(*list(adapter._send_tasks))
+
+
 @pytest.mark.asyncio
 async def test_datapoint_update_sends_message_to_provider(bus, dummy_provider, monkeypatch):
     dp_id = uuid.uuid4()
@@ -158,6 +173,7 @@ async def test_datapoint_update_sends_message_to_provider(bus, dummy_provider, m
     await adapter.reload_bindings([binding])
 
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=29.4, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
 
     dummy_provider.send.assert_awaited_once()
     kwargs = dummy_provider.send.await_args.kwargs
@@ -179,7 +195,9 @@ async def test_send_on_change_suppresses_repeated_true_condition(bus, dummy_prov
 
     event = DataValueEvent(datapoint_id=dp_id, value=29.4, quality="good", source_adapter="test")
     await adapter._on_value_event(event)
+    await _drain_sends(adapter)
     await adapter._on_value_event(event)
+    await _drain_sends(adapter)
 
     dummy_provider.send.assert_awaited_once()
 
@@ -197,7 +215,9 @@ async def test_cooldown_suppresses_repeated_sends(bus, dummy_provider, monkeypat
 
     event = DataValueEvent(datapoint_id=dp_id, value=29.4, quality="good", source_adapter="test")
     await adapter._on_value_event(event)
+    await _drain_sends(adapter)
     await adapter._on_value_event(event)
+    await _drain_sends(adapter)
 
     dummy_provider.send.assert_awaited_once()
 
@@ -214,8 +234,10 @@ async def test_condition_reset_allows_next_true_transition(bus, dummy_provider, 
     await adapter.reload_bindings([binding])
 
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=29, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=20, quality="good", source_adapter="test"))
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=30, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
 
     assert dummy_provider.send.await_count == 2
 
@@ -232,8 +254,10 @@ async def test_any_operator_sends_for_each_changed_value(bus, dummy_provider, mo
     await adapter.reload_bindings([binding])
 
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=False, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=False, quality="good", source_adapter="test"))
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=True, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
 
     assert dummy_provider.send.await_count == 2
 
@@ -249,6 +273,7 @@ async def test_write_path_sends_message_to_provider(bus, dummy_provider, monkeyp
     binding = _message_binding(dp_id, operator="any")
 
     await adapter.write(binding, "manual")
+    await _drain_sends(adapter)
 
     dummy_provider.send.assert_awaited_once()
     assert dummy_provider.send.await_args.kwargs["message"] == "Temperatur kritisch: manual "
@@ -297,8 +322,62 @@ async def test_provider_failures_publish_warning(bus, dummy_provider, monkeypatc
     await adapter.reload_bindings([binding])
 
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
 
     assert any(getattr(call.args[0], "severity", None) == "warning" for call in bus.publish.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_complete_provider_failure_is_retried_for_same_condition(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    dummy_provider.send.return_value = MessageSendResult("dummy", "default", False, "temporary")
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id)
+    await adapter.reload_bindings([binding])
+    event = DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test")
+
+    await adapter._on_value_event(event)
+    await _drain_sends(adapter)
+    await adapter._on_value_event(event)
+    await _drain_sends(adapter)
+
+    assert dummy_provider.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_value_event_does_not_wait_for_provider_http_call(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    release = asyncio.Event()
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            await release.wait()
+            return MessageSendResult("slow", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, providers=[{"provider": "slow", "target": "default"}])
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+
+    assert len(adapter._send_tasks) == 1
+    release.set()
+    await _drain_sends(adapter)
 
 
 @pytest.mark.asyncio
@@ -338,7 +417,9 @@ async def test_send_to_targets_reports_missing_disabled_and_unknown_providers(bu
 @pytest.mark.asyncio
 async def test_pushover_provider_posts_payload(monkeypatch):
     _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = None
     _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = "100"
     monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await PushoverProvider().send(
@@ -368,7 +449,9 @@ async def test_pushover_provider_posts_payload(monkeypatch):
 @pytest.mark.asyncio
 async def test_pushover_provider_reports_http_error(monkeypatch):
     _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = None
     _FakeAsyncClient.status_code = 500
+    _FakeAsyncClient.text = "100"
     monkeypatch.setattr("obs.adapters.message.providers.pushover.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await PushoverProvider().send(
@@ -387,7 +470,9 @@ async def test_pushover_provider_reports_http_error(monkeypatch):
 @pytest.mark.asyncio
 async def test_telegram_provider_posts_message(monkeypatch):
     _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = None
     _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = "100"
     monkeypatch.setattr("obs.adapters.message.providers.telegram.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await TelegramProvider().send(
@@ -408,7 +493,9 @@ async def test_telegram_provider_posts_message(monkeypatch):
 @pytest.mark.asyncio
 async def test_sevenio_provider_posts_voice_payload(monkeypatch):
     _FakeAsyncClient.calls = []
+    _FakeAsyncClient.json_body = None
     _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = "100"
     monkeypatch.setattr("obs.adapters.message.providers.sevenio.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await SevenIoProvider().send(
@@ -425,3 +512,45 @@ async def test_sevenio_provider_posts_voice_payload(monkeypatch):
     assert url == "https://gateway.seven.io/api/voice"
     assert kwargs["headers"] == {"X-Api-Key": "key"}
     assert kwargs["data"] == {"to": "+4100000000", "text": "Alarm: Door", "from": "Home"}
+
+
+@pytest.mark.asyncio
+async def test_sevenio_provider_reports_body_failure(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = "101"
+    _FakeAsyncClient.json_body = None
+    monkeypatch.setattr("obs.adapters.message.providers.sevenio.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await SevenIoProvider().send(
+        provider_config={"enabled": True, "api_key": "key", "targets": {}},
+        target_name="sms",
+        target_config={"to": "+4100000000", "channel": "sms"},
+        title=None,
+        message="Door",
+        context={},
+    )
+
+    assert result.ok is False
+    assert result.detail == "seven.io code 101"
+
+
+@pytest.mark.asyncio
+async def test_sevenio_provider_reports_json_success_false(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = ""
+    _FakeAsyncClient.json_body = {"messages": [{"success": True}, {"success": False}]}
+    monkeypatch.setattr("obs.adapters.message.providers.sevenio.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await SevenIoProvider().send(
+        provider_config={"enabled": True, "api_key": "key", "targets": {}},
+        target_name="sms",
+        target_config={"to": "+4100000000", "channel": "sms"},
+        title=None,
+        message="Door",
+        context={},
+    )
+
+    assert result.ok is False
+    assert result.detail == "seven.io response success=false"

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from obs.adapters.message.adapter import (
     MessageAdapter,
     MessageAdapterConfig,
+    MessageBindingConfig,
     evaluate_condition,
     render_message,
 )
@@ -130,6 +131,15 @@ def test_disabled_provider_allows_incomplete_hidden_targets():
     cfg = MessageAdapterConfig(providers={"telegram": {"enabled": False, "targets": {"default": {}}}})
 
     assert cfg.providers["telegram"]["enabled"] is False
+
+
+def test_enabled_binding_requires_message_target():
+    with pytest.raises(ValueError, match="at least one target"):
+        MessageBindingConfig(providers=[])
+
+    cfg = MessageBindingConfig(enabled=False, providers=[])
+
+    assert cfg.enabled is False
 
 
 @pytest.fixture
@@ -677,6 +687,26 @@ async def test_binding_reload_drops_stale_pending_in_flight_send(bus, monkeypatc
     await _drain_sends(adapter)
 
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_binding_reload_resets_previous_condition_state(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id)
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
+    await adapter.reload_bindings([binding])
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
+
+    assert dummy_provider.send.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -314,6 +314,49 @@ async def test_any_operator_queues_each_changed_value_during_in_flight_send(bus,
 
 
 @pytest.mark.asyncio
+async def test_any_operator_continues_draining_after_suppressed_pending_duplicate(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
+    release = asyncio.Event()
+    messages: list[str] = []
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-any-duplicate"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            messages.append(kwargs["message"])
+            await release.wait()
+            return MessageSendResult("slow-any-duplicate", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-any-duplicate": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        operator="any",
+        compare_value=None,
+        message="###DP###",
+        providers=[{"provider": "slow-any-duplicate", "target": "default"}],
+    )
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="B", quality="good", source_adapter="test"))
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert messages == ["A", "B"]
+
+
+@pytest.mark.asyncio
 async def test_write_path_sends_message_to_provider(bus, dummy_provider, monkeypatch):
     dp_id = uuid.uuid4()
     monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
@@ -551,6 +594,48 @@ async def test_condition_reset_clears_pending_in_flight_send(bus, monkeypatch):
     await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=20, quality="good", source_adapter="test"))
 
     release.set()
+    await _drain_sends(adapter)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cooldown_is_recorded_when_condition_resets_during_in_flight_send(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    release = asyncio.Event()
+    calls = 0
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-cooldown"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            return MessageSendResult("slow-cooldown", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-cooldown": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        cooldown_seconds=300,
+        providers=[{"provider": "slow-cooldown", "target": "default"}],
+    )
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=20, quality="good", source_adapter="test"))
+    release.set()
+    await _drain_sends(adapter)
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
     await _drain_sends(adapter)
 
     assert calls == 1

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -409,6 +409,49 @@ async def test_any_operator_continues_draining_after_suppressed_pending_duplicat
 
 
 @pytest.mark.asyncio
+async def test_send_on_change_coalesces_duplicate_pending_failure_retries(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
+    release = asyncio.Event()
+    messages: list[str] = []
+
+    class _FailingSlowProvider(_DummyProvider):
+        provider_type = "slow-failing-duplicate"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            messages.append(kwargs["message"])
+            await release.wait()
+            return MessageSendResult("slow-failing-duplicate", "default", False, "down")
+
+    provider = _FailingSlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-failing-duplicate": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        operator="any",
+        compare_value=None,
+        message="###DP###",
+        providers=[{"provider": "slow-failing-duplicate", "target": "default"}],
+    )
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value="A", quality="good", source_adapter="test"))
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert messages == ["A"]
+
+
+@pytest.mark.asyncio
 async def test_in_flight_pending_events_are_bounded_to_newest_values(bus, monkeypatch):
     monkeypatch.setattr("obs.adapters.message.adapter.MAX_PENDING_EVENTS_PER_BINDING", 2)
     dp_id = uuid.uuid4()

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from obs.adapters.message.adapter import (
     MessageAdapter,
+    MessageAdapterConfig,
     evaluate_condition,
     render_message,
 )
@@ -123,6 +124,12 @@ def test_render_message_replaces_value_unit_and_metadata():
     )
 
     assert rendered == f"Temperatur {dp_id} 29.4 °C 2026-06-28T12:00:00+00:00"
+
+
+def test_disabled_provider_allows_incomplete_hidden_targets():
+    cfg = MessageAdapterConfig(providers={"telegram": {"enabled": False, "targets": {"default": {}}}})
+
+    assert cfg.providers["telegram"]["enabled"] is False
 
 
 @pytest.fixture
@@ -465,6 +472,44 @@ async def test_false_true_transition_during_in_flight_send_is_retried(bus, monke
     await _drain_sends(adapter)
 
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_condition_reset_clears_pending_in_flight_send(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    release = asyncio.Event()
+    calls = 0
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-reset"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            return MessageSendResult("slow-reset", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-reset": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, providers=[{"provider": "slow-reset", "target": "default"}])
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=20, quality="good", source_adapter="test"))
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -133,6 +133,22 @@ def test_disabled_provider_allows_incomplete_hidden_targets():
     assert cfg.providers["telegram"]["enabled"] is False
 
 
+@pytest.mark.parametrize(
+    ("provider", "config", "error"),
+    [
+        ("pushover", {"enabled": True, "api_token": "", "targets": {}}, "api_token"),
+        ("telegram", {"enabled": True, "bot_token": " ", "targets": {}}, "bot_token"),
+        ("seven.io", {"enabled": True, "api_key": "", "targets": {}}, "api_key"),
+        ("pushover", {"enabled": True, "api_token": "app", "targets": {"default": {"user_key": ""}}}, "user_key"),
+        ("telegram", {"enabled": True, "bot_token": "token", "targets": {"default": {"chat_id": " "}}}, "chat_id"),
+        ("seven.io", {"enabled": True, "api_key": "key", "targets": {"default": {"to": ""}}}, "to"),
+    ],
+)
+def test_enabled_provider_rejects_empty_credentials_and_recipients(provider, config, error):
+    with pytest.raises(ValueError, match=error):
+        MessageAdapterConfig(providers={provider: config})
+
+
 def test_enabled_binding_requires_message_target():
     with pytest.raises(ValueError, match="at least one target"):
         MessageBindingConfig(providers=[])
@@ -364,6 +380,53 @@ async def test_any_operator_continues_draining_after_suppressed_pending_duplicat
     await _drain_sends(adapter)
 
     assert messages == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_in_flight_pending_events_are_bounded_to_newest_values(bus, monkeypatch):
+    monkeypatch.setattr("obs.adapters.message.adapter.MAX_PENDING_EVENTS_PER_BINDING", 2)
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id, unit=None)))
+    release = asyncio.Event()
+    messages: list[str] = []
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-bounded"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            messages.append(kwargs["message"])
+            await release.wait()
+            return MessageSendResult("slow-bounded", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-bounded": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        operator="any",
+        compare_value=None,
+        message="###DP###",
+        providers=[{"provider": "slow-bounded", "target": "default"}],
+        send_on_change=False,
+    )
+    await adapter.reload_bindings([binding])
+
+    for value in ["A", "B", "C", "D", "E"]:
+        await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=value, quality="good", source_adapter="test"))
+
+    state = adapter._states[binding.id]
+    assert len(state.pending_events) == 2
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert messages == ["A", "D", "E"]
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -158,6 +158,14 @@ def test_enabled_binding_requires_message_target():
     assert cfg.enabled is False
 
 
+def test_binding_rejects_blank_message_body():
+    with pytest.raises(ValueError, match="message must not be empty"):
+        MessageBindingConfig(
+            message="   ",
+            providers=[{"provider": "telegram", "target": "default"}],
+        )
+
+
 def test_binding_rejects_duplicate_message_targets():
     with pytest.raises(ValueError, match="Duplicate MESSAGE target"):
         MessageBindingConfig(

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -158,6 +158,16 @@ def test_enabled_binding_requires_message_target():
     assert cfg.enabled is False
 
 
+def test_binding_rejects_duplicate_message_targets():
+    with pytest.raises(ValueError, match="Duplicate MESSAGE target"):
+        MessageBindingConfig(
+            providers=[
+                {"provider": "telegram", "target": "default"},
+                {"provider": "telegram", "target": "default"},
+            ]
+        )
+
+
 @pytest.fixture
 def dummy_provider():
     provider = _DummyProvider()

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -1,0 +1,212 @@
+"""Unit tests for the MESSAGE adapter."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from obs.adapters.message.adapter import (
+    MessageAdapter,
+    evaluate_condition,
+    render_message,
+)
+from obs.adapters.message.providers.base import MessageSendResult
+from obs.adapters.message.providers.registry import register_provider
+from obs.core.event_bus import DataValueEvent
+from tests.adapters.conftest import make_binding
+
+
+class _DummyConfig(BaseModel):
+    enabled: bool = True
+    targets: dict[str, dict] = {}
+
+
+class _DummyProvider:
+    provider_type = "dummy"
+    config_schema = _DummyConfig
+    target_schema = BaseModel
+
+    def __init__(self) -> None:
+        self.send = AsyncMock(return_value=MessageSendResult("dummy", "default", True))
+
+
+class _Dp:
+    def __init__(self, dp_id: uuid.UUID, name: str = "Temperatur", unit: str | None = "°C") -> None:
+        self.id = dp_id
+        self.name = name
+        self.unit = unit
+
+
+class _Registry:
+    def __init__(self, dp: _Dp) -> None:
+        self._dp = dp
+
+    def get(self, dp_id: uuid.UUID) -> _Dp | None:
+        return self._dp if dp_id == self._dp.id else None
+
+
+@pytest.mark.parametrize(
+    ("value", "operator", "compare_value", "expected"),
+    [
+        ("anything", "any", None, True),
+        (None, "any", "ignored", True),
+        (29.4, ">=", 28, True),
+        ("29.4", "<", "30", True),
+        ("bad", "<", 30, False),
+        ("open", "=", "open", True),
+        (1, "==", "1", True),
+        (True, "==", "true", True),
+        (False, "==", "false", True),
+        (True, "!=", "false", True),
+        ("abc", "!=", "def", True),
+        ("hello world", "contains", "world", True),
+        ("hello world", "contains not", "mars", True),
+        ("sensor/temp", "starts with", "sensor", True),
+        ("sensor/temp", "ends with", "temp", True),
+    ],
+)
+def test_evaluate_condition(value, operator, compare_value, expected):
+    assert evaluate_condition(value, operator, compare_value) is expected
+
+
+def test_render_message_replaces_value_unit_and_metadata():
+    dp_id = uuid.uuid4()
+    ts = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+
+    rendered = render_message(
+        "###DPN### ###DPI### ###DP### ###DPU### ###TS###",
+        value=29.4,
+        unit="°C",
+        name="Temperatur",
+        datapoint_id=dp_id,
+        ts=ts,
+    )
+
+    assert rendered == f"Temperatur {dp_id} 29.4 °C 2026-06-28T12:00:00+00:00"
+
+
+@pytest.fixture
+def dummy_provider():
+    provider = _DummyProvider()
+    register_provider(provider)
+    return provider
+
+
+@pytest.fixture
+def bus():
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    return bus
+
+
+def _message_binding(dp_id: uuid.UUID, **config):
+    binding = make_binding(
+        {
+            "operator": ">=",
+            "compare_value": 28,
+            "message": "Temperatur kritisch: ###DP### ###DPU###",
+            "title": "OBS Alarm",
+            "providers": [{"provider": "dummy", "target": "default"}],
+            "send_on_change": True,
+            **config,
+        },
+        direction="SOURCE",
+    )
+    binding.datapoint_id = dp_id
+    return binding
+
+
+@pytest.mark.asyncio
+async def test_datapoint_update_sends_message_to_provider(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {"id": "x"}}}}},
+    )
+    binding = _message_binding(dp_id)
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=29.4, quality="good", source_adapter="test"))
+
+    dummy_provider.send.assert_awaited_once()
+    kwargs = dummy_provider.send.await_args.kwargs
+    assert kwargs["title"] == "OBS Alarm"
+    assert kwargs["message"] == "Temperatur kritisch: 29.4 °C"
+    assert kwargs["target_name"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_send_on_change_suppresses_repeated_true_condition(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id)
+    await adapter.reload_bindings([binding])
+
+    event = DataValueEvent(datapoint_id=dp_id, value=29.4, quality="good", source_adapter="test")
+    await adapter._on_value_event(event)
+    await adapter._on_value_event(event)
+
+    dummy_provider.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_repeated_sends(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, send_on_change=False, cooldown_seconds=300)
+    await adapter.reload_bindings([binding])
+
+    event = DataValueEvent(datapoint_id=dp_id, value=29.4, quality="good", source_adapter="test")
+    await adapter._on_value_event(event)
+    await adapter._on_value_event(event)
+
+    dummy_provider.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_condition_reset_allows_next_true_transition(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id)
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=29, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=20, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=30, quality="good", source_adapter="test"))
+
+    assert dummy_provider.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_any_operator_sends_for_each_changed_value(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, operator="any", compare_value=None, send_on_change=True)
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=False, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=False, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=True, quality="good", source_adapter="test"))
+
+    assert dummy_provider.send.await_count == 2

--- a/tests/adapters/test_message_adapter.py
+++ b/tests/adapters/test_message_adapter.py
@@ -157,7 +157,7 @@ def _message_binding(dp_id: uuid.UUID, **config):
 
 
 async def _drain_sends(adapter: MessageAdapter) -> None:
-    if adapter._send_tasks:
+    while adapter._send_tasks:
         await asyncio.gather(*list(adapter._send_tasks))
 
 
@@ -310,6 +310,23 @@ async def test_disabled_binding_is_not_reloaded(bus, dummy_provider):
 
 
 @pytest.mark.asyncio
+async def test_both_binding_is_not_observed(bus, dummy_provider):
+    dp_id = uuid.uuid4()
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id)
+    binding.direction = "BOTH"
+
+    await adapter.reload_bindings([binding])
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await _drain_sends(adapter)
+
+    dummy_provider.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_provider_failures_publish_warning(bus, dummy_provider, monkeypatch):
     dp_id = uuid.uuid4()
     monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
@@ -349,6 +366,38 @@ async def test_complete_provider_failure_is_retried_for_same_condition(bus, dumm
 
 
 @pytest.mark.asyncio
+async def test_partial_provider_failure_is_retried_for_same_condition(bus, dummy_provider, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    dummy_provider.send.side_effect = [
+        MessageSendResult("dummy", "ok", True),
+        MessageSendResult("dummy", "fail", False, "temporary"),
+        MessageSendResult("dummy", "ok", True),
+        MessageSendResult("dummy", "fail", False, "temporary"),
+    ]
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"dummy": {"enabled": True, "targets": {"ok": {}, "fail": {}}}}},
+    )
+    binding = _message_binding(
+        dp_id,
+        providers=[
+            {"provider": "dummy", "target": "ok"},
+            {"provider": "dummy", "target": "fail"},
+        ],
+    )
+    await adapter.reload_bindings([binding])
+    event = DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test")
+
+    await adapter._on_value_event(event)
+    await _drain_sends(adapter)
+    await adapter._on_value_event(event)
+    await _drain_sends(adapter)
+
+    assert dummy_provider.send.await_count == 4
+
+
+@pytest.mark.asyncio
 async def test_value_event_does_not_wait_for_provider_http_call(bus, monkeypatch):
     dp_id = uuid.uuid4()
     monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
@@ -378,6 +427,44 @@ async def test_value_event_does_not_wait_for_provider_http_call(bus, monkeypatch
     assert len(adapter._send_tasks) == 1
     release.set()
     await _drain_sends(adapter)
+
+
+@pytest.mark.asyncio
+async def test_false_true_transition_during_in_flight_send_is_retried(bus, monkeypatch):
+    dp_id = uuid.uuid4()
+    monkeypatch.setattr("obs.core.registry.get_registry", lambda: _Registry(_Dp(dp_id)))
+    release = asyncio.Event()
+    calls = 0
+
+    class _SlowProvider(_DummyProvider):
+        provider_type = "slow-transition"
+
+        def __init__(self) -> None:
+            pass
+
+        async def send(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            return MessageSendResult("slow-transition", "default", True)
+
+    provider = _SlowProvider()
+    register_provider(provider)
+    adapter = MessageAdapter(
+        event_bus=bus,
+        config={"providers": {"slow-transition": {"enabled": True, "targets": {"default": {}}}}},
+    )
+    binding = _message_binding(dp_id, providers=[{"provider": "slow-transition", "target": "default"}])
+    await adapter.reload_bindings([binding])
+
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=20, quality="good", source_adapter="test"))
+    await adapter._on_value_event(DataValueEvent(datapoint_id=dp_id, value=99, quality="good", source_adapter="test"))
+
+    release.set()
+    await _drain_sends(adapter)
+
+    assert calls == 2
 
 
 @pytest.mark.asyncio
@@ -541,6 +628,27 @@ async def test_sevenio_provider_reports_json_success_false(monkeypatch):
     _FakeAsyncClient.status_code = 200
     _FakeAsyncClient.text = ""
     _FakeAsyncClient.json_body = {"messages": [{"success": True}, {"success": False}]}
+    monkeypatch.setattr("obs.adapters.message.providers.sevenio.httpx.AsyncClient", _FakeAsyncClient)
+
+    result = await SevenIoProvider().send(
+        provider_config={"enabled": True, "api_key": "key", "targets": {}},
+        target_name="sms",
+        target_config={"to": "+4100000000", "channel": "sms"},
+        title=None,
+        message="Door",
+        context={},
+    )
+
+    assert result.ok is False
+    assert result.detail == "seven.io response success=false"
+
+
+@pytest.mark.asyncio
+async def test_sevenio_provider_reports_json_success_error_code(monkeypatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.status_code = 200
+    _FakeAsyncClient.text = ""
+    _FakeAsyncClient.json_body = {"success": "101"}
     monkeypatch.setattr("obs.adapters.message.providers.sevenio.httpx.AsyncClient", _FakeAsyncClient)
 
     result = await SevenIoProvider().send(

--- a/tests/integration/test_adapters_instances.py
+++ b/tests/integration/test_adapters_instances.py
@@ -517,3 +517,48 @@ async def test_migrate_message_bindings_rejects_missing_target_on_target_instanc
 
     assert resp.status_code == 422
     assert "MESSAGE target not configured" in resp.text
+
+
+async def test_migrate_message_bindings_prevalidates_before_updates(client, auth_headers):
+    source = await _create_message_instance(
+        client,
+        auth_headers,
+        config={
+            "providers": {
+                "pushover": {
+                    "enabled": True,
+                    "api_token": "app-token",
+                    "targets": {
+                        "default": {"user_key": "user-key"},
+                        "other": {"user_key": "other-key"},
+                    },
+                }
+            }
+        },
+    )
+    target = await _create_message_instance(client, auth_headers, config=_message_instance_config(target="default"))
+    dp_ok = await _create_dp(client, auth_headers)
+    dp_bad = await _create_dp(client, auth_headers)
+    for dp, target_name in ((dp_ok, "default"), (dp_bad, "other")):
+        create_resp = await client.post(
+            f"/api/v1/datapoints/{dp['id']}/bindings",
+            json={
+                "adapter_instance_id": source["id"],
+                "direction": "SOURCE",
+                "config": {"providers": [{"provider": "pushover", "target": target_name}]},
+            },
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+    resp = await client.post(
+        f"/api/v1/adapters/instances/{source['id']}/bindings/migrate",
+        json={"target_instance_id": target["id"]},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    source_bindings = await client.get(f"/api/v1/adapters/instances/{source['id']}/bindings", headers=auth_headers)
+    target_bindings = await client.get(f"/api/v1/adapters/instances/{target['id']}/bindings", headers=auth_headers)
+    assert len(source_bindings.json()) == 2
+    assert target_bindings.json() == []

--- a/tests/integration/test_adapters_instances.py
+++ b/tests/integration/test_adapters_instances.py
@@ -37,6 +37,43 @@ async def _create_instance(client, auth_headers, name: str = "", adapter_type: s
     return resp.json()
 
 
+def _message_instance_config(target: str = "default") -> dict:
+    return {
+        "providers": {
+            "pushover": {
+                "enabled": True,
+                "api_token": "app-token",
+                "targets": {target: {"user_key": "user-key"}},
+            }
+        }
+    }
+
+
+async def _create_message_instance(client, auth_headers, config: dict | None = None) -> dict:
+    resp = await client.post(
+        "/api/v1/adapters/instances",
+        json={
+            "adapter_type": "MESSAGE",
+            "name": f"MsgInst-{uuid.uuid4().hex[:6]}",
+            "config": config or _message_instance_config(),
+            "enabled": False,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_dp(client, auth_headers) -> dict:
+    resp = await client.post(
+        "/api/v1/datapoints/",
+        json={"name": f"AdpMsgDP-{uuid.uuid4().hex[:8]}", "data_type": "FLOAT"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
 async def _create_non_admin_headers(client, auth_headers) -> tuple[str, dict]:
     username = f"adp-user-{uuid.uuid4().hex[:8]}"
     resp = await client.post(
@@ -208,6 +245,30 @@ async def test_update_instance_config(client, auth_headers):
     )
     assert resp.status_code == 200
     assert resp.json()["config"].get("offset_override") == 5
+
+
+async def test_update_message_instance_rejects_target_rename_used_by_binding(client, auth_headers):
+    inst = await _create_message_instance(client, auth_headers)
+    dp = await _create_dp(client, auth_headers)
+    create_resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+
+    resp = await client.patch(
+        f"/api/v1/adapters/instances/{inst['id']}",
+        json={"config": _message_instance_config(target="renamed")},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "MESSAGE target not configured" in resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_adapters_instances.py
+++ b/tests/integration/test_adapters_instances.py
@@ -492,3 +492,28 @@ async def test_migrate_instance_bindings_non_admin_forbidden(client, auth_header
         assert resp.status_code == 403
     finally:
         await client.delete(f"/api/v1/auth/users/{username}", headers=auth_headers)
+
+
+async def test_migrate_message_bindings_rejects_missing_target_on_target_instance(client, auth_headers):
+    source = await _create_message_instance(client, auth_headers, config=_message_instance_config(target="default"))
+    target = await _create_message_instance(client, auth_headers, config=_message_instance_config(target="other"))
+    dp = await _create_dp(client, auth_headers)
+    create_resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": source["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+
+    resp = await client.post(
+        f"/api/v1/adapters/instances/{source['id']}/bindings/migrate",
+        json={"target_instance_id": target["id"]},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "MESSAGE target not configured" in resp.text

--- a/tests/integration/test_bindings_api.py
+++ b/tests/integration/test_bindings_api.py
@@ -48,13 +48,25 @@ async def _create_instance(client, auth_headers, name: str = "") -> dict:
     return resp.json()
 
 
-async def _create_message_instance(client, auth_headers, name: str = "") -> dict:
+def _message_instance_config() -> dict:
+    return {
+        "providers": {
+            "pushover": {
+                "enabled": True,
+                "api_token": "app-token",
+                "targets": {"default": {"user_key": "user-key"}},
+            }
+        }
+    }
+
+
+async def _create_message_instance(client, auth_headers, name: str = "", config: dict | None = None) -> dict:
     resp = await client.post(
         "/api/v1/adapters/instances",
         json={
             "adapter_type": "MESSAGE",
             "name": name or f"MsgBindTest-{uuid.uuid4().hex[:6]}",
-            "config": {},
+            "config": config or {},
             "enabled": False,
         },
         headers=auth_headers,
@@ -228,6 +240,24 @@ async def test_create_disabled_message_binding_allows_no_targets(client, auth_he
     assert resp.json()["enabled"] is False
 
 
+async def test_create_message_binding_rejects_unknown_instance_target(client, auth_headers):
+    dp = await _create_dp(client, auth_headers)
+    inst = await _create_message_instance(client, auth_headers, config=_message_instance_config())
+
+    resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "missing"}]},
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "MESSAGE target not configured" in resp.text
+
+
 async def test_create_binding_invalid_formula_returns_422(client, auth_headers):
     dp = await _create_dp(client, auth_headers)
     inst = await _create_instance(client, auth_headers)
@@ -305,7 +335,7 @@ async def test_update_binding_success(client, auth_headers):
 
 async def test_update_disabled_message_binding_allows_no_targets(client, auth_headers):
     dp = await _create_dp(client, auth_headers)
-    inst = await _create_message_instance(client, auth_headers)
+    inst = await _create_message_instance(client, auth_headers, config=_message_instance_config())
     create_resp = await client.post(
         f"/api/v1/datapoints/{dp['id']}/bindings",
         json={

--- a/tests/integration/test_bindings_api.py
+++ b/tests/integration/test_bindings_api.py
@@ -258,6 +258,27 @@ async def test_create_message_binding_rejects_unknown_instance_target(client, au
     assert "MESSAGE target not configured" in resp.text
 
 
+async def test_create_message_binding_rejects_blank_message_body(client, auth_headers):
+    dp = await _create_dp(client, auth_headers)
+    inst = await _create_message_instance(client, auth_headers, config=_message_instance_config())
+
+    resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {
+                "message": "   ",
+                "providers": [{"provider": "pushover", "target": "default"}],
+            },
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "message must not be empty" in resp.text
+
+
 async def test_create_binding_invalid_formula_returns_422(client, auth_headers):
     dp = await _create_dp(client, auth_headers)
     inst = await _create_instance(client, auth_headers)

--- a/tests/integration/test_bindings_api.py
+++ b/tests/integration/test_bindings_api.py
@@ -258,6 +258,36 @@ async def test_create_message_binding_rejects_unknown_instance_target(client, au
     assert "MESSAGE target not configured" in resp.text
 
 
+async def test_create_message_binding_uses_parsed_provider_enabled_flag(client, auth_headers):
+    dp = await _create_dp(client, auth_headers)
+    inst = await _create_message_instance(
+        client,
+        auth_headers,
+        config={
+            "providers": {
+                "pushover": {
+                    "enabled": "false",
+                    "api_token": "app-token",
+                    "targets": {"default": {"user_key": "user-key"}},
+                }
+            }
+        },
+    )
+
+    resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "MESSAGE provider is disabled" in resp.text
+
+
 async def test_create_message_binding_rejects_blank_message_body(client, auth_headers):
     dp = await _create_dp(client, auth_headers)
     inst = await _create_message_instance(client, auth_headers, config=_message_instance_config())

--- a/tests/integration/test_bindings_api.py
+++ b/tests/integration/test_bindings_api.py
@@ -48,6 +48,21 @@ async def _create_instance(client, auth_headers, name: str = "") -> dict:
     return resp.json()
 
 
+async def _create_message_instance(client, auth_headers, name: str = "") -> dict:
+    resp = await client.post(
+        "/api/v1/adapters/instances",
+        json={
+            "adapter_type": "MESSAGE",
+            "name": name or f"MsgBindTest-{uuid.uuid4().hex[:6]}",
+            "config": {},
+            "enabled": False,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
 async def _create_non_admin_headers(client, auth_headers) -> tuple[str, dict]:
     username = f"bind-user-{uuid.uuid4().hex[:8]}"
     resp = await client.post(
@@ -194,6 +209,25 @@ async def test_create_binding_with_formula(client, auth_headers):
     assert resp.json()["value_formula"] == "x * 2"
 
 
+async def test_create_disabled_message_binding_allows_no_targets(client, auth_headers):
+    dp = await _create_dp(client, auth_headers)
+    inst = await _create_message_instance(client, auth_headers)
+
+    resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": []},
+            "enabled": False,
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["enabled"] is False
+
+
 async def test_create_binding_invalid_formula_returns_422(client, auth_headers):
     dp = await _create_dp(client, auth_headers)
     inst = await _create_instance(client, auth_headers)
@@ -267,6 +301,31 @@ async def test_update_binding_success(client, auth_headers):
     body = resp.json()
     assert body["enabled"] is False
     assert body["direction"] == "BOTH"
+
+
+async def test_update_disabled_message_binding_allows_no_targets(client, auth_headers):
+    dp = await _create_dp(client, auth_headers)
+    inst = await _create_message_instance(client, auth_headers)
+    create_resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+
+    resp = await client.patch(
+        f"/api/v1/datapoints/{dp['id']}/bindings/{create_resp.json()['id']}",
+        json={"enabled": False, "config": {"providers": []}},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["enabled"] is False
+    assert resp.json()["config"] == {"providers": []}
 
 
 async def test_update_binding_formula(client, auth_headers):

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -405,6 +405,35 @@ async def test_import_binding_invalid_formula_records_error(client, auth_headers
     assert len(resp.json()["errors"]) > 0
 
 
+async def test_import_message_binding_non_source_direction_records_error(client, auth_headers):
+    dp_id = str(uuid.uuid4())
+    inst_id = str(uuid.uuid4())
+    binding_id = str(uuid.uuid4())
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [{"id": dp_id, "name": f"MsgDP-{uuid.uuid4().hex[:6]}", "data_type": "FLOAT", "unit": None, "tags": [], "mqtt_alias": None}],
+        "bindings": [
+            {
+                "id": binding_id,
+                "datapoint_id": dp_id,
+                "adapter_type": "MESSAGE",
+                "adapter_instance_id": inst_id,
+                "direction": "DEST",
+                "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+                "enabled": True,
+            }
+        ],
+        "adapter_instances": [
+            {"id": inst_id, "adapter_type": "MESSAGE", "name": f"MsgInst-{uuid.uuid4().hex[:6]}", "config": {}, "enabled": False}
+        ],
+    }
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert any("MESSAGE-Bindings" in error for error in resp.json()["errors"])
+
+
 # ---------------------------------------------------------------------------
 # POST /config/import  — datapoint UPDATE path (existing DP gets updated)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -506,6 +506,54 @@ async def test_import_message_binding_rejects_unknown_instance_target(client, au
     assert any("MESSAGE target not configured" in error for error in body["errors"])
 
 
+async def test_import_message_binding_rejects_blank_message_body(client, auth_headers):
+    dp_id = str(uuid.uuid4())
+    inst_id = str(uuid.uuid4())
+    binding_id = str(uuid.uuid4())
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [{"id": dp_id, "name": f"MsgDP-{uuid.uuid4().hex[:6]}", "data_type": "FLOAT", "unit": None, "tags": [], "mqtt_alias": None}],
+        "bindings": [
+            {
+                "id": binding_id,
+                "datapoint_id": dp_id,
+                "adapter_type": "MESSAGE",
+                "adapter_instance_id": inst_id,
+                "direction": "SOURCE",
+                "config": {
+                    "message": "",
+                    "providers": [{"provider": "pushover", "target": "default"}],
+                },
+                "enabled": True,
+            }
+        ],
+        "adapter_instances": [
+            {
+                "id": inst_id,
+                "adapter_type": "MESSAGE",
+                "name": f"MsgInst-{uuid.uuid4().hex[:6]}",
+                "config": {
+                    "providers": {
+                        "pushover": {
+                            "enabled": True,
+                            "api_token": "app-token",
+                            "targets": {"default": {"user_key": "user-key"}},
+                        }
+                    }
+                },
+                "enabled": False,
+            }
+        ],
+    }
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bindings_created"] == 0
+    assert any("message must not be empty" in error for error in body["errors"])
+
+
 # ---------------------------------------------------------------------------
 # POST /config/import  — datapoint UPDATE path (existing DP gets updated)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -533,6 +533,35 @@ async def test_import_message_binding_rejects_unknown_instance_target(client, au
     assert any("MESSAGE target not configured" in error for error in body["errors"])
 
 
+async def test_import_message_binding_rejects_missing_instance(client, auth_headers):
+    dp_id = str(uuid.uuid4())
+    inst_id = str(uuid.uuid4())
+    binding_id = str(uuid.uuid4())
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [{"id": dp_id, "name": f"MsgDP-{uuid.uuid4().hex[:6]}", "data_type": "FLOAT", "unit": None, "tags": [], "mqtt_alias": None}],
+        "bindings": [
+            {
+                "id": binding_id,
+                "datapoint_id": dp_id,
+                "adapter_type": "MESSAGE",
+                "adapter_instance_id": inst_id,
+                "direction": "SOURCE",
+                "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+                "enabled": True,
+            }
+        ],
+    }
+
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bindings_created"] == 0
+    assert any(f"MESSAGE adapter instance not found: {inst_id}" in error for error in body["errors"])
+
+
 async def test_import_message_binding_rejects_blank_message_body(client, auth_headers):
     dp_id = str(uuid.uuid4())
     inst_id = str(uuid.uuid4())

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -49,6 +49,33 @@ async def _make_instance(client, auth_headers) -> dict:
     return resp.json()
 
 
+def _message_instance_config(target: str = "default") -> dict:
+    return {
+        "providers": {
+            "pushover": {
+                "enabled": True,
+                "api_token": "app-token",
+                "targets": {target: {"user_key": "user-key"}},
+            }
+        }
+    }
+
+
+async def _make_message_instance(client, auth_headers, config: dict | None = None) -> dict:
+    resp = await client.post(
+        "/api/v1/adapters/instances",
+        json={
+            "adapter_type": "MESSAGE",
+            "name": f"CfgMsgInst-{uuid.uuid4().hex[:6]}",
+            "config": config or _message_instance_config(),
+            "enabled": False,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
 async def _make_graph(client, auth_headers) -> dict:
     resp = await client.post(
         "/api/v1/logic/graphs",
@@ -552,6 +579,45 @@ async def test_import_message_binding_rejects_blank_message_body(client, auth_he
     body = resp.json()
     assert body["bindings_created"] == 0
     assert any("message must not be empty" in error for error in body["errors"])
+
+
+async def test_import_message_instance_config_does_not_orphan_existing_binding(client, auth_headers):
+    dp = await _make_dp(client, auth_headers)
+    inst = await _make_message_instance(client, auth_headers, config=_message_instance_config(target="default"))
+    create_resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [],
+        "bindings": [],
+        "adapter_instances": [
+            {
+                "id": inst["id"],
+                "adapter_type": "MESSAGE",
+                "name": inst["name"],
+                "config": _message_instance_config(target="renamed"),
+                "enabled": False,
+            }
+        ],
+    }
+
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["adapter_instances_upserted"] == 0
+    assert any("MESSAGE target not configured" in error for error in body["errors"])
+    get_resp = await client.get(f"/api/v1/adapters/instances/{inst['id']}", headers=auth_headers)
+    assert set(get_resp.json()["config"]["providers"]["pushover"]["targets"]) == {"default"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -620,6 +620,62 @@ async def test_import_message_instance_config_does_not_orphan_existing_binding(c
     assert set(get_resp.json()["config"]["providers"]["pushover"]["targets"]) == {"default"}
 
 
+async def test_import_message_binding_update_validates_against_existing_instance(client, auth_headers):
+    dp = await _make_dp(client, auth_headers)
+    old_inst = await _make_message_instance(client, auth_headers, config=_message_instance_config(target="default"))
+    new_inst = await _make_message_instance(client, auth_headers, config=_message_instance_config(target="other"))
+    create_resp = await client.post(
+        f"/api/v1/datapoints/{dp['id']}/bindings",
+        json={
+            "adapter_instance_id": old_inst["id"],
+            "direction": "SOURCE",
+            "config": {"providers": [{"provider": "pushover", "target": "default"}]},
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    binding = create_resp.json()
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [],
+        "bindings": [
+            {
+                "id": binding["id"],
+                "datapoint_id": dp["id"],
+                "adapter_type": "MESSAGE",
+                "adapter_instance_id": new_inst["id"],
+                "direction": "SOURCE",
+                "config": {"providers": [{"provider": "pushover", "target": "other"}]},
+                "enabled": True,
+            }
+        ],
+        "adapter_instances": [
+            {
+                "id": old_inst["id"],
+                "adapter_type": "MESSAGE",
+                "name": old_inst["name"],
+                "config": _message_instance_config(target="renamed"),
+                "enabled": False,
+            }
+        ],
+    }
+
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["adapter_instances_upserted"] == 0
+    assert body["bindings_updated"] == 0
+    assert any("MESSAGE target not configured" in error for error in body["errors"])
+    old_get_resp = await client.get(f"/api/v1/adapters/instances/{old_inst['id']}", headers=auth_headers)
+    assert set(old_get_resp.json()["config"]["providers"]["pushover"]["targets"]) == {"default"}
+    export_resp = await client.get("/api/v1/config/export", headers=auth_headers)
+    imported_binding = next(item for item in export_resp.json()["bindings"] if item["id"] == binding["id"])
+    assert imported_binding["adapter_instance_id"] == old_inst["id"]
+    assert imported_binding["config"] == {"providers": [{"provider": "pushover", "target": "default"}]}
+
+
 # ---------------------------------------------------------------------------
 # POST /config/import  — datapoint UPDATE path (existing DP gets updated)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -424,9 +424,7 @@ async def test_import_message_binding_non_source_direction_records_error(client,
                 "enabled": True,
             }
         ],
-        "adapter_instances": [
-            {"id": inst_id, "adapter_type": "MESSAGE", "name": f"MsgInst-{uuid.uuid4().hex[:6]}", "config": {}, "enabled": False}
-        ],
+        "adapter_instances": [{"id": inst_id, "adapter_type": "MESSAGE", "name": f"MsgInst-{uuid.uuid4().hex[:6]}", "config": {}, "enabled": False}],
     }
     resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
 

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -432,6 +432,35 @@ async def test_import_message_binding_non_source_direction_records_error(client,
     assert any("MESSAGE-Bindings" in error for error in resp.json()["errors"])
 
 
+async def test_import_disabled_message_binding_allows_no_targets(client, auth_headers):
+    dp_id = str(uuid.uuid4())
+    inst_id = str(uuid.uuid4())
+    binding_id = str(uuid.uuid4())
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [{"id": dp_id, "name": f"MsgDP-{uuid.uuid4().hex[:6]}", "data_type": "FLOAT", "unit": None, "tags": [], "mqtt_alias": None}],
+        "bindings": [
+            {
+                "id": binding_id,
+                "datapoint_id": dp_id,
+                "adapter_type": "MESSAGE",
+                "adapter_instance_id": inst_id,
+                "direction": "SOURCE",
+                "config": {"providers": []},
+                "enabled": False,
+            }
+        ],
+        "adapter_instances": [{"id": inst_id, "adapter_type": "MESSAGE", "name": f"MsgInst-{uuid.uuid4().hex[:6]}", "config": {}, "enabled": False}],
+    }
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bindings_created"] == 1
+    assert body["errors"] == []
+
+
 # ---------------------------------------------------------------------------
 # POST /config/import  — datapoint UPDATE path (existing DP gets updated)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_config_api.py
+++ b/tests/integration/test_config_api.py
@@ -461,6 +461,51 @@ async def test_import_disabled_message_binding_allows_no_targets(client, auth_he
     assert body["errors"] == []
 
 
+async def test_import_message_binding_rejects_unknown_instance_target(client, auth_headers):
+    dp_id = str(uuid.uuid4())
+    inst_id = str(uuid.uuid4())
+    binding_id = str(uuid.uuid4())
+    payload = {
+        "obs_version": "5",
+        "exported_at": "2024-01-01T00:00:00",
+        "datapoints": [{"id": dp_id, "name": f"MsgDP-{uuid.uuid4().hex[:6]}", "data_type": "FLOAT", "unit": None, "tags": [], "mqtt_alias": None}],
+        "bindings": [
+            {
+                "id": binding_id,
+                "datapoint_id": dp_id,
+                "adapter_type": "MESSAGE",
+                "adapter_instance_id": inst_id,
+                "direction": "SOURCE",
+                "config": {"providers": [{"provider": "pushover", "target": "missing"}]},
+                "enabled": True,
+            }
+        ],
+        "adapter_instances": [
+            {
+                "id": inst_id,
+                "adapter_type": "MESSAGE",
+                "name": f"MsgInst-{uuid.uuid4().hex[:6]}",
+                "config": {
+                    "providers": {
+                        "pushover": {
+                            "enabled": True,
+                            "api_token": "app-token",
+                            "targets": {"default": {"user_key": "user-key"}},
+                        }
+                    }
+                },
+                "enabled": False,
+            }
+        ],
+    }
+    resp = await client.post("/api/v1/config/import", json=payload, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bindings_created"] == 0
+    assert any("MESSAGE target not configured" in error for error in body["errors"])
+
+
 # ---------------------------------------------------------------------------
 # POST /config/import  — datapoint UPDATE path (existing DP gets updated)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_support_api.py
+++ b/tests/integration/test_support_api.py
@@ -550,6 +550,7 @@ def test_sanitize_support_data_redacts_dictionary_keys_and_preserves_path_basena
                 "sniffer.process.com": {"status": "ok"},
             },
             "logger": "mqtt.customer.local api_key=logger-secret",
+            "to": "+41000000000",
             "user_key": "pushover-user-key",
             "path": "obs.db",
             "config_source": r"C:\Users\Alice\obs\customer.com.key",
@@ -566,6 +567,7 @@ def test_sanitize_support_data_redacts_dictionary_keys_and_preserves_path_basena
     assert "[REDACTED_IP] (2)" in sanitized["devices"]
     assert "[REDACTED_DOMAIN]" in sanitized["devices"]
     assert sanitized["devices"]["access_token"] == "[REDACTED]"
+    assert sanitized["to"] == "[REDACTED]"
     assert sanitized["user_key"] == "[REDACTED]"
     assert "mqtt.customer.local" not in sanitized["logger"]
     assert "logger-secret" not in sanitized["logger"]

--- a/tests/integration/test_support_api.py
+++ b/tests/integration/test_support_api.py
@@ -247,6 +247,37 @@ async def test_support_package_sanitizes_adapter_config_and_counts(client, auth_
     assert adapter["metrics_source"] == "ringbuffer_metadata_adapter_instance_60s"
 
 
+async def test_support_package_redacts_message_telegram_chat_id(client, auth_headers):
+    instance_resp = await client.post(
+        "/api/v1/adapters/instances",
+        json={
+            "adapter_type": "MESSAGE",
+            "name": "Support Message Telegram",
+            "enabled": False,
+            "config": {
+                "providers": {
+                    "telegram": {
+                        "enabled": True,
+                        "bot_token": "telegram-token",
+                        "targets": {"default": {"chat_id": "123456789"}},
+                    }
+                }
+            },
+        },
+        headers=auth_headers,
+    )
+    assert instance_resp.status_code == 201, instance_resp.text
+    instance_id = instance_resp.json()["id"]
+
+    resp = await client.post("/api/v1/support/package", headers=auth_headers)
+
+    assert resp.status_code == 200
+    adapter = next(entry for entry in resp.json()["adapters"] if entry["id"] == instance_id)
+    telegram = adapter["config"]["providers"]["telegram"]
+    assert telegram["bot_token"] == "[REDACTED]"
+    assert telegram["targets"]["default"]["chat_id"] == "[REDACTED]"
+
+
 async def test_support_package_reports_ringbuffer_tps_for_adapter(client, auth_headers):
     instance_resp = await client.post(
         "/api/v1/adapters/instances",

--- a/tests/integration/test_support_api.py
+++ b/tests/integration/test_support_api.py
@@ -552,6 +552,7 @@ def test_sanitize_support_data_redacts_dictionary_keys_and_preserves_path_basena
             "logger": "mqtt.customer.local api_key=logger-secret",
             "to": "+41000000000",
             "user_key": "pushover-user-key",
+            "chat_id": "123456789",
             "path": "obs.db",
             "config_source": r"C:\Users\Alice\obs\customer.com.key",
         }
@@ -569,6 +570,7 @@ def test_sanitize_support_data_redacts_dictionary_keys_and_preserves_path_basena
     assert sanitized["devices"]["access_token"] == "[REDACTED]"
     assert sanitized["to"] == "[REDACTED]"
     assert sanitized["user_key"] == "[REDACTED]"
+    assert sanitized["chat_id"] == "[REDACTED]"
     assert "mqtt.customer.local" not in sanitized["logger"]
     assert "logger-secret" not in sanitized["logger"]
     assert "[REDACTED_DOMAIN]" in sanitized["logger"]

--- a/tests/integration/test_support_api.py
+++ b/tests/integration/test_support_api.py
@@ -550,6 +550,7 @@ def test_sanitize_support_data_redacts_dictionary_keys_and_preserves_path_basena
                 "sniffer.process.com": {"status": "ok"},
             },
             "logger": "mqtt.customer.local api_key=logger-secret",
+            "user_key": "pushover-user-key",
             "path": "obs.db",
             "config_source": r"C:\Users\Alice\obs\customer.com.key",
         }
@@ -565,6 +566,7 @@ def test_sanitize_support_data_redacts_dictionary_keys_and_preserves_path_basena
     assert "[REDACTED_IP] (2)" in sanitized["devices"]
     assert "[REDACTED_DOMAIN]" in sanitized["devices"]
     assert sanitized["devices"]["access_token"] == "[REDACTED]"
+    assert sanitized["user_key"] == "[REDACTED]"
     assert "mqtt.customer.local" not in sanitized["logger"]
     assert "logger-secret" not in sanitized["logger"]
     assert "[REDACTED_DOMAIN]" in sanitized["logger"]

--- a/tests/unit/test_coverage_api_auth_icons_dp.py
+++ b/tests/unit/test_coverage_api_auth_icons_dp.py
@@ -1791,6 +1791,16 @@ class TestCreateBinding:
         result = await bindings_api.create_binding(dp_id=dp.id, body=body, _user="admin", db=db)
         assert result.adapter_type == "MQTT"
 
+    def test_validate_message_binding_rejects_non_source_direction(self):
+        with pytest.raises(HTTPException) as exc:
+            bindings_api._validate_adapter_binding(
+                "MESSAGE",
+                "DEST",
+                {"providers": [{"provider": "pushover", "target": "default"}]},
+            )
+
+        assert exc.value.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # bindings.py — update_binding endpoint

--- a/tests/unit/test_coverage_config_ringbuffer_misc.py
+++ b/tests/unit/test_coverage_config_ringbuffer_misc.py
@@ -535,7 +535,7 @@ async def test_import_config_updates_existing_binding(monkeypatch):
 
     bind_id = str(uuid.uuid4())
     # fetchone returns existing row
-    db = _DbStub(fetchone_result=_row({"id": bind_id}))
+    db = _DbStub(fetchone_result=_row({"id": bind_id, "adapter_type": "mqtt", "adapter_instance_id": None}))
 
     body = _make_config_export(
         bindings=[

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -126,6 +126,19 @@ async def test_no_value_filters_does_not_keep_last_value_cache(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_write_to_dest_bindings_skips_message_observers(monkeypatch):
+    binding = _binding(adapter_type="MESSAGE")
+    instance = _FakeInstance()
+    router = _make_router([{"id": str(binding.id), "adapter_type": "MESSAGE"}])
+
+    _patch_registry(monkeypatch, binding, instance)
+
+    await router._write_to_dest_bindings(uuid.uuid4(), "value", skip_binding_id=None)
+
+    assert instance.writes == []
+
+
+@pytest.mark.asyncio
 async def test_send_on_change_does_not_cache_full_large_object(monkeypatch):
     binding = _binding(send_on_change=True)
     instance = _FakeInstance()
@@ -286,6 +299,24 @@ async def test_handle_ignores_disabled_bindings_without_publishing_internal_stat
     await router.handle(dp_id, "21.5")
 
     bus.publish.assert_not_awaited()
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_publishes_internal_state_for_message_only_binding():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    router = _make_router([_row(datapoint_id=str(dp_id), direction="SOURCE", adapter_type="MESSAGE")])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal Alarm", data_type="FLOAT"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "21.5")
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == pytest.approx(21.5)
     router._write_to_dest_bindings.assert_not_awaited()
 
 

--- a/tests/unit/test_write_router.py
+++ b/tests/unit/test_write_router.py
@@ -288,7 +288,7 @@ async def test_handle_ignores_source_only_datapoint_without_publishing_state():
 
 
 @pytest.mark.asyncio
-async def test_handle_ignores_disabled_bindings_without_publishing_internal_state():
+async def test_handle_ignores_disabled_bindings_when_deciding_write_semantics():
     dp_id = uuid.uuid4()
     bus = SimpleNamespace(publish=AsyncMock())
     router = _make_router([_row(datapoint_id=str(dp_id), direction="DEST", enabled=0)])
@@ -298,7 +298,10 @@ async def test_handle_ignores_disabled_bindings_without_publishing_internal_stat
 
     await router.handle(dp_id, "21.5")
 
-    bus.publish.assert_not_awaited()
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == pytest.approx(21.5)
     router._write_to_dest_bindings.assert_not_awaited()
 
 
@@ -307,6 +310,28 @@ async def test_handle_publishes_internal_state_for_message_only_binding():
     dp_id = uuid.uuid4()
     bus = SimpleNamespace(publish=AsyncMock())
     router = _make_router([_row(datapoint_id=str(dp_id), direction="SOURCE", adapter_type="MESSAGE")])
+    router._bus = bus
+    router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal Alarm", data_type="FLOAT"))
+    router._write_to_dest_bindings = AsyncMock()
+
+    await router.handle(dp_id, "21.5")
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.datapoint_id == dp_id
+    assert event.value == pytest.approx(21.5)
+    router._write_to_dest_bindings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_publishes_internal_state_for_message_with_disabled_write_binding():
+    dp_id = uuid.uuid4()
+    bus = SimpleNamespace(publish=AsyncMock())
+    rows = [
+        _row(datapoint_id=str(dp_id), direction="SOURCE", adapter_type="MESSAGE"),
+        _row(datapoint_id=str(dp_id), direction="SOURCE", adapter_type="KNX", enabled=0),
+    ]
+    router = _make_router(rows)
     router._bus = bus
     router._registry = SimpleNamespace(get=lambda _dp_id: SimpleNamespace(name="Internal Alarm", data_type="FLOAT"))
     router._write_to_dest_bindings = AsyncMock()


### PR DESCRIPTION
## Summary

Implements the MESSAGE notification adapter for issue #882.

The adapter observes data point value updates through SOURCE bindings and sends notification messages when the configured condition matches. Bindings support comparison operators, `any`, `send_on_change`, cooldowns, message templates, and multiple provider targets.

Supported providers for now:
- Pushover
- Telegram
- seven.io SMS/Voice

Signal is intentionally not included at this time because it requires operating a separate Signal gateway service.

## User impact

Admins can configure a notification adapter instance, add provider targets, and link data points to message bindings directly from the Admin GUI. MESSAGE bindings stay in the read direction to reflect that they observe value changes.

## Validation

- `.venv/bin/pytest tests/adapters/test_message_adapter.py tests/adapters/test_registry.py`
- `npm test -- --run tests/components/datapoints/BindingForm.spec.js tests/components/datapoints/BindingForm.submit.spec.js tests/views/AdaptersView.spec.js tests/views/DataPointDetailView.spec.js`
- Locale JSON parse check for `de.json` and `en.json`
