### PR TITLE
Add multiselect to the Visu page editor

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,7 @@
 
 ### New features ✨
 * Logic Engine/Admin GUI: Added a Sequence node for state-triggered, non-blocking value-write and pause sequences. Sequences are configured with a visual step editor (including object picker, reordering, duplication, pauses and a blink preset), configurable repeat/restart policies, and normal object values such as colours, switches or dimmer levels. https://github.com/abeggled/openbridgeserver/issues/1021
+* Visu: The page editor now supports selecting multiple widgets at once — Shift/Ctrl+click toggles individual widgets, dragging on empty canvas draws a selection box, and dragging any selected widget moves the whole selection together; Delete/Backspace removes all selected widgets. https://github.com/abeggled/openbridgeserver/issues/1036
 
 ### Fixes 🐞
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -98,6 +98,7 @@
     "hintDrag": "Ziehen → verschieben",
     "hintResize": "↘ Handle → Größe ändern",
     "hintDelete": "Entf → Widget löschen",
+    "hintMultiSelect": "Umschalt/Strg+Klick oder Ziehen auf freier Fläche → Mehrfachauswahl",
     "removeWidget": "Entfernen",
     "widgetName": "Name",
     "widgetNamePlaceholder": "z.B. Wohnzimmer Dimmer",
@@ -110,6 +111,11 @@
     "configuration": "Konfiguration",
     "hintEmpty": "Widget aus der Palette links einfügen",
     "hintNoSelection": "Widget auf dem Canvas anklicken\noder aus der Palette einfügen",
+    "multiSelect": {
+      "count": "{n} Widgets ausgewählt",
+      "removeAll": "Alle löschen",
+      "hint": "Die Konfiguration kann nicht für mehrere Widgets gleichzeitig bearbeitet werden. Wähle nur eines aus, um dessen Einstellungen zu bearbeiten."
+    },
     "widgetCountSingular": "Widget auf dieser Seite",
     "widgetCountPlural": "Widgets auf dieser Seite",
     "brokenDpRef": "Mindestens ein Datenpunkt-Verweis wurde nicht gefunden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -98,6 +98,7 @@
     "hintDrag": "Drag → move",
     "hintResize": "↘ Handle → resize",
     "hintDelete": "Del → delete widget",
+    "hintMultiSelect": "Shift/Ctrl+click or drag on empty space → select multiple",
     "removeWidget": "Remove",
     "widgetName": "Name",
     "widgetNamePlaceholder": "e.g. Living room dimmer",
@@ -110,6 +111,11 @@
     "configuration": "Configuration",
     "hintEmpty": "Insert a widget from the palette on the left",
     "hintNoSelection": "Click a widget on the canvas\nor insert from the palette",
+    "multiSelect": {
+      "count": "{n} widgets selected",
+      "removeAll": "Delete all",
+      "hint": "Configuration editing isn't available for multiple widgets. Select just one to edit its settings."
+    },
     "widgetCountSingular": "widget on this page",
     "widgetCountPlural": "widgets on this page",
     "brokenDpRef": "At least one datapoint reference was not found",

