### PR TITLE
fix(help): add help button to data point create/edit form

### DIFF
--- a/gui/src/components/ui/Modal.vue
+++ b/gui/src/components/ui/Modal.vue
@@ -32,11 +32,14 @@
             <!-- Header -->
             <div v-if="title" class="card-header shrink-0">
               <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100">{{ title }}</h3>
-              <button :disabled="!dismissible" @click="dismiss" class="btn-icon">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                </svg>
-              </button>
+              <div class="flex items-center gap-2">
+                <slot name="header-actions" />
+                <button :disabled="!dismissible" @click="dismiss" class="btn-icon">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                  </svg>
+                </button>
+              </div>
             </div>
 
             <!-- Body -->

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -208,6 +208,9 @@
 
     <!-- Edit Objekt Modal -->
     <Modal v-model="showEdit" :title="$t('datapoints.form.editTitle')">
+      <template #header-actions>
+        <HelpButton help-id="datapoints-form" />
+      </template>
       <DataPointForm :initial="dp" :datatypes="dpStore.datatypes" :save-handler="onEditSave" @cancel="showEdit = false" />
     </Modal>
 
@@ -236,6 +239,7 @@ import { useRegionalFormat } from '@/composables/useRegionalFormat'
 import Badge          from '@/components/ui/Badge.vue'
 import Spinner        from '@/components/ui/Spinner.vue'
 import Modal          from '@/components/ui/Modal.vue'
+import HelpButton     from '@/components/ui/HelpButton.vue'
 import ConfirmDialog  from '@/components/ui/ConfirmDialog.vue'
 import DataPointForm          from '@/components/datapoints/DataPointForm.vue'
 import BindingForm            from '@/components/datapoints/BindingForm.vue'

--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -415,6 +415,9 @@
 
     <!-- Create / Edit Modal -->
     <Modal v-model="showForm" :title="editTarget ? $t('datapoints.form.editTitle') : $t('datapoints.createModal')">
+      <template #header-actions>
+        <HelpButton help-id="datapoints-form" />
+      </template>
       <DataPointForm :initial="editTarget" :datatypes="store.datatypes" :save-handler="onSave" @cancel="showForm = false" />
     </Modal>
 

--- a/gui/tests/components/ui/Modal.spec.js
+++ b/gui/tests/components/ui/Modal.spec.js
@@ -203,6 +203,36 @@ describe('Modal — leaves room for an open help drawer (issue feedback: a dialo
   })
 })
 
+describe('Modal — header-actions slot (issue #1197)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders header-actions slot content next to the title, before the close button', () => {
+    const wrapper = mount(Modal, {
+      props: { modelValue: true, title: 'Test Modal' },
+      slots: {
+        default: '<div data-testid="modal-body">body</div>',
+        'header-actions': '<button data-testid="help-btn">help</button>',
+      },
+      attachTo: document.body,
+    })
+    const helpBtn = document.querySelector('[data-testid="help-btn"]')
+    expect(helpBtn).toBeTruthy()
+    // header-actions must precede the close button so the layout matches
+    // the rest of the app's header-icon-row pattern (e.g. AdaptersView).
+    const closeBtn = document.querySelector('.btn-icon')
+    expect(helpBtn.compareDocumentPosition(closeBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('renders no extra content when header-actions is not provided', () => {
+    mountModal()
+    // Exactly one .btn-icon (the close button) — no stray slot output.
+    expect(document.querySelectorAll('.btn-icon').length).toBe(1)
+  })
+})
+
 describe('Modal — dismissible=false', () => {
   beforeEach(() => {
     document.body.innerHTML = ''

--- a/gui/tests/views/DataPointDetailView.editModal.help.spec.js
+++ b/gui/tests/views/DataPointDetailView.editModal.help.spec.js
@@ -1,0 +1,124 @@
+/**
+ * Integrated help drawer wiring on DataPointDetailView's edit modal (#1197):
+ * the "Edit data point" dialog had no HelpButton, unlike the rest of the
+ * app's forms. This spec checks the button is present in the modal header
+ * and that clicking it opens the real help store.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import DataPointDetailView from '@/views/DataPointDetailView.vue'
+
+const apiMocks = vi.hoisted(() => ({
+  dpApi: {
+    get: vi.fn(),
+    listBindings: vi.fn(),
+    knxContext: vi.fn(),
+    writeValue: vi.fn(),
+  },
+  logicApi: {
+    datapointUsages: vi.fn(),
+  },
+  systemApi: {
+    datatypes: vi.fn(),
+  },
+  helpApi: {
+    index: vi.fn(),
+  },
+}))
+
+vi.mock('@/api/client', () => apiMocks)
+
+function mountView() {
+  return mount(DataPointDetailView, {
+    props: { id: 'dp-internal' },
+    global: {
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+        DataPointHierarchyCard: { template: '<div />' },
+        DataPointForm: { template: '<div />' },
+        BindingForm: { template: '<div />' },
+        ConfirmDialog: { template: '<div />' },
+      },
+    },
+    attachTo: document.body,
+  })
+}
+
+// Modal.vue teleports its content to document.body, outside the wrapper's
+// own DOM subtree — vue-test-utils' wrapper.find() doesn't traverse into a
+// real (unstubbed) Teleport target, so query the attached document instead.
+function helpButton(_wrapper, helpId) {
+  const el = document.querySelector(`[data-testid="help-button-${helpId}"]`)
+  return {
+    exists: () => !!el,
+    trigger: (event) => {
+      el.dispatchEvent(new MouseEvent(event, { bubbles: true }))
+      return flushPromises()
+    },
+  }
+}
+
+describe('DataPointDetailView — edit modal help button', () => {
+  let wrapper
+
+  afterEach(() => {
+    // Modal.vue teleports to document.body; without unmounting, a stale
+    // help button from a previous test's still-mounted instance (and its
+    // own pinia) would shadow the one under test via a global querySelector.
+    wrapper?.unmount()
+    wrapper = undefined
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMocks.systemApi.datatypes.mockResolvedValue({ data: [{ name: 'FLOAT' }] })
+    apiMocks.dpApi.get.mockResolvedValue({
+      data: {
+        id: 'dp-internal',
+        name: 'Internal Temperature',
+        data_type: 'FLOAT',
+        unit: '°C',
+        tags: [],
+        mqtt_topic: 'dp/dp-internal/value',
+        mqtt_alias: null,
+        persist_value: true,
+        record_history: true,
+        value: null,
+        quality: 'uncertain',
+        created_at: '2026-06-11T10:00:00+00:00',
+        updated_at: '2026-06-11T10:00:00+00:00',
+      },
+    })
+    apiMocks.dpApi.listBindings.mockResolvedValue({ data: [] })
+    apiMocks.dpApi.knxContext.mockResolvedValue({ data: { datapoint_id: 'dp-internal', group_addresses: [] } })
+    apiMocks.logicApi.datapointUsages.mockResolvedValue({ data: [] })
+    apiMocks.helpApi.index.mockResolvedValue({ data: { helpIds: {} } })
+  })
+
+  it('renders a help button in the edit modal once opened', async () => {
+    wrapper = mountView()
+    await flushPromises()
+    expect(helpButton(wrapper, 'datapoints-form').exists()).toBe(false)
+
+    const editButton = wrapper.findAll('button').find(button => button.text() === 'Bearbeiten')
+    await editButton.trigger('click')
+    await flushPromises()
+
+    expect(helpButton(wrapper, 'datapoints-form').exists()).toBe(true)
+  })
+
+  it('opens the help store with datapoints-form when its button is clicked', async () => {
+    wrapper = mountView()
+    await flushPromises()
+    const editButton = wrapper.findAll('button').find(button => button.text() === 'Bearbeiten')
+    await editButton.trigger('click')
+    await flushPromises()
+
+    const { useHelpStore } = await import('@/stores/help')
+    const helpStore = useHelpStore()
+    await helpButton(wrapper, 'datapoints-form').trigger('click')
+
+    expect(helpStore.isOpen).toBe(true)
+    expect(helpStore.currentHelpId).toBe('datapoints-form')
+  })
+})

--- a/gui/tests/views/DataPointsView.help.spec.js
+++ b/gui/tests/views/DataPointsView.help.spec.js
@@ -49,7 +49,7 @@ async function mountDataPointsView() {
         Badge: { template: '<span><slot /></span>' },
         ConfirmDialog: true,
         DataPointForm: true,
-        Modal: { template: '<div><slot /></div>', props: ['modelValue', 'title', 'dismissible'] },
+        Modal: { template: '<div><slot name="header-actions" /><slot /></div>', props: ['modelValue', 'title', 'dismissible'] },
         RouterLink: { props: ['to'], template: '<a><slot /></a>' },
         Spinner: { template: '<span />' },
       },
@@ -87,4 +87,22 @@ describe('DataPointsView — help buttons (#896)', () => {
       expect(helpStore.currentHelpId).toBe(helpId)
     }
   )
+})
+
+describe('DataPointsView — create/edit modal help button (#1197)', () => {
+  it('renders a help button in the create/edit modal header', async () => {
+    const wrapper = await mountDataPointsView()
+    expect(helpButton(wrapper, 'datapoints-form').exists()).toBe(true)
+  })
+
+  it('opens the help store with datapoints-form when its button is clicked', async () => {
+    const wrapper = await mountDataPointsView()
+    const { useHelpStore } = await import('@/stores/help')
+    const helpStore = useHelpStore()
+
+    await helpButton(wrapper, 'datapoints-form').trigger('click')
+
+    expect(helpStore.isOpen).toBe(true)
+    expect(helpStore.currentHelpId).toBe('datapoints-form')
+  })
 })

--- a/help/de/datapoints/list.md
+++ b/help/de/datapoints/list.md
@@ -44,3 +44,24 @@ Suche, Typ, Adapter, Tag, Qualität und Hierarchie-Auswahl in einem Schritt zur�
   Werte oder Historie) und Löschen (entfernt auch alle Verknüpfungen des Objekts).
 
 Die Liste lädt beim Scrollen automatisch weitere Einträge nach.
+
+## Anlegen/Bearbeiten-Formular {#datapoints-form}
+
+Öffnet sich über „Neu" auf dieser Seite oder über „Bearbeiten" auf der Objekt-Detailseite
+bzw. in der Tabellenzeile. Beide Modi teilen sich dieselben Felder, nur der Titel
+unterscheidet sich.
+
+- **Name** — Pflichtfeld, frei wählbar.
+- **Datentyp** — der Werttyp (z. B. FLOAT, BOOL, STRING); bestimmt, wie geschriebene Werte
+  validiert und dargestellt werden.
+- **Einheit** — optional, aus einer kategorisierten Liste (Temperatur, Elektrizität, …)
+  oder als Freitext über „Andere".
+- **Tags** — optional, kommagetrennt; werden für Filter und Hierarchie-Ansichten genutzt.
+- **MQTT Alias** — ein optionales zweites MQTT-Topic, unter dem der Wert zusätzlich zum
+  eigenen Topic des Objekts veröffentlicht wird.
+- **Wert dauerhaft speichern** — behält den letzten Wert, sodass er nach einem Neustart
+  sofort wieder verfügbar ist, statt leer zu starten.
+- **Historie aufzeichnen** — speichert Wertänderungen in der Historie-Datenbank, sodass sie
+  auf der Seite **Historie** erscheinen.
+- **Externes Schreiben erlauben** — erlaubt jedem MQTT-Client mit Zugriff auf den Broker,
+  diesen Wert zu setzen — nicht nur den eigenen Adaptern und der Logik von OBS.

--- a/help/en/datapoints/list.md
+++ b/help/en/datapoints/list.md
@@ -44,3 +44,23 @@ and hierarchy selection in one step.
   (also removes all of the data point's bindings).
 
 The list loads further entries automatically as you scroll.
+
+## Create / edit form {#datapoints-form}
+
+Opens from "New" on this page, or "Edit" on a data point's detail page or table row. Both
+modes share the same fields; only the title differs.
+
+- **Name** — required, freely chosen.
+- **Data type** — the value type (e.g. FLOAT, BOOL, STRING); determines how written values
+  are validated and displayed.
+- **Unit** — optional, picked from a categorized list (temperature, electricity, …) or
+  entered as free text via "Other".
+- **Tags** — optional, comma-separated; used for filtering and hierarchy views.
+- **MQTT alias** — an optional second MQTT topic the value is also published under, in
+  addition to the data point's own topic.
+- **Persist value** — keep the last value so it's immediately available again after a
+  restart, instead of starting empty.
+- **Record history** — store value changes in the history database so they appear on the
+  **History** page.
+- **Allow external write** — lets any MQTT client that can reach the broker set this value,
+  not just OBS's own adapters and Logic.


### PR DESCRIPTION
## Summary
- The "Edit data point" / "New data point" modal (`DataPointForm`, used both from the object list and the object detail page) had no `HelpButton`, unlike the rest of the app's forms.
- Added a `header-actions` slot to `Modal.vue` (rendered next to the title, before the close button) and wired a `HelpButton` into both places the form is used, pointing at a new `datapoints-form` help section documenting every field.

Closes #1197.

## Test plan
- [x] `tools/with-venv ./tools/lint.sh --check`
- [x] `cd gui && npm run build`
- [x] `cd gui && npm run test` (2585 passed)
- [x] `cd gui && npm run test:coverage` (no regression)
- [x] `cd help && npm run build` (new anchor resolves cleanly, no locale-parity warnings)
- [x] `./tools/check-i18n-hardcoded-strings.sh`
- [x] New specs cover: `Modal.vue`'s `header-actions` slot rendering/positioning, the create/edit modal's help button on the list view, and the edit modal's help button on the detail view (including opening the real help store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HeL6K2dpXpfqjLAwzYoPb