### PR TITLE
feat(modbus_tcp): bound shared_bus semaphore acquire (avoid silent cross-instance wedge)

### DIFF
--- a/gui/src/locales/de.json
+++ b/gui/src/locales/de.json
@@ -779,6 +779,10 @@
           "title": "Wartezeit zwischen Reads (ms)",
           "description": "Pause nach jeder Modbus-Transaktion auf dem (geteilten) Bus, bevor die nächste startet. Gibt langsamen RS485/Modbus-TCP-Gateways die nötige Umschaltzeit und entzerrt mehrere Geräte an einem Bus. 0 = deaktiviert."
         },
+        "shared_bus_acquire_timeout_s": {
+          "title": "Shared-Bus Acquire-Timeout (s)",
+          "description": "Nur bei geteiltem Bus: Obergrenze für das Warten auf die gemeinsame Bus-Sperre. Bleibt die Sperre über Instanzen hinweg verklemmt, wird die Transaktion mit Warnung übersprungen statt unbegrenzt zu blockieren. 0 = kein Timeout (unbegrenzt warten)."
+        },
         "startup_jitter_s": {
           "title": "Startup-Jitter (s)",
           "description": "Maximale zufällige Verzögerung (Sekunden) vor dem ersten Poll jedes Bindings. Verhindert einen Request-Burst wenn alle Tasks gleichzeitig starten. 0 = deaktiviert."

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -779,6 +779,10 @@
           "title": "Delay between reads (ms)",
           "description": "Pause after each Modbus transaction on the (shared) bus before the next one starts. Gives slow RS485/Modbus-TCP gateways the turnaround time they need and spaces out multiple devices on one bus. 0 = disabled."
         },
+        "shared_bus_acquire_timeout_s": {
+          "title": "Shared bus acquire timeout (s)",
+          "description": "Shared bus only: upper bound on waiting for the shared bus lock. If the lock stays wedged across instances, the transaction is skipped with a warning instead of blocking indefinitely. 0 = no timeout (wait forever)."
+        },
         "startup_jitter_s": {
           "title": "Startup jitter (s)",
           "description": "Maximum random delay (seconds) before the first poll of each binding. Prevents a request burst when all tasks start simultaneously. 0 = disabled."

--- a/obs/adapters/modbus_tcp/adapter.py
+++ b/obs/adapters/modbus_tcp/adapter.py
@@ -93,6 +93,13 @@ class ModbusTcpAdapterConfig(BaseModel):
         title="Wartefrist pro Read (ms)",
         description="Pause nach jeder Modbus-Transaktion auf dem (geteilten) Bus, bevor die naechste startet. Gibt langsamen RS485/Modbus-TCP-Gateways Umschaltzeit und entzerrt mehrere Geraete an einem Bus. 0 = deaktiviert.",
     )
