### PR TITLE
chore: hold typescript major renovate bumps until vue-tsc supports TS7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,13 @@
         "vue-draggable-plus"
       ],
       "groupName": "frontend-deps (monitor phase 2)"
+    },
+    {
+      "description": "Hold typescript major bumps: TypeScript 7 replaced typescript/lib/tsc with a new exports map (only ./unstable/*), which vue-tsc (used by frontend/'s `npm run build`) cannot resolve yet (ERR_PACKAGE_PATH_NOT_EXPORTED). Re-enable once vue-tsc ships TS7 support (see PR #972).",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- TypeScript 7 replaced `typescript/lib/tsc` with a new `exports` map (only `./unstable/*` paths remain), which `vue-tsc` (used by `frontend/`'s `npm run build`) still resolves internally — breaking the Visu SPA build with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- Seen concretely in #972 (`chore(deps): update dependency typescript to v7`), where the `playwright` e2e job fails because the full-stack build can't produce `frontend_dist/`.
- Adds a `renovate.json` packageRule disabling major-version updates for `typescript`, so Renovate stops proposing TS7 bumps until `vue-tsc` catches up. Re-enable once vue-tsc ships TS7 support.

## Test plan
- [x] `renovate.json` validated against the Renovate config schema (`packageRules[].enabled: false` + `matchUpdateTypes: ["major"]`)
- N/A — config-only change, no app code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)