### PR TITLE
fix: serve obs_logo_light/dark.svg as explicit routes (issue #912)

### DIFF
--- a/obs/main.py
+++ b/obs/main.py
@@ -248,6 +248,14 @@ def create_app() -> FastAPI:
         async def admin_apple_touch_icon():
             return FileResponse(_gui_dist / "apple-touch-icon.png")
 
+        @app.get("/obs_logo_light.svg", include_in_schema=False)
+        async def obs_logo_light():
+            return FileResponse(_gui_dist / "obs_logo_light.svg")
+
+        @app.get("/obs_logo_dark.svg", include_in_schema=False)
+        async def obs_logo_dark():
+            return FileResponse(_gui_dist / "obs_logo_dark.svg")
+
     # ── Serve Visu SPA (frontend_dist → /visu) ────────────────────────────
     _visu_dist = Path(__file__).parent.parent / "frontend_dist"
     if _visu_dist.is_dir():

--- a/tests/integration/test_visu_static_files.py
+++ b/tests/integration/test_visu_static_files.py
@@ -130,6 +130,8 @@ async def gui_dist_client(tmp_path):
             ("favicon.svg", b'<svg xmlns="http://www.w3.org/2000/svg"/>'),
             ("manifest.webmanifest", b'{"name":"OBS Admin"}'),
             ("apple-touch-icon.png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 8),
+            ("obs_logo_light.svg", b'<svg xmlns="http://www.w3.org/2000/svg" id="light"/>'),
+            ("obs_logo_dark.svg", b'<svg xmlns="http://www.w3.org/2000/svg" id="dark"/>'),
             ("index.html", b"<html/>"),
         ]:
             target = gui_dist / name
@@ -192,3 +194,17 @@ async def test_admin_apple_touch_icon_returns_png(gui_dist_client):
     resp = await gui_dist_client.get("/apple-touch-icon.png")
     assert resp.status_code == 200
     assert resp.headers.get("content-type", "").startswith("image/png")
+
+
+@pytest.mark.asyncio
+async def test_obs_logo_light_returns_svg(gui_dist_client):
+    resp = await gui_dist_client.get("/obs_logo_light.svg")
+    assert resp.status_code == 200
+    assert "svg" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.asyncio
+async def test_obs_logo_dark_returns_svg(gui_dist_client):
+    resp = await gui_dist_client.get("/obs_logo_dark.svg")
+    assert resp.status_code == 200
+    assert "svg" in resp.headers.get("content-type", "")


### PR DESCRIPTION
## Summary

- `obs_logo_light.svg` and `obs_logo_dark.svg` were added to `gui/public/` in fe621aed (theme-aware login logos), but no dedicated FastAPI routes were registered for them
- Requests for `/obs_logo_light.svg` and `/obs_logo_dark.svg` hit the 404 catch-all handler, which returns `index.html` — unauthenticated users get the login page HTML rendered as the image source instead of the SVG
- Adds two explicit GET routes (`/obs_logo_light.svg`, `/obs_logo_dark.svg`) following the exact same pattern established for `/favicon.svg`, `/manifest.webmanifest`, and `/apple-touch-icon.png` (PR #884)
- Both Admin GUI and Visu login views reference these paths without a `/visu/` prefix, so the single pair of root-level routes covers both SPAs

## Test plan

- [x] `tools/with-venv ./tools/lint.sh --check` — passes
- [x] `tools/with-venv pytest tests/integration/test_visu_static_files.py -v` — 8/8 pass (including 2 new tests for the logo routes)
- [x] `tools/with-venv pytest tests/unit tests/adapters tests/contracts -q` — 3956 passed
- [x] `./tools/check-i18n-hardcoded-strings.sh` — nothing to check (no frontend changes)

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)