+    shared_bus_acquire_timeout_s: float = Field(
+        default=30.0,
+        ge=0.0,
+        le=300.0,
+        title="Shared-Bus Acquire-Timeout (s)",
+        description="Nur bei shared_bus: Obergrenze fuers Warten auf die geteilte Bus-Semaphore. Laeuft die Sperre laenger nicht frei (verklemmte Semaphore ueber Instanzen), wird die Transaktion mit WARNING uebersprungen statt unbegrenzt zu blockieren. 0 = kein Timeout.",
+    )
     startup_jitter_s: float = Field(
         default=30.0,
         ge=0.0,
@@ -502,6 +509,33 @@ class ModbusTcpAdapter(AdapterBase):
                     yield client
                 finally:
                     await self._space_out_bus(client)
+            return
+
+        # Shared bus: bound the acquire so a wedged cross-instance semaphore surfaces
+        # as a logged, skipped transaction instead of an unbounded silent hang. The
+        # per-instance serialize lock (not shared) keeps its plain blocking acquire.
+        _sbt = self._adp_cfg.shared_bus_acquire_timeout_s
+        if self._shared_bus_key is not None and _sbt > 0:
+            try:
+                await asyncio.wait_for(self._io_sem.acquire(), timeout=_sbt)
+            except (asyncio.TimeoutError, TimeoutError):
+                logger.warning(
+                    "Modbus shared bus %s: I/O semaphore acquire timed out after %.0fs "
+                    "(possible cross-instance wedge) — skipping this transaction",
+                    self._shared_bus_key,
+                    _sbt,
+                )
+                yield None
+                return
+            try:
+                async with self._inflight_modbus_call():
+                    client = self._client if self._client_ready() else None
+                    try:
+                        yield client
+                    finally:
+                        await self._space_out_bus(client)
+            finally:
+                self._io_sem.release()
             return
 
         async with self._io_sem, self._inflight_modbus_call():

--- a/tests/adapters/test_modbus_adapters.py
+++ b/tests/adapters/test_modbus_adapters.py
@@ -2305,3 +2305,50 @@ class TestSharedEndpointDelayPolicy:
         await self._connect(adapter)
         assert adapter._shared_bus_key is None
         assert adapter._effective_delay() == 30
+
+
+class TestSharedBusAcquireTimeout:
+    """A wedged cross-instance shared_bus semaphore must not block forever: the
+    acquire is bounded and a timeout skips the transaction (yield None) with a
+    warning, instead of hanging silently."""
+
+    def test_default_timeout_is_30s(self):
+        assert ModbusTcpAdapterConfig().shared_bus_acquire_timeout_s == 30.0
+
+    async def _connect_shared(self, host, timeout_s):
+        adapter, _ = _make_tcp(
+            {"host": host, "port": 502, "timeout": 1.0, "shared_bus": True,
+             "shared_bus_acquire_timeout_s": timeout_s}
+        )
+        client = _make_client(connected=True)
+        fake_mod = MagicMock()
+        fake_mod.AsyncModbusTcpClient = MagicMock(return_value=client)
+        with patch.dict("sys.modules", {"pymodbus.client": fake_mod}):
+            await adapter.connect()
+        adapter._client = client
+        return adapter, client
+
+    async def test_timeout_skips_transaction_when_semaphore_held(self):
+        adapter, _ = await self._connect_shared("10.9.9.20", 0.2)
+        assert adapter._shared_bus_key == ("10.9.9.20", 502)
+        # Simulate a sibling holding the shared bus and never releasing it.
+        await adapter._io_sem.acquire()
+        try:
+            async with adapter._modbus_io_context() as client:
+                assert client is None  # acquire timed out -> transaction skipped
+        finally:
+            adapter._io_sem.release()
+
+    async def test_acquires_and_yields_client_when_free(self):
+        adapter, client = await self._connect_shared("10.9.9.21", 0.2)
+        async with adapter._modbus_io_context() as c:
+            assert c is client  # free semaphore -> normal transaction
+        # semaphore released again after the context
+        assert adapter._io_sem.locked() is False
+
+    async def test_zero_timeout_disables_bounding(self):
+        """With shared_bus_acquire_timeout_s=0 the shared path uses the plain
+        blocking acquire (unbounded), same as before this feature."""
+        adapter, client = await self._connect_shared("10.9.9.22", 0.0)
+        async with adapter._modbus_io_context() as c:
+            assert c is client


### PR DESCRIPTION
## What
Bound the `shared_bus` I/O semaphore acquire so a wedged cross-instance lock can't block an adapter forever.

## Why (observed in production)
Two Modbus-TCP adapter instances sharing one gateway via `shared_bus=True` share a single module-level `asyncio.Semaphore`. After aggressive **simultaneous** reconnects (an external watchdog toggling both instances at once), the shared semaphore ended up permanently unavailable: **both instances blocked forever inside `_modbus_io_context`, with no error logged and no bus traffic**. An adapter disable/enable did **not** recover it (the lock is process-global) — even a config change hung; only a full container restart cleared it.

## Change
- New optional config field **`shared_bus_acquire_timeout_s`** (default **30 s**), applied **only on the shared-bus path** (`_shared_bus_key is not None`).
- On the shared-bus path the semaphore is acquired via `asyncio.wait_for(...)`. On timeout the transaction is **skipped with a WARNING** (`yield None`, exactly like a not-ready client) instead of hanging indefinitely — a wedge becomes **visible and bounded**.
- The per-instance `serialize_reads` lock keeps its plain blocking acquire, so **all non-`shared_bus` adapters are unaffected**. With the generous 30 s default the timeout is never reached in normal operation (reads complete in ms); it only fires on a genuine wedge.
- `0` = unbounded (previous behaviour).

Note: this bounds/surfaces the wedge. Actual recovery of a leaked process-global lock still needs a restart; the intent here is to make it loud and non-silent (and to stop one instance's wedge from silently taking down its sibling).

## Tests
`TestSharedBusAcquireTimeout`: timeout skips the transaction when the semaphore is held; yields the client normally when free; `0` keeps the unbounded acquire; default is 30 s.

## i18n
`shared_bus_acquire_timeout_s` schema labels added to `gui/src/locales/de.json` + `en.json`.

---
**Stacked on #1105** (branched from `feat/modbus-inter-read-delay`; base is that branch so the diff shows only this change). Please retarget base to `main` once #1105 is merged.