--- a/frontend/src/utils/multiSelect.test.ts
+++ b/frontend/src/utils/multiSelect.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { rectFromPoints, widgetsInRect, computeGroupMove, type GridWidgetLike } from './multiSelect'
+
+describe('rectFromPoints', () => {
+  it('normalizes a drag dragged down-right', () => {
+    expect(rectFromPoints(10, 20, 110, 220)).toEqual({ left: 10, top: 20, width: 100, height: 200 })
+  })
+
+  it('normalizes a drag dragged up-left (reversed direction)', () => {
+    expect(rectFromPoints(110, 220, 10, 20)).toEqual({ left: 10, top: 20, width: 100, height: 200 })
+  })
+
+  it('normalizes a drag with mixed directions', () => {
+    expect(rectFromPoints(10, 220, 110, 20)).toEqual({ left: 10, top: 20, width: 100, height: 200 })
+  })
+
+  it('returns a zero-size rect for a click without movement', () => {
+    expect(rectFromPoints(50, 50, 50, 50)).toEqual({ left: 50, top: 50, width: 0, height: 0 })
+  })
+})
+
+describe('widgetsInRect', () => {
+  const cellW = 80
+  const cellH = 40
+  const widgets: GridWidgetLike[] = [
+    { id: 'a', x: 0, y: 0, w: 2, h: 2 },  // px: 0-160, 0-80
+    { id: 'b', x: 3, y: 0, w: 1, h: 1 },  // px: 240-320, 0-40
+    { id: 'c', x: 0, y: 5, w: 2, h: 2 },  // px: 0-160, 200-280 (far below)
+  ]
+
+  it('selects widgets fully inside the rect', () => {
+    const rect = { left: 0, top: 0, width: 400, height: 100 }
+    expect(widgetsInRect(widgets, rect, cellW, cellH)).toEqual(new Set(['a', 'b']))
+  })
+
+  it('selects widgets that only partially intersect the rect', () => {
+    // rect only overlaps the right sliver of widget "a" and none of "b"
+    const rect = { left: 150, top: 0, width: 20, height: 20 }
+    expect(widgetsInRect(widgets, rect, cellW, cellH)).toEqual(new Set(['a']))
+  })
+
+  it('excludes widgets entirely outside the rect', () => {
+    const rect = { left: 0, top: 0, width: 400, height: 100 }
+    expect(widgetsInRect(widgets, rect, cellW, cellH).has('c')).toBe(false)
+  })
+
+  it('excludes widgets that only touch the rect edge (no overlap area)', () => {
+    // rect ends exactly where widget "b" begins (240px) — touching, not overlapping
+    const rect = { left: 0, top: 0, width: 240, height: 40 }
+    expect(widgetsInRect(widgets, rect, cellW, cellH).has('b')).toBe(false)
+  })
+
+  it('returns an empty set for a zero-size rect over empty canvas (plain click, no drag)', () => {
+    const rect = { left: 500, top: 500, width: 0, height: 0 }
+    expect(widgetsInRect(widgets, rect, cellW, cellH).size).toBe(0)
+  })
+
+  it('treats a zero-size rect landing inside a widget as a hit (point-in-widget)', () => {
+    const rect = { left: 10, top: 10, width: 0, height: 0 }
+    expect(widgetsInRect(widgets, rect, cellW, cellH)).toEqual(new Set(['a']))
+  })
+
+  it('returns an empty set when there are no widgets', () => {
+    const rect = { left: 0, top: 0, width: 1000, height: 1000 }
+    expect(widgetsInRect([], rect, cellW, cellH).size).toBe(0)
+  })
+})
+
+describe('computeGroupMove', () => {
+  it('applies the same delta to every widget in the group', () => {
+    const start = new Map([
+      ['a', { x: 0, y: 0 }],
+      ['b', { x: 3, y: 2 }],
+    ])
+    const widthById = new Map([['a', 2], ['b', 1]])
+    const result = computeGroupMove(start, 1, 1, widthById, 12)
+    expect(result.get('a')).toEqual({ x: 1, y: 1 })
+    expect(result.get('b')).toEqual({ x: 4, y: 3 })
+  })
+
+  it('clamps each widget independently to the left/top canvas edge', () => {
+    const start = new Map([
+      ['a', { x: 0, y: 0 }],
+      ['b', { x: 5, y: 5 }],
+    ])
+    const widthById = new Map([['a', 2], ['b', 2]])
+    // dx/dy would push "a" off the negative edge, "b" stays within bounds
+    const result = computeGroupMove(start, -3, -3, widthById, 12)
+    expect(result.get('a')).toEqual({ x: 0, y: 0 })
+    expect(result.get('b')).toEqual({ x: 2, y: 2 })
+  })
+
+  it('clamps each widget independently to the right canvas edge based on its own width', () => {
+    const start = new Map([
+      ['narrow', { x: 5, y: 0 }],
+      ['wide', { x: 5, y: 0 }],
+    ])
+    const widthById = new Map([['narrow', 1], ['wide', 4]])
+    // dx pushes both far right; "narrow" (w=1) can reach col 11, "wide" (w=4) only col 8
+    const result = computeGroupMove(start, 20, 0, widthById, 12)
+    expect(result.get('narrow')).toEqual({ x: 11, y: 0 })
+    expect(result.get('wide')).toEqual({ x: 8, y: 0 })
+  })
+
+  it('falls back to width 1 when a widget id is missing from widthById', () => {
+    const start = new Map([['ghost', { x: 5, y: 0 }]])
+    const result = computeGroupMove(start, 10, 0, new Map(), 12)
+    expect(result.get('ghost')).toEqual({ x: 11, y: 0 })
+  })
+
+  it('returns an empty map for an empty selection', () => {
+    const result = computeGroupMove(new Map(), 5, 5, new Map(), 12)
+    expect(result.size).toBe(0)
+  })
+
+  it('leaves positions unchanged for a zero delta', () => {
+    const start = new Map([['a', { x: 4, y: 4 }]])
+    const widthById = new Map([['a', 2]])
+    const result = computeGroupMove(start, 0, 0, widthById, 12)
+    expect(result.get('a')).toEqual({ x: 4, y: 4 })
+  })
+})

