### PR TITLE
fix(help): use localized quality labels for dashboard and history

### DIFF
--- a/gui/src/views/DashboardView.vue
+++ b/gui/src/views/DashboardView.vue
@@ -114,7 +114,7 @@
                 <div :class="['text-sm font-mono font-medium', liveClass(dp)]">
                   {{ displayValue(dp) }}
                 </div>
-                <Badge :variant="qualityVariant(dp.quality)" size="xs" dot>{{ dp.quality ?? '—' }}</Badge>
+                <Badge :variant="qualityVariant(dp.quality)" size="xs" dot>{{ qualityLabel(dp.quality) ?? '—' }}</Badge>
               </div>
             </div>
           </template>
@@ -200,5 +200,9 @@ function qualityVariant(q) {
   if (q === 'bad')       return 'danger'
   if (q === 'uncertain') return 'warning'
   return 'muted'
+}
+
+function qualityLabel(q) {
+  return q === 'good' ? t('datapoints.quality.good') : q === 'bad' ? t('datapoints.quality.bad') : q === 'uncertain' ? t('datapoints.quality.uncertain') : q
 }
 </script>

--- a/help/de/dashboard/overview.md
+++ b/help/de/dashboard/overview.md
@@ -70,6 +70,6 @@ Anzahl der Verknüpfungen (Bindings). Der Status-Punkt fasst zusammen:
 ## Live-Werte {#dashboard-values}
 
 Die zuletzt bekannten Werte der ersten zehn Objekte (DataPoints), inklusive MQTT-Topic
-und Qualitätsangabe (`good` / `uncertain` / `bad`). Werte, die seit dem Laden der Seite
+und Qualitätsangabe (**Gut** / **Unbekannt** / **Schlecht**). Werte, die seit dem Laden der Seite
 über die WebSocket-Verbindung aktualisiert wurden, sind farblich hervorgehoben. „Alle →"
 führt zur vollständigen, durchsuch- und filterbaren Objektliste unter **Objekte**.

--- a/help/de/history/overview.md
+++ b/help/de/history/overview.md
@@ -30,6 +30,6 @@ Auswahl geändert werden — es zählt immer nur die zuletzt gestartete Abfrage.
 
 Das Diagramm zeigt die geladene Reihe über der Zeit, mit der Anzahl geladener Punkte in
 der Kopfzeile. Im **Raw**-Modus erscheint zusätzlich eine Tabelle mit jedem einzelnen
-Wert: Zeitstempel, Wert (inkl. Einheit, falls vorhanden), Qualität (`good`/`uncertain`)
+Wert: Zeitstempel, Wert (inkl. Einheit, falls vorhanden), Qualität (**Gut**/**Unbekannt**)
 und der Adapter, von dem der Wert stammt. Ist im gewählten Zeitraum kein Wert vorhanden,
 erscheint ein entsprechender Hinweis statt eines leeren Diagramms.

--- a/help/en/dashboard/overview.md
+++ b/help/en/dashboard/overview.md
@@ -67,6 +67,6 @@ The status dot summarizes:
 ## Live Values {#dashboard-values}
 
 The last known values of the first ten data points, including their MQTT topic and quality
-(`good` / `uncertain` / `bad`). Values updated over the WebSocket connection since the page
+(**Good** / **Unknown** / **Bad**). Values updated over the WebSocket connection since the page
 loaded are highlighted. "All →" leads to the full, searchable and filterable data point list
 under **Data Points**.

--- a/help/en/datapoints/list.md
+++ b/help/en/datapoints/list.md
@@ -21,7 +21,7 @@ respective adapter instance.
 - **Adapter** — multi-select by adapter **type** (e.g. KNX, Modbus); shows data points bound
   to any instance of the selected types.
 - **Tag** — multi-select over the tags currently in use across the system.
-- **Quality** — filters by the last reported quality status (**Good** / **Uncertain** /
+- **Quality** — filters by the last reported quality status (**Good** / **Unknown** /
   **Bad**).
 - **Hierarchy nodes** — filters to one or more nodes/branches of the data point hierarchy;
   the search also finds nodes outside the currently selected trees.

--- a/help/en/history/overview.md
+++ b/help/en/history/overview.md
@@ -30,6 +30,6 @@ running — only the most recently started query ever counts.
 
 The chart shows the loaded series over time, with the number of loaded points in the
 header. In **Raw** mode, a table with every individual value also appears: timestamp,
-value (including unit, if any), quality (`good`/`uncertain`), and the adapter the value
+value (including unit, if any), quality (**Good**/**Unknown**), and the adapter the value
 came from. If no value exists in the selected time range, a corresponding hint appears
 instead of an empty chart.


### PR DESCRIPTION
## Summary
- Dashboard's live-values badge showed the raw quality key (`good`/`uncertain`/`bad`) instead of the localized label every other view already renders via a `qualityLabel()` helper — fixed in `DashboardView.vue`.
- The German and English help pages for Dashboard and History documented that raw-key behavior instead of the intended localized labels (**Gut**/**Unbekannt**/**Schlecht**, **Good**/**Unknown**/**Bad**).
- The English data point list help said "Uncertain" where the GUI actually shows "Unknown" (`en.json` → `datapoints.quality.uncertain`).

Fixes #1191

## Test plan
- [x] `gui npm run test` (2579 passed)
- [x] `gui npm run test:coverage` — new `qualityLabel()` branches fully covered by existing quality-badge tests
- [x] `gui npm run build`
- [x] `./tools/check-i18n-hardcoded-strings.sh`
- [x] `tools/with-venv ./tools/lint.sh --check`
- [x] `cd help && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HeL6K2dpXpfqjLAwzYoPb