### PR TITLE
ci: make Node installs reproducible across automated builds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Playwright dependencies
         working-directory: tests/gui
         run: |
-          npm install
+          npm ci
           npx playwright install --with-deps chromium
 
       - name: Run Playwright suite

--- a/.github/workflows/lxc-template.yml
+++ b/.github/workflows/lxc-template.yml
@@ -83,13 +83,13 @@ jobs:
       - name: Build Admin GUI
         run: |
           cd gui
-          npm install --prefer-offline
+          npm ci --prefer-offline
           npm run build
 
       - name: Build Visu Frontend
         run: |
           cd frontend
-          npm install --prefer-offline
+          npm ci --prefer-offline
           npm run build
 
       - name: Write obs-update script

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 # open bridge server — Multi-Stage Dockerfile (3 stages)
-# Stage 1 (node-builder):   npm install + vite build → gui_dist/ + frontend_dist/
+# Stage 1 (node-builder):   npm ci + vite build → gui_dist/ + frontend_dist/
 # Stage 2 (py-builder):     pip install Python deps
 # Stage 3 (runtime):        python:3.14-slim, copies all artefacts
 #
@@ -16,16 +16,16 @@ ENV VITE_INSTANCE_COLOR=${VITE_INSTANCE_COLOR}
 
 # Admin-GUI (gui/ → ../gui_dist)
 WORKDIR /gui-src
-COPY gui/package.json ./
-RUN npm install --prefer-offline
+COPY gui/package.json gui/package-lock.json ./
+RUN npm ci --prefer-offline
 COPY gui/ ./
 RUN npm run build
 # Output: /gui_dist
 
 # Visu-Frontend (frontend/ → ../frontend_dist)
 WORKDIR /visu-src
-COPY frontend/package.json ./
-RUN npm install --prefer-offline
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --prefer-offline
 COPY frontend/ ./
 RUN npm run build
 # Output: /frontend_dist

--- a/tests/gui/package-lock.json
+++ b/tests/gui/package-lock.json
@@ -1,0 +1,90 @@
+{
+  "name": "obs-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obs-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.44.0",
+        "dotenv": "^16.4.5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tools/_lxc-inner.sh
+++ b/tools/_lxc-inner.sh
@@ -39,13 +39,13 @@ npm pkg set version="$VERSION" --prefix gui
 # ── Build frontends ───────────────────────────────────────────────────────────
 echo "==> Building Admin GUI..."
 cd gui
-npm install --prefer-offline
+npm ci --prefer-offline
 npm run build
 cd ..
 
 echo "==> Building Visu frontend..."
 cd frontend
-npm install --prefer-offline
+npm ci --prefer-offline
 npm run build
 cd ..
 


### PR DESCRIPTION
## Summary

- commit the missing Playwright E2E lockfile
- replace mutable `npm install` steps with frozen `npm ci` installs
- make Docker, GitHub Actions, the LXC workflow, and the local LXC builder consume the committed dependency graphs

Closes #990.

## Why this change

Automated builds currently resolve semver ranges at install time in several places. That means two builds of the same commit can install different transitive dependency graphs as registry metadata and compatible releases change. It also allows a changed `package.json` and a stale lockfile to pass unnoticed in automation.

This is especially undesirable in CI and image/template builds: these paths should validate the dependency state committed by the project, not calculate a new one during every run.

## Why `npm ci`

`npm ci` is designed for clean, automated installs from a committed lockfile. It removes an existing dependency tree, installs the exact locked graph, and fails when `package.json` and `package-lock.json` disagree instead of rewriting the lockfile.

This does not require contributors to stop using `npm install` when intentionally changing dependencies. The resulting lockfile update remains reviewable; automated consumers then reproduce that reviewed graph with `npm ci`.

## Benefits

- **Reproducibility:** the same commit installs the same dependency versions in E2E, Docker, GitHub Actions, and LXC builds.
- **Fail-fast drift detection:** manifest/lockfile mismatches fail at install time rather than being silently repaired.
- **Local/CI parity:** the local LXC builder and its GitHub workflow use the same frozen install contract.
- **Reviewability:** dependency graph changes appear explicitly as lockfile diffs.
- **Safer caching and diagnosis:** failures can be compared against a stable dependency graph instead of an install-time resolution.
- **Typically faster clean installs:** `npm ci` avoids dependency resolution and lockfile mutation work intended for interactive dependency management.

## Changes

- add `tests/gui/package-lock.json`
- use `npm ci` for Playwright E2E dependencies
- copy GUI/frontend lockfiles into Docker build stages and use `npm ci --prefer-offline`
- use `npm ci --prefer-offline` in both the LXC GitHub workflow and `tools/_lxc-inner.sh`

## Scope

This PR changes dependency installation semantics only. It does not update application dependencies, introduce Nub, change runtime behavior, or add dependency caching.

## Verification

Run with Node 24 / npm 11:

- GUI frozen install and production build
- GUI tests: **1,368 passed**
- GUI coverage: statements 81.92%, branches 72.15%, functions 71.77%, lines 84.23%
- frontend frozen install and production build
- frontend tests: **119 passed**
- E2E frozen install and Playwright CLI resolution: **Playwright 1.61.1**
- lockfile hashes unchanged after all frozen installs
- workflow YAML parsing passed
- `bash -n tools/_lxc-inner.sh` passed
- repository lint checks passed
- full backend/pre-push suite with Docker-backed integration tests: **3,851 passed, 13 skipped, 87% total coverage**

The pre-push suite printed its successful final summary but its pytest process remained alive during teardown. After explicit owner approval, the already-verified commit was pushed once with `--no-verify`; no check listed above was skipped.