--- a/frontend/src/utils/multiSelect.ts
+++ b/frontend/src/utils/multiSelect.ts
@@ -1,0 +1,63 @@
+/** Pure selection-geometry helpers for the Visu editor's multiselect (issue #1036). */
+
+export interface RectPx {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+/** Normalizes a drag-start/current point pair (which may go in any direction) into a top-left rect. */
+export function rectFromPoints(startX: number, startY: number, curX: number, curY: number): RectPx {
+  return {
+    left: Math.min(startX, curX),
+    top: Math.min(startY, curY),
+    width: Math.abs(curX - startX),
+    height: Math.abs(curY - startY),
+  }
+}
+
+export interface GridWidgetLike {
+  id: string
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** Returns the ids of every widget whose pixel bounds intersect the marquee rect (grid units × cell size). */
+export function widgetsInRect(widgets: GridWidgetLike[], rect: RectPx, cellW: number, cellH: number): Set<string> {
+  const hit = new Set<string>()
+  for (const w of widgets) {
+    const wx = w.x * cellW
+    const wy = w.y * cellH
+    const ww = w.w * cellW
+    const wh = w.h * cellH
+    const intersects = wx < rect.left + rect.width && wx + ww > rect.left && wy < rect.top + rect.height && wy + wh > rect.top
+    if (intersects) hit.add(w.id)
+  }
+  return hit
+}
+
+/**
+ * Applies the same (dx, dy) grid-cell delta to every widget's start position, each clamped
+ * independently to stay within [0, cols - width] / [0, ∞) — mirrors the single-widget clamp
+ * used by the pre-multiselect drag code, applied per widget in the group.
+ */
+export function computeGroupMove(
+  startPositions: Map<string, { x: number; y: number }>,
+  dx: number,
+  dy: number,
+  widthById: Map<string, number>,
+  cols: number,
+): Map<string, { x: number; y: number }> {
+  const next = new Map<string, { x: number; y: number }>()
+  for (const [id, start] of startPositions) {
+    const w = widthById.get(id) ?? 1
+    next.set(id, {
+      x: Math.max(0, Math.min(cols - w, start.x + dx)),
+      y: Math.max(0, start.y + dy),
+    })
+  }
+  return next
+}

--- a/frontend/src/views/VisuEditor.vue
+++ b/frontend/src/views/VisuEditor.vue
@@ -49,6 +49,7 @@ import {
 } from '@/utils/backgroundPresentation'
 import { getAutoContrastText } from '@/utils/colorContrast'
 import type { PageConfig, WidgetInstance } from '@/types'
+import { rectFromPoints, widgetsInRect, computeGroupMove } from '@/utils/multiSelect'
 
 import '@/widgets/ValueDisplay/index'
 import '@/widgets/Toggle/index'
@@ -95,13 +96,27 @@ const config = ref<PageConfig>({
   grid_cols: 12, grid_row_height: 80, grid_cell_width: 80, background: null, widgets: [],
 })
 
-const selectedId = ref<string | null>(null)
+// Multiselect (issue #1036): `selectedIds` is the source of truth; `selectedId`
+// mirrors it as "the one selected widget, or null" so existing single-widget
+// code paths (config panel, insertWidget, etc.) keep working unchanged.
+const selectedIds = ref<Set<string>>(new Set())
+const selectedId = computed<string | null>({
+  get: () => (selectedIds.value.size === 1 ? [...selectedIds.value][0]! : null),
+  set: (id) => { selectedIds.value = id ? new Set([id]) : new Set() },
+})
 const selectedWidget = computed(() =>
   config.value.widgets.find(w => w.id === selectedId.value) ?? null,
 )
 const selectedDef = computed(() =>
   selectedWidget.value ? WidgetRegistry.get(selectedWidget.value.type) : null,
 )
+
+function toggleSelected(id: string) {
+  const next = new Set(selectedIds.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selectedIds.value = next
+}
 
 function withWidgetDefaults(type: string, raw: unknown): Record<string, unknown> {
   const def = WidgetRegistry.get(type)
@@ -380,24 +395,46 @@ function widgetChrome(w: WidgetInstance): string {
 }
 
 // ── Drag & Resize ─────────────────────────────────────────────────────────────
-interface DragState {
-  type: 'move' | 'resize'
-  widgetId: string
-  startMX: number; startMY: number
-  startX: number;  startY: number   // Grid-Einheiten
-  startW: number;  startH: number
-}
+// 'move' carries every selected widget's start position so the whole
+// selection is dragged together (issue #1036); 'resize' always narrows the
+// selection to the single widget being resized.
+type DragState =
+  | {
+      type: 'move'
+      widgetIds: string[]
+      startMX: number; startMY: number
+      startPositions: Map<string, { x: number; y: number }>
+    }
+  | {
+      type: 'resize'
+      widgetId: string
+      startMX: number; startMY: number
+      startX: number; startY: number
+      startW: number; startH: number
+    }
 const drag = shallowRef<DragState | null>(null)
 
 function startDrag(e: MouseEvent, w: WidgetInstance) {
   if (e.button !== 0) return
   e.preventDefault()
-  selectedId.value = w.id
+  if (e.shiftKey || e.ctrlKey || e.metaKey) {
+    toggleSelected(w.id)
+    return
+  }
+  if (!selectedIds.value.has(w.id)) selectedIds.value = new Set([w.id])
+
+  const ids = [...selectedIds.value]
   frozenCanvasHeight.value = dynamicCanvasHeight.value
   drag.value = {
-    type: 'move', widgetId: w.id,
+    type: 'move',
+    widgetIds: ids,
     startMX: e.clientX, startMY: e.clientY,
-    startX: w.x, startY: w.y, startW: w.w, startH: w.h,
+    startPositions: new Map(
+      ids
+        .map(id => config.value.widgets.find(x => x.id === id))
+        .filter((x): x is WidgetInstance => !!x)
+        .map(x => [x.id, { x: x.x, y: x.y }]),
+    ),
   }
 }
 
@@ -405,7 +442,7 @@ function startResize(e: MouseEvent, w: WidgetInstance) {
   if (e.button !== 0) return
   e.preventDefault()
   e.stopPropagation()
-  selectedId.value = w.id
+  selectedIds.value = new Set([w.id])
   frozenCanvasHeight.value = dynamicCanvasHeight.value
   drag.value = {
     type: 'resize', widgetId: w.id,
@@ -414,40 +451,90 @@ function startResize(e: MouseEvent, w: WidgetInstance) {
   }
 }
 
-function onMouseMove(e: MouseEvent) {
-  if (!drag.value) return
-  const w = config.value.widgets.find(x => x.id === drag.value!.widgetId)
-  if (!w) return
+// ── Rahmen-Auswahl (Marquee) auf leerer Canvas-Fläche ─────────────────────────
+interface MarqueeState {
+  startX: number; startY: number   // px, canvas-relativ
+  curX: number;   curY: number
+  additive: boolean                 // Shift/Strg beim Start gehalten → Auswahl erweitern statt ersetzen
+  baseSelection: Set<string>
+}
+const marquee = shallowRef<MarqueeState | null>(null)
 
-  const dx = Math.round((e.clientX - drag.value.startMX) / CELL_W.value)
-  const dy = Math.round((e.clientY - drag.value.startMY) / CELL_H.value)
+const marqueeRect = computed(() => {
+  if (!marquee.value) return null
+  return rectFromPoints(marquee.value.startX, marquee.value.startY, marquee.value.curX, marquee.value.curY)
+})
+
+function applyMarqueeSelection() {
+  const r = marqueeRect.value
+  if (!r || !marquee.value) return
+  const hit = widgetsInRect(config.value.widgets, r, CELL_W.value, CELL_H.value)
+  selectedIds.value = marquee.value.additive
+    ? new Set([...marquee.value.baseSelection, ...hit])
+    : hit
+}
+
+function onCanvasMouseDown(e: MouseEvent) {
+  if (e.button !== 0) return
+  if (e.target !== e.currentTarget) return // nur auf leerer Fläche starten, nicht auf einem Widget
+  if (!canvasRef.value) return
+  const rect = canvasRef.value.getBoundingClientRect()
+  const x = e.clientX - rect.left
+  const y = e.clientY - rect.top
+  const additive = e.shiftKey || e.ctrlKey || e.metaKey
+  marquee.value = { startX: x, startY: y, curX: x, curY: y, additive, baseSelection: new Set(selectedIds.value) }
+  if (!additive) selectedIds.value = new Set()
+}
+
+function onMouseMove(e: MouseEvent) {
+  if (marquee.value && canvasRef.value) {
+    const rect = canvasRef.value.getBoundingClientRect()
+    marquee.value = { ...marquee.value, curX: e.clientX - rect.left, curY: e.clientY - rect.top }
+    applyMarqueeSelection()
+    return
+  }
+  const d = drag.value
+  if (!d) return
+
+  const dx = Math.round((e.clientX - d.startMX) / CELL_W.value)
+  const dy = Math.round((e.clientY - d.startMY) / CELL_H.value)
+
+  if (d.type === 'move') {
+    const widthById = new Map(config.value.widgets.map(w => [w.id, w.w]))
+    const next = computeGroupMove(d.startPositions, dx, dy, widthById, COLS.value)
+    for (const [id, pos] of next) {
+      const w = config.value.widgets.find(x => x.id === id)
+      if (!w) continue
+      w.x = pos.x
+      w.y = pos.y
+    }
+    return
+  }
+
+  const w = config.value.widgets.find(x => x.id === d.widgetId)
+  if (!w) return
   const def = WidgetRegistry.get(w.type)
   const minW = def?.minW ?? 1
   const minH = def?.minH ?? 1
-
-  if (drag.value.type === 'move') {
-    w.x = Math.max(0, Math.min(COLS.value - w.w, drag.value.startX + dx))
-    w.y = Math.max(0, drag.value.startY + dy)
-  } else {
-    w.w = Math.max(minW, Math.min(COLS.value - w.x, drag.value.startW + dx))
-    w.h = Math.max(minH, drag.value.startH + dy)
-  }
+  w.w = Math.max(minW, Math.min(COLS.value - w.x, d.startW + dx))
+  w.h = Math.max(minH, d.startH + dy)
 }
 
 function onMouseUp() {
   drag.value = null
   frozenCanvasHeight.value = null
+  marquee.value = null
 }
 
 // ── Tastatur ──────────────────────────────────────────────────────────────────
 function onKeyDown(e: KeyboardEvent) {
-  if (!selectedId.value) return
+  if (selectedIds.value.size === 0) return
   if (e.key === 'Delete' || e.key === 'Backspace') {
     if ((e.target as HTMLElement).tagName === 'INPUT' ||
         (e.target as HTMLElement).tagName === 'TEXTAREA') return
     removeSelected()
   }
-  if (e.key === 'Escape') selectedId.value = null
+  if (e.key === 'Escape') selectedIds.value = new Set()
 }
 
 onMounted(() => window.addEventListener('keydown', onKeyDown))
@@ -533,8 +620,18 @@ function insertWidgetAt(type: string, px: number, py: number) {
 
 // ── Widget entfernen ──────────────────────────────────────────────────────────
 function removeSelected() {
-  config.value.widgets = config.value.widgets.filter(w => w.id !== selectedId.value)
-  selectedId.value = null
+  const ids = selectedIds.value
+  config.value.widgets = config.value.widgets.filter(w => !ids.has(w.id))
+  selectedIds.value = new Set()
+}
+
+function removeWidget(id: string) {
+  config.value.widgets = config.value.widgets.filter(w => w.id !== id)
+  if (selectedIds.value.has(id)) {
+    const next = new Set(selectedIds.value)
+    next.delete(id)
+    selectedIds.value = next
+  }
 }
 
 // ── Config aktualisieren ──────────────────────────────────────────────────────
@@ -806,6 +903,7 @@ const showSettings = ref(false)
           <p class="text-xs text-gray-400 dark:text-gray-600">{{ $t('editor.hintDrag') }}</p>
           <p class="text-xs text-gray-400 dark:text-gray-600">{{ $t('editor.hintResize') }}</p>
           <p class="text-xs text-gray-400 dark:text-gray-600">{{ $t('editor.hintDelete') }}</p>
+          <p class="text-xs text-gray-400 dark:text-gray-600">{{ $t('editor.hintMultiSelect') }}</p>
         </div>
       </aside>
 
@@ -819,10 +917,10 @@ const showSettings = ref(false)
             minWidth: '100%',
             height: canvasHeight + 'px',
             ...canvasStyle,
-            cursor: drag ? (drag.type === 'move' ? 'grabbing' : 'se-resize') : 'default',
-            userSelect: drag ? 'none' : 'auto',
+            cursor: drag ? (drag.type === 'move' ? 'grabbing' : 'se-resize') : (marquee ? 'crosshair' : 'default'),
+            userSelect: (drag || marquee) ? 'none' : 'auto',
           }"
-          @click.self="selectedId = null"
+          @mousedown="onCanvasMouseDown"
           @dragover="onCanvasDragOver"
           @dragleave="onCanvasDragLeave"
           @drop="onCanvasDrop"
@@ -845,6 +943,17 @@ const showSettings = ref(false)
               }
             })()"
           />
+          <!-- Rahmen-Auswahl (Marquee) -->
+          <div
+            v-if="marqueeRect"
+            class="absolute pointer-events-none border-2 border-blue-400 bg-blue-400/10 z-40"
+            :style="{
+              left:   marqueeRect.left + 'px',
+              top:    marqueeRect.top + 'px',
+              width:  marqueeRect.width + 'px',
+              height: marqueeRect.height + 'px',
+            }"
+          />
           <!-- Widgets -->
           <div
             v-for="w in config.widgets"
@@ -852,15 +961,14 @@ const showSettings = ref(false)
             class="absolute transition-[border-color,box-shadow] group"
             :class="[
               widgetChrome(w),
-              selectedId === w.id
+              selectedIds.has(w.id)
                 ? '!border-2 !border-blue-500 shadow-lg shadow-blue-500/30 z-10'
                 : 'hover:border-gray-400 dark:hover:border-gray-500 z-0',
-              drag?.widgetId === w.id && drag?.type === 'move' ? 'opacity-90' : '',
+              drag?.type === 'move' && drag.widgetIds.includes(w.id) ? 'opacity-90' : '',
             ]"
             :style="widgetStyle(w)"
             :data-widget-id="w.id"
             @mousedown="startDrag($event, w)"
-            @click.stop="selectedId = w.id"
           >
             <!-- Widget-Vorschau (echte Komponente, editorMode=true) -->
             <div class="w-full h-full pointer-events-none">
@@ -887,21 +995,21 @@ const showSettings = ref(false)
             <!-- Widget-Label (nur sichtbar wenn selektiert oder hover) -->
             <div
               class="absolute top-0 left-0 right-0 flex items-center justify-between px-2 py-1 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
-              :class="{ '!opacity-100': selectedId === w.id }"
+              :class="{ '!opacity-100': selectedIds.has(w.id) }"
             >
               <span class="text-xs text-gray-700 dark:text-gray-300 font-medium">
                 {{ w.name || (WidgetRegistry.get(w.type)?.label ? widgetLabel(WidgetRegistry.get(w.type)!.label) : w.type) }}
               </span>
               <button
                 class="text-xs text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors ml-2"
-                @click.stop="() => { selectedId = w.id; removeSelected() }"
+                @click.stop="removeWidget(w.id)"
               >✕</button>
             </div>
 
             <!-- Resize-Handle (unten-rechts) -->
             <div
               class="absolute bottom-0 right-0 w-5 h-5 flex items-end justify-end pb-1 pr-1 cursor-se-resize opacity-0 group-hover:opacity-100 transition-opacity"
-              :class="{ '!opacity-100': selectedId === w.id }"
+              :class="{ '!opacity-100': selectedIds.has(w.id) }"
               @mousedown.stop="startResize($event, w)"
             >
               <svg width="10" height="10" viewBox="0 0 10 10" class="text-gray-400">
@@ -1044,6 +1152,24 @@ const showSettings = ref(false)
             </div>
           </div>
         </template>
+
+        <!-- Mehrere Widgets gewählt (issue #1036) -->
+        <div v-else-if="selectedIds.size > 1" class="flex-1 flex flex-col">
+          <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-100/50 dark:bg-gray-800/50">
+            <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {{ $t('editor.multiSelect.count', { n: selectedIds.size }) }}
+            </span>
+            <button
+              class="text-xs text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 transition-colors flex items-center gap-1 px-2 py-1 rounded hover:bg-red-500/10"
+              @click="removeSelected"
+            >
+              🗑 {{ $t('editor.multiSelect.removeAll') }}
+            </button>
+          </div>
+          <div class="flex-1 flex items-center justify-center px-6">
+            <p class="text-sm text-gray-400 dark:text-gray-500 text-center">{{ $t('editor.multiSelect.hint') }}</p>
+          </div>
+        </div>
 
         <!-- Kein Widget gewählt -->
         <div v-else class="flex-1 flex flex-col items-center justify-center gap-3 text-center px-6">


### PR DESCRIPTION
## Summary
- The Visu page editor now supports selecting multiple widgets at once: Shift/Ctrl+click toggles individual widgets, dragging on empty canvas draws a marquee selection box, and dragging any selected widget moves the whole selection together.
- Delete/Backspace/Escape now act on the full selection; the config panel shows a "N widgets selected / Delete all" summary when more than one widget is selected.
- The Logic editor already gets equivalent behavior for free from Vue Flow's built-in multi-selection (Shift-drag box select, Ctrl/Cmd+click, group drag) — no changes needed there.
- Selection-geometry math (marquee intersection, group-move clamping) is extracted into `frontend/src/utils/multiSelect.ts` with dedicated unit tests.

Fixes https://github.com/abeggled/openbridgeserver/issues/1036

## Test plan
- [x] `cd frontend && npm run build` (includes `vue-tsc`)
- [x] `cd frontend && npm run test`
- [x] `./tools/check-i18n-hardcoded-strings.sh` (verified against changed files)
- [x] `tools/with-venv ./tools/lint.sh --check`
- [x] New unit tests for `multiSelect.ts` (marquee rect normalization, intersection, group-move clamping)
- [x] Manually verified in the dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)