### PR TITLE
fix(knx): add DPT 13.012 (Reactive Energy VARh) and 13.015 (kVARh)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 ### New features ✨
 
 ### Fixes 🐞
+* KNX: Added the reactive-energy datapoint types DPT 13.012 (VARh) and DPT 13.015 (kVARh) to the DPT registry. Bindings configured with these DPTs previously fell back to the UNKNOWN definition and produced no decoded value. https://github.com/abeggled/openbridgeserver/pull/1030
 
 ### Known Issues 🔔
 * none

--- a/obs/adapters/knx/dpt_registry.py
+++ b/obs/adapters/knx/dpt_registry.py
@@ -880,6 +880,24 @@ def _register_builtin_dpts() -> None:
             _dpt13_encode,
             _dpt13_decode,
         ),
+        DPTDefinition(
+            "DPT13.012",
+            "Reactive Energy (VARh)",
+            "INTEGER",
+            "VARh",
+            4,
+            _dpt13_encode,
+            _dpt13_decode,
+        ),
+        DPTDefinition(
+            "DPT13.015",
+            "Reactive Energy (kVARh)",
+            "INTEGER",
+            "kVARh",
+            4,
+            _dpt13_encode,
+            _dpt13_decode,
+        ),
         # DPT 14 — 32-bit IEEE float (vollständig nach KNX-Spec v02.02.01)
         DPTDefinition(
             "DPT14.000",


### PR DESCRIPTION
## Summary
The KNX DPT registry (obs/adapters/knx/dpt_registry.py) defined DPT13.001, 13.010 and 13.013 but was missing the reactive-energy subtypes 13.012 and 13.015. Bindings using them fell back to the UNKNOWN definition (data_type=UNKNOWN, size_bytes=0) and were not decoded.

## Change
Adds two DPTDefinition entries (4-byte / V32 signed, per KNX System Specification), reusing the existing _dpt13_encode / _dpt13_decode:

| DPT | Name | Unit |
|---|---|---|
| 13.012 | DPT_ReactiveEnergy | VARh |
| 13.015 | DPT_ReactiveEnergy_kVARh | kVARh |

Counterparts to the already-supported 13.010 (Wh) / 13.013 (kWh); same encoding. Tested on OBS 2026.7.0 with live KNX bindings; both now decode as signed integer counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)