### PR TITLE
modbus_tcp: recover from half-open + deadlocked gateway sockets (keepalive + bounded drain) [test phase]

### DIFF
--- a/obs/adapters/modbus_tcp/adapter.py
+++ b/obs/adapters/modbus_tcp/adapter.py
@@ -26,6 +26,7 @@ import asyncio
 import contextlib
 import logging
 import random
+import socket
 import time
 from typing import Any
 
@@ -165,6 +166,7 @@ class ModbusTcpAdapter(AdapterBase):
         self._client = self._new_client()
         try:
             await self._client.connect()
+            self._apply_socket_keepalive()
             if self._client.connected:
                 await self._publish_status(
                     True,
@@ -234,6 +236,7 @@ class ModbusTcpAdapter(AdapterBase):
                     try:
                         self._client = self._new_client()
                         await self._client.connect()
+                        self._apply_socket_keepalive()
                         if self._client.connected:
                             self._reconnect_ok_after = 0.0
                             await self._publish_status(
@@ -309,6 +312,7 @@ class ModbusTcpAdapter(AdapterBase):
                             try:
                                 async with self._client_lifecycle():
                                     await self._client.connect()
+                                    self._apply_socket_keepalive()
                                 if self._client.connected:
                                     self._reconnect_ok_after = 0.0  # clear backoff on success
                                     host = self._adp_cfg.host
@@ -416,6 +420,58 @@ class ModbusTcpAdapter(AdapterBase):
     # ------------------------------------------------------------------
     # Low-level Modbus operations
     # ------------------------------------------------------------------
+
+    def _apply_socket_keepalive(self) -> None:
+        """Force fast dead-peer detection on the freshly connected TCP socket.
+
+        Modbus gateways behind an RS485 bridge can go half-open: a request stays
+        stuck unacknowledged in the socket Send-Q while TCP still reports
+        ESTABLISHED, so the read await hangs for minutes (default TCP retransmit)
+        and pymodbus' own timeout never fires (it waits for a response that never
+        comes). SO_KEEPALIVE + TCP_USER_TIMEOUT make the kernel drop such a socket
+        within ~15 s, turning the silent hang into a normal socket error that the
+        existing reconnect handling recovers from. Best-effort: never raises.
+        """
+        cl = self._client
+        if cl is None:
+            return
+        sock = None
+        for attr in ("transport", "ctx"):
+            obj = getattr(cl, attr, None)
+            tr = obj if attr == "transport" else getattr(obj, "transport", None)
+            if tr is not None:
+                try:
+                    sock = tr.get_extra_info("socket")
+                except Exception:
+                    sock = None
+                if sock is not None:
+                    break
+        if sock is None:
+            logger.debug(
+                "Modbus TCP: no socket to set keepalive on (%s:%s)",
+                self._adp_cfg.host, self._adp_cfg.port,
+            )
+            return
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            applied = ["SO_KEEPALIVE"]
+            for name, val in (
+                ("TCP_KEEPIDLE", 10), ("TCP_KEEPINTVL", 5),
+                ("TCP_KEEPCNT", 3), ("TCP_USER_TIMEOUT", 15000),
+            ):
+                opt = getattr(socket, name, None)
+                if opt is not None:
+                    sock.setsockopt(socket.IPPROTO_TCP, opt, val)
+                    applied.append("%s=%s" % (name, val))
+            logger.info(
+                "Modbus TCP keepalive set on %s:%s (%s)",
+                self._adp_cfg.host, self._adp_cfg.port, ",".join(applied),
+            )
+        except Exception:
+            logger.debug(
+                "Modbus TCP: keepalive setsockopt failed (%s:%s)",
+                self._adp_cfg.host, self._adp_cfg.port, exc_info=True,
+            )
 
     def _new_client(self) -> Any:
         if self._client_factory is None:

--- a/obs/adapters/modbus_tcp/adapter.py
+++ b/obs/adapters/modbus_tcp/adapter.py
@@ -186,16 +186,45 @@ class ModbusTcpAdapter(AdapterBase):
             await self._publish_status(False, str(exc))
             logger.exception("Modbus TCP connect failed")
 
+    async def _drain_poll_tasks(self) -> None:
+        """Cancel poll tasks and wait for them — but bounded.
+
+        A task may be stuck in a read that ignores cancellation (only closing the
+        socket frees it). A plain ``await gather()`` then deadlocks disconnect()/reload,
+        which holds ``_reload_lock`` forever and pins the adapter at enabled=False. So:
+        bound the drain with ``asyncio.wait`` (NOT ``wait_for`` — that would try to
+        cancel the un-cancellable gather and hang itself), and if the tasks do not
+        finish, force-close the client to break the stuck read. Force-close happens
+        only in that stuck case, so normal teardown (tasks cancel promptly) is unchanged.
+        """
+        if not self._poll_tasks:
+            return
+        for t in self._poll_tasks:
+            t.cancel()
+        gt = asyncio.ensure_future(asyncio.gather(*self._poll_tasks, return_exceptions=True))
+        done, _ = await asyncio.wait({gt}, timeout=5.0)
+        if gt not in done:
+            logger.warning(
+                "Modbus TCP: poll tasks did not cancel within 5s — force-closing client "
+                "to break a stuck read (%s:%s)",
+                self._adp_cfg.host, self._adp_cfg.port,
+            )
+            try:
+                if self._client:
+                    self._client.close()
+            except Exception:
+                logger.debug("Modbus TCP: force-close during drain failed", exc_info=True)
+            await asyncio.wait({gt}, timeout=3.0)
+            if not gt.done():
+                gt.cancel()
+                with contextlib.suppress(Exception):
+                    await gt
+        self._poll_tasks.clear()
+
     async def disconnect(self) -> None:
         async with self._reload_lock:
             self._stopping = True
-            for t in self._poll_tasks:
-                t.cancel()
-            # Wait for tasks to finish — same as _on_bindings_reloaded to avoid the
-            # race condition where a cancelled task is still mid-read when close() runs.
-            if self._poll_tasks:
-                await asyncio.gather(*self._poll_tasks, return_exceptions=True)
-            self._poll_tasks.clear()
+            await self._drain_poll_tasks()
             # Reset initial-load flag so jitter applies again on next connect().
             self._initial_load_done = False
             if self._client:
@@ -216,14 +245,9 @@ class ModbusTcpAdapter(AdapterBase):
 
             needs_clean_session = self._initial_load_done or bool(self._poll_tasks) or self._inflight_io > 0
 
-            # Cancel existing pollers and wait for them to actually finish.
-            # Without awaiting gather(), old tasks may still be executing a Modbus read
-            # concurrently with the new tasks, which corrupts the shared TCP connection.
-            for t in self._poll_tasks:
-                t.cancel()
-            if self._poll_tasks:
-                await asyncio.gather(*self._poll_tasks, return_exceptions=True)
-            self._poll_tasks.clear()
+            # Cancel existing pollers and wait for them to actually finish (bounded —
+            # force-closes a wedged client so a stuck read cannot deadlock the reload).
+            await self._drain_poll_tasks()
 
             # Close and reconnect only for real reloads; the initial binding load
             # follows connect() and should not create a second TCP session.


### PR DESCRIPTION
## ⚠️ Note: this is currently under a test phase

Trialed on a live production instance (Deye + Gree heat pumps behind a shared RS485→TCP gateway); not yet validated over a long period. Timeout values are provisional. Feedback welcome.

This PR addresses **two distinct failure modes** of the same real-world symptom: one heat pump behind a shared gateway goes stale (`connected=False`), the watchdog's disable/enable can't recover it, and only a full process restart clears it. Both were captured live with `nsenter -n ss` and reproduced in isolation.

## Mode 1 — half-open socket (`Send-Q` stuck)

The gateway stops acknowledging a request; TCP still reports `ESTABLISHED` while the request sits unacked in the socket **Send-Q**. The read hangs for minutes (TCP retransmit) and pymodbus' `timeout` never fires (no response ever comes).

```
ESTAB  Recv-Q 0  Send-Q 12   -> gateway:502   (wedged)     # 12B = one Modbus/TCP request
ESTAB  Recv-Q 0  Send-Q  0   -> gateway:502   (healthy)
```

**Fix:** `_apply_socket_keepalive()` after each `connect()` sets `SO_KEEPALIVE` + `TCP_KEEPIDLE/INTVL/CNT` + **`TCP_USER_TIMEOUT=15000`**. The kernel then drops a half-open socket within ~15 s, turning the silent hang into a normal socket error the existing reconnect handles. Verified: every gateway socket now shows a `timer:(keepalive,…)` in `ss -tnope`.

## Mode 2 — application-level deadlock (`Send-Q` empty, socket healthy)

A later wedge showed `Send-Q = 0` — the socket is fine at TCP level, so Mode 1's fix cannot apply. Here a poll task is stuck in a read that ignores cancellation (only closing the socket frees it). `disconnect()` / `_on_bindings_reloaded()` do `await asyncio.gather(poll_tasks)` after cancelling — which never returns, so `_reload_lock` is held forever and the adapter is pinned at `enabled=False`.

**Fix:** `_drain_poll_tasks()` bounds the drain with `asyncio.wait` (**not** `wait_for` — that would try to cancel the un-cancellable gather and hang itself), and if the tasks don't finish within 5 s it **force-closes the client**, which breaks the stuck read so the tasks can exit and the lock is released. Force-close happens only in the wedged case; normal teardown (tasks cancel promptly) is unchanged.

## Verification

Both fixes deployed on the affected production instance; both heat pumps recover and stay connected. Mode 2 was reproduced in isolation (an un-cancellable read deadlocks disconnect/enable without the fix, both return cleanly with it).

## Not included (yet)

No unit tests — socket options and the force-close path are impractical to exercise without a fake gateway/transport. Happy to add targeted tests (e.g. asserting `setsockopt` on a mock transport, and that a non-cancellable poll task triggers the force-close branch) if wanted during review.
