### PR TITLE
feat(logic): API-Doku für FBs agent-tauglich machen (#1208)

### DIFF
--- a/gui/src/components/logic/NodePalette.vue
+++ b/gui/src/components/logic/NodePalette.vue
@@ -55,7 +55,7 @@
             >
               <span class="w-2 h-2 rounded-full flex-shrink-0" :style="{ background: nt.color }"></span>
               <span class="text-xs text-slate-700 dark:text-slate-200 flex-1 min-w-0 truncate">{{ $te('logic.nodeTypes.' + nt.type) ? $t('logic.nodeTypes.' + nt.type) : nt.label }}</span>
-              <HelpButton v-if="NODE_HELP_IDS[nt.type]" :help-id="NODE_HELP_IDS[nt.type]" compact class="flex-shrink-0" />
+              <HelpButton v-if="nt.help_id" :help-id="nt.help_id" compact class="flex-shrink-0" />
             </div>
           </div>
         </div>
@@ -79,57 +79,6 @@ const emit = defineEmits(['drag-start', 'toggle'])
 const { t } = useI18n()
 
 const CATEGORY_IDS = ['logic', 'datapoint', 'math', 'string', 'timer', 'astro', 'notification', 'integration', 'script', 'ai']
-
-// Per-block-type help — documented one category at a time (see
-// help/de/logic/blocks-<category>.md); a type with no entry here simply
-// gets no help button yet rather than one pointing at nonexistent content.
-const NODE_HELP_IDS = {
-  and: 'logic-block-and',
-  or: 'logic-block-or',
-  xor: 'logic-block-xor',
-  not: 'logic-block-not',
-  gate: 'logic-block-gate',
-  memory: 'logic-block-memory',
-  change_filter: 'logic-block-change-filter',
-  compare: 'logic-block-compare',
-  hysteresis: 'logic-block-hysteresis',
-  merge: 'logic-block-merge',
-  decision: 'logic-block-decision',
-  value_mapping: 'logic-block-value-mapping',
-  const_value: 'logic-block-const-value',
-  datapoint_read: 'logic-block-datapoint-read',
-  datapoint_write: 'logic-block-datapoint-write',
-  math_formula: 'logic-block-math-formula',
-  math_map: 'logic-block-math-map',
-  clamp: 'logic-block-clamp',
-  random_value: 'logic-block-random-value',
-  statistics: 'logic-block-statistics',
-  avg_multi: 'logic-block-avg-multi',
-  min_max_tracker: 'logic-block-min-max-tracker',
-  consumption_counter: 'logic-block-consumption-counter',
-  heating_circuit: 'logic-block-heating-circuit',
-  string_concat: 'logic-block-string-concat',
-  string_replace: 'logic-block-string-replace',
-  comment: 'logic-block-comment',
-  timer_cron: 'logic-block-timer-cron',
-  datetime: 'logic-block-datetime',
-  timer_delay: 'logic-block-timer-delay',
-  timer_pulse: 'logic-block-timer-pulse',
-  operating_hours: 'logic-block-operating-hours',
-  value_sequence: 'logic-block-value-sequence',
-  astro_sun: 'logic-block-astro-sun',
-  notify_message: 'logic-block-notify-message',
-  message_archive: 'logic-block-message-archive',
-  wake_on_lan: 'logic-block-wake-on-lan',
-  host_check: 'logic-block-host-check',
-  json_extractor: 'logic-block-json-extractor',
-  xml_extractor: 'logic-block-xml-extractor',
-  substring_extractor: 'logic-block-substring-extractor',
-  ical: 'logic-block-ical',
-  api_client: 'logic-block-api-client',
-  python_script: 'logic-block-python-script',
-  ai_logic: 'logic-block-ai-logic',
-}
 
 const categories = computed(() =>
   CATEGORY_IDS

--- a/gui/tests/components/logic/NodePalette.help.spec.js
+++ b/gui/tests/components/logic/NodePalette.help.spec.js
@@ -1,8 +1,11 @@
 /**
  * Integrated help drawer wiring on NodePalette.vue — one HelpButton per
- * documented block type (see help/de/logic/blocks-logic.md and onward per
- * category). A type without an entry in NODE_HELP_IDS gets no button yet
- * rather than one pointing at nonexistent content.
+ * documented block type. `help_id` is served by the backend as part of each
+ * node type's definition (`GET /api/v1/logic/node-types`, see
+ * `obs/logic/models.py::NodeTypeDef.help_id`) and points at the matching
+ * anchor in help/de/logic/blocks-*.md and onward per category. A type whose
+ * definition carries no `help_id` gets no button yet rather than one
+ * pointing at nonexistent content.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
@@ -10,27 +13,28 @@ import { createPinia, setActivePinia } from 'pinia'
 import NodePalette from '@/components/logic/NodePalette.vue'
 
 const NODE_TYPES = [
-  { type: 'and',             label: 'AND',           category: 'logic',     color: '#4ade80' },
-  { type: 'or',              label: 'OR',            category: 'logic',     color: '#4ade80' },
-  { type: 'datapoint_read',  label: 'Objekt lesen',  category: 'datapoint', color: '#0f766e' },
-  { type: 'datapoint_write', label: 'Objekt schreiben', category: 'datapoint', color: '#0f766e' },
-  { type: 'math_formula',  label: 'Formel',  category: 'math',   color: '#7c3aed' },
-  { type: 'string_concat', label: 'String Verketten', category: 'string', color: '#0891b2' },
-  { type: 'timer_delay',   label: 'Verzögerung', category: 'timer', color: '#b45309' },
-  { type: 'astro_sun',     label: 'Astro Sonne', category: 'astro', color: '#f59e0b' },
-  { type: 'notify_message', label: 'Benachrichtigung', category: 'notification', color: '#dc2626' },
-  { type: 'message_archive', label: 'Meldungsarchiv', category: 'notification', color: '#2563eb' },
-  { type: 'wake_on_lan', label: 'Wake on LAN', category: 'integration', color: '#0369a1' },
-  { type: 'host_check', label: 'Host Check (Ping)', category: 'integration', color: '#0369a1' },
-  { type: 'json_extractor', label: 'JSON Extractor', category: 'integration', color: '#0369a1' },
-  { type: 'xml_extractor', label: 'XML Extractor', category: 'integration', color: '#0369a1' },
-  { type: 'substring_extractor', label: 'Substring / RegEx', category: 'integration', color: '#0369a1' },
-  { type: 'ical', label: 'iCalendar', category: 'integration', color: '#0369a1' },
-  { type: 'api_client', label: 'API Client', category: 'integration', color: '#0e7490' },
-  { type: 'python_script', label: 'Python Script', category: 'script', color: '#65a30d' },
-  { type: 'ai_logic', label: 'AI Logic', category: 'ai', color: '#9333ea' },
-  // Synthetic type, not a real backend node — exercises the "no entry in
-  // NODE_HELP_IDS" branch now that every real registered type is documented.
+  { type: 'and',             label: 'AND',           category: 'logic',     color: '#4ade80', help_id: 'logic-block-and' },
+  { type: 'or',              label: 'OR',            category: 'logic',     color: '#4ade80', help_id: 'logic-block-or' },
+  { type: 'datapoint_read',  label: 'Objekt lesen',  category: 'datapoint', color: '#0f766e', help_id: 'logic-block-datapoint-read' },
+  { type: 'datapoint_write', label: 'Objekt schreiben', category: 'datapoint', color: '#0f766e', help_id: 'logic-block-datapoint-write' },
+  { type: 'math_formula',  label: 'Formel',  category: 'math',   color: '#7c3aed', help_id: 'logic-block-math-formula' },
+  { type: 'string_concat', label: 'String Verketten', category: 'string', color: '#0891b2', help_id: 'logic-block-string-concat' },
+  { type: 'timer_delay',   label: 'Verzögerung', category: 'timer', color: '#b45309', help_id: 'logic-block-timer-delay' },
+  { type: 'astro_sun',     label: 'Astro Sonne', category: 'astro', color: '#f59e0b', help_id: 'logic-block-astro-sun' },
+  { type: 'notify_message', label: 'Benachrichtigung', category: 'notification', color: '#dc2626', help_id: 'logic-block-notify-message' },
+  { type: 'message_archive', label: 'Meldungsarchiv', category: 'notification', color: '#2563eb', help_id: 'logic-block-message-archive' },
+  { type: 'wake_on_lan', label: 'Wake on LAN', category: 'integration', color: '#0369a1', help_id: 'logic-block-wake-on-lan' },
+  { type: 'host_check', label: 'Host Check (Ping)', category: 'integration', color: '#0369a1', help_id: 'logic-block-host-check' },
+  { type: 'json_extractor', label: 'JSON Extractor', category: 'integration', color: '#0369a1', help_id: 'logic-block-json-extractor' },
+  { type: 'xml_extractor', label: 'XML Extractor', category: 'integration', color: '#0369a1', help_id: 'logic-block-xml-extractor' },
+  { type: 'substring_extractor', label: 'Substring / RegEx', category: 'integration', color: '#0369a1', help_id: 'logic-block-substring-extractor' },
+  { type: 'ical', label: 'iCalendar', category: 'integration', color: '#0369a1', help_id: 'logic-block-ical' },
+  { type: 'api_client', label: 'API Client', category: 'integration', color: '#0e7490', help_id: 'logic-block-api-client' },
+  { type: 'python_script', label: 'Python Script', category: 'script', color: '#65a30d', help_id: 'logic-block-python-script' },
+  { type: 'ai_logic', label: 'AI Logic', category: 'ai', color: '#9333ea', help_id: 'logic-block-ai-logic' },
+  // Synthetic type, not a real backend node — exercises the "no help_id on
+  // the node type definition" branch. edge_detect/notify_pushover/notify_sms
+  // are the real-world equivalent today (see issue #1200 for edge_detect).
   { type: 'not_yet_documented', label: 'Not Yet Documented', category: 'ai', color: '#9333ea' },
 ]
 
@@ -82,10 +86,10 @@ describe('NodePalette — per-block help buttons', () => {
     expect(helpButton(wrapper, helpId).exists()).toBe(true)
   })
 
-  it('does not render a help button for a block type with no entry in NODE_HELP_IDS', () => {
+  it('does not render a help button for a block type whose definition carries no help_id', () => {
     const wrapper = mountPalette()
-    // not_yet_documented is a synthetic type absent from NODE_HELP_IDS — every
-    // real registered node type is now documented (all 10 categories shipped).
+    // not_yet_documented is a synthetic type with no help_id — every real
+    // registered node type is now documented (all 10 categories shipped).
     expect(wrapper.find('[data-testid="help-button-logic-block-not-yet-documented"]').exists()).toBe(false)
   })
 

--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -618,6 +618,50 @@ def _logic_run_warnings(outputs: dict) -> list[dict[str, str]]:
 
 @router.get("/node-types", response_model=list[NodeTypeDef])
 async def get_node_types(_user: str = Depends(get_current_user)) -> list[NodeTypeDef]:
+    """List every built-in Logic function block, for building a `flow_data` graph.
+
+    Each `NodeTypeDef` is the complete, authoritative contract for one block — this is the
+    single source of truth also used by the Logic editor, so nothing here goes stale.
+
+    **Ports and `flow_data` wiring.** A `LogicGraph`'s `flow_data` is `{nodes: [...], edges:
+    [...]}`. Each node has `id`, `type` (one of the `type` values in this catalogue), `position`
+    (`{x, y}`, cosmetic only), and `data` (the node's `config_schema` values, plus a `label`
+    string). Each edge has `id`, `source`/`target` (node ids) and `sourceHandle`/`targetHandle`
+    (port ids from that node type's `outputs`/`inputs`). A port's `type` is `"value"` (carries a
+    value every tick it has one) or `"trigger"` (carries a one-shot pulse, no persistent value).
+
+    **Execution semantics not visible elsewhere in this API:**
+    - A node's per-tick result is a dict keyed by output port id. A key **absent** from that dict
+      means "nothing produced this tick" — a trigger that did not fire, or a value withheld by the
+      block itself (e.g. `change_filter` only sets `changed` when the input actually changed).
+      This is different from the key being present with value `null`/`None`, which means a value
+      arrived but was empty/unset.
+    - `memory` is the **only** node allowed to close a feedback loop within one graph (it outputs
+      the previous tick's stored value) — any other cycle is rejected, see `POST /graphs/validate`.
+
+    **Resolving `help_id` to full prose documentation** (English and German, one paragraph per
+    block with the exact intended behaviour): `GET /help/help-index.json`, then
+    `.helpIds[<help_id>].en` (or `.de`) is a ready-to-fetch URL under `/help/...`. Not every type
+    has a `help_id` yet (`null` if undocumented).
+
+    **Minimal `flow_data` example** — a `compare` block driving a `datapoint_write`:
+    ```json
+    {
+      "nodes": [
+        {"id": "n1", "type": "datapoint_read", "position": {"x": 0, "y": 0},
+         "data": {"datapoint_id": "<uuid>"}},
+        {"id": "n2", "type": "compare", "position": {"x": 200, "y": 0},
+         "data": {"operator": ">", "operand": 20}},
+        {"id": "n3", "type": "datapoint_write", "position": {"x": 400, "y": 0},
+         "data": {"datapoint_id": "<uuid>"}}
+      ],
+      "edges": [
+        {"id": "e1", "source": "n1", "target": "n2", "sourceHandle": "value", "targetHandle": "in1"},
+        {"id": "e2", "source": "n2", "target": "n3", "sourceHandle": "out", "targetHandle": "value"}
+      ]
+    }
+    ```
+    """
     return list_node_types()
 
 
@@ -626,6 +670,15 @@ async def validate_graph(
     body: FlowData,
     _user: str = Depends(get_current_user),
 ) -> dict:
+    """Check `flow_data` for graph-topology problems before saving it.
+
+    Today this checks exactly two things: graph cycles not broken by a `memory` node, and timer
+    duration bounds (`timer_delay`/`timer_pulse`/`api_client.timeout_s`). It does **not** validate
+    node `data` against each type's `config_schema` (types, enums, or the nested shape of fields
+    like `decision.conditions`) — a `{"status": "ok"}` response does not guarantee the graph will
+    execute as intended. `POST`/`PUT /graphs` accept and persist a structurally invalid node config
+    the same way; the mistake only shows up at run time.
+    """
     return {"status": "ok", "warnings": topology_warnings(body)}
 
 
@@ -648,6 +701,7 @@ async def create_graph(
     _user: Principal | str = Depends(get_current_principal),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
+    """Create a Logic graph. See `GET /node-types` for the `flow_data` authoring contract."""
     _validate_timer_durations(body.flow_data)
     principal = _principal_from_mutation_dependency(_user)
     delegated = await _require_logic_graph_creation(
@@ -703,6 +757,7 @@ async def update_graph_full(
     _user: Principal | str = Depends(get_current_principal),
     db: Database = Depends(lambda: get_db()),
 ) -> LogicGraphOut:
+    """Replace a Logic graph's `flow_data` (full save). See `GET /node-types` for the authoring contract."""
     now = datetime.now(UTC).isoformat()
     row = await db.fetchone("SELECT * FROM logic_graphs WHERE id=?", (graph_id,))
     if not row:

--- a/obs/logic/models.py
+++ b/obs/logic/models.py
@@ -107,6 +107,9 @@ class NodeTypeDef(BaseModel):
     required_capability: str | None = None
     hidden_from_palette: bool = False
     legacy: bool = False
+    # Heading anchor id in help/{en,de}/logic/blocks-<category>.md, resolvable at
+    # runtime via GET /help/help-index.json -> .helpIds[help_id].{en,de}.
+    help_id: str | None = None
 
 
 class LogicRunPreflightCheck(BaseModel):

--- a/obs/logic/nodes/ai/ai_logic.py
+++ b/obs/logic/nodes/ai/ai_logic.py
@@ -13,4 +13,5 @@ NODE_TYPE = NodeTypeDef(
     outputs=[],
     config_schema={},
     color="#7c3aed",
+    help_id="logic-block-ai-logic",
 )

--- a/obs/logic/nodes/astro/sun.py
+++ b/obs/logic/nodes/astro/sun.py
@@ -21,4 +21,5 @@ NODE_TYPE = NodeTypeDef(
         "longitude": {"type": "number", "default": 8.54, "label": "Längengrad"},
     },
     color="#d97706",
+    help_id="logic-block-astro-sun",
 )

--- a/obs/logic/nodes/base.py
+++ b/obs/logic/nodes/base.py
@@ -17,3 +17,24 @@ def port(id_: str, label: str, type_: str = "value") -> NodeTypePort:
     ``number`` — the set the catalogue contract test accepts.
     """
     return NodeTypePort(id=id_, label=label, type=type_)
+
+
+# The operator vocabulary a "condition" rule accepts — shared by ``decision``
+# and ``value_mapping``, whose rule lists are both matched by
+# ``GraphExecutor._condition_matches``. Kept as one constant so the two node
+# modules' published ``config_schema`` cannot drift apart from each other or
+# from the executor's actual accepted operators.
+CONDITION_OPERATORS: tuple[str, ...] = (
+    "eq",
+    "ne",
+    "gt",
+    "lt",
+    "gte",
+    "lte",
+    "range",
+    "text_eq",
+    "contains",
+    "starts_with",
+    "ends_with",
+    "regex",
+)

--- a/obs/logic/nodes/datapoint/read.py
+++ b/obs/logic/nodes/datapoint/read.py
@@ -25,4 +25,5 @@ NODE_TYPE = NodeTypeDef(
         "throttle_unit": {"type": "string", "default": "s"},
     },
     color="#0f766e",
+    help_id="logic-block-datapoint-read",
 )

--- a/obs/logic/nodes/datapoint/write.py
+++ b/obs/logic/nodes/datapoint/write.py
@@ -24,4 +24,5 @@ NODE_TYPE = NodeTypeDef(
         "throttle_unit": {"type": "string", "default": "s"},
     },
     color="#0f766e",
+    help_id="logic-block-datapoint-write",
 )

--- a/obs/logic/nodes/integration/api_client.py
+++ b/obs/logic/nodes/integration/api_client.py
@@ -49,6 +49,7 @@ NODE_TYPE = NodeTypeDef(
             "type": "string",
             "default": "",
             "label": "Header (JSON-Objekt, optional)",
+            "description": 'Flat JSON object of extra request headers, e.g. \'{"X-Api-Key": "..."}\'.',
         },
         "headers_secret_file": {
             "type": "string",
@@ -59,6 +60,16 @@ NODE_TYPE = NodeTypeDef(
             "type": "array",
             "default": [],
             "label": "Variablen",
+            "description": ("DataPoint-backed placeholders, substituted into url/body/headers as '###OBS<slot>###' (e.g. '###OBS1###')."),
+            "items": {
+                "type": "object",
+                "required": ["slot", "datapoint_id"],
+                "properties": {
+                    "slot": {"type": "integer", "description": "Placeholder index, referenced as ###OBS<slot>###."},
+                    "datapoint_id": {"type": "string", "format": "datapoint"},
+                    "datapoint_name": {"type": "string"},
+                },
+            },
         },
         "timeout_s": {"type": "number", "default": 10, "min": 1, "label": "Timeout (s)"},
         "auth_type": {
@@ -91,4 +102,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#0e7490",
+    help_id="logic-block-api-client",
 )

--- a/obs/logic/nodes/integration/host_check.py
+++ b/obs/logic/nodes/integration/host_check.py
@@ -33,4 +33,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#0369a1",
+    help_id="logic-block-host-check",
 )

--- a/obs/logic/nodes/integration/ical.py
+++ b/obs/logic/nodes/integration/ical.py
@@ -45,4 +45,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#0369a1",
+    help_id="logic-block-ical",
 )

--- a/obs/logic/nodes/integration/json_extractor.py
+++ b/obs/logic/nodes/integration/json_extractor.py
@@ -17,4 +17,5 @@ NODE_TYPE = NodeTypeDef(
         "json_paths": {"type": "string", "default": "", "label": "Ausgänge (JSON-Array)"},
     },
     color="#0369a1",
+    help_id="logic-block-json-extractor",
 )

--- a/obs/logic/nodes/integration/substring_extractor.py
+++ b/obs/logic/nodes/integration/substring_extractor.py
@@ -30,4 +30,5 @@ NODE_TYPE = NodeTypeDef(
         "group": {"type": "number", "default": 0, "label": "Capture-Gruppe (0 = gesamter Treffer)"},
     },
     color="#0369a1",
+    help_id="logic-block-substring-extractor",
 )

--- a/obs/logic/nodes/integration/wake_on_lan.py
+++ b/obs/logic/nodes/integration/wake_on_lan.py
@@ -30,4 +30,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#0369a1",
+    help_id="logic-block-wake-on-lan",
 )

--- a/obs/logic/nodes/integration/xml_extractor.py
+++ b/obs/logic/nodes/integration/xml_extractor.py
@@ -17,4 +17,5 @@ NODE_TYPE = NodeTypeDef(
         "xml_paths": {"type": "string", "default": "", "label": "Ausgänge (JSON-Array)"},
     },
     color="#0369a1",
+    help_id="logic-block-xml-extractor",
 )

--- a/obs/logic/nodes/logic/and_node.py
+++ b/obs/logic/nodes/logic/and_node.py
@@ -22,4 +22,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-and",
 )

--- a/obs/logic/nodes/logic/change_filter.py
+++ b/obs/logic/nodes/logic/change_filter.py
@@ -23,4 +23,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-change-filter",
 )

--- a/obs/logic/nodes/logic/compare.py
+++ b/obs/logic/nodes/logic/compare.py
@@ -21,4 +21,5 @@ NODE_TYPE = NodeTypeDef(
         "operand": {"type": "number", "default": "", "label": "Operand"},
     },
     color="#1d4ed8",
+    help_id="logic-block-compare",
 )

--- a/obs/logic/nodes/logic/const_value.py
+++ b/obs/logic/nodes/logic/const_value.py
@@ -22,4 +22,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#475569",
+    help_id="logic-block-const-value",
 )

--- a/obs/logic/nodes/logic/decision.py
+++ b/obs/logic/nodes/logic/decision.py
@@ -17,10 +17,10 @@ NODE_TYPE = NodeTypeDef(
             "type": "array",
             "label": "Bedingungen",
             "description": (
-                "Ordered list of independent conditions, each tested against the 'value' "
-                "input. The first field that matches its rule fires its own trigger output "
-                "— unlike value_mapping there is no 'first match wins', every matching "
-                "condition fires."
+                "Independent conditions, each tested against the 'value' input every tick. "
+                "Each condition's own 'handle' output fires (once) when its rule matches — "
+                "unlike value_mapping, order does not matter and any number of conditions "
+                "can match and fire in the same tick."
             ),
             "items": {
                 "type": "object",

--- a/obs/logic/nodes/logic/decision.py
+++ b/obs/logic/nodes/logic/decision.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from obs.logic.models import NodeTypeDef
-from obs.logic.nodes.base import port
+from obs.logic.nodes.base import CONDITION_OPERATORS, port
 
 NODE_TYPE = NodeTypeDef(
     type="decision",
@@ -14,10 +14,45 @@ NODE_TYPE = NodeTypeDef(
     outputs=[port("out_1", "Ausgang 1", "trigger"), port("out_2", "Ausgang 2", "trigger")],
     config_schema={
         "conditions": {
-            "type": "string",
-            "default": ('[{"handle":"out_1","operator":"eq"},{"handle":"out_2","operator":"eq"}]'),
+            "type": "array",
             "label": "Bedingungen",
+            "description": (
+                "Ordered list of independent conditions, each tested against the 'value' "
+                "input. The first field that matches its rule fires its own trigger output "
+                "— unlike value_mapping there is no 'first match wins', every matching "
+                "condition fires."
+            ),
+            "items": {
+                "type": "object",
+                "required": ["handle", "operator"],
+                "properties": {
+                    "handle": {
+                        "type": "string",
+                        "description": "Output port id this condition drives, e.g. 'out_1'.",
+                    },
+                    "operator": {
+                        "type": "string",
+                        "enum": list(CONDITION_OPERATORS),
+                        "default": "eq",
+                    },
+                    "value": {
+                        "description": ("Comparison operand — used by all operators except 'range' (which uses min/max)."),
+                    },
+                    "min": {"description": "Lower bound, operator 'range' only."},
+                    "max": {"description": "Upper bound, operator 'range' only."},
+                    "case_sensitive": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "text_eq/contains/starts_with/ends_with only.",
+                    },
+                },
+            },
+            "default": [
+                {"handle": "out_1", "operator": "eq"},
+                {"handle": "out_2", "operator": "eq"},
+            ],
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-decision",
 )

--- a/obs/logic/nodes/logic/gate.py
+++ b/obs/logic/nodes/logic/gate.py
@@ -39,4 +39,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-gate",
 )

--- a/obs/logic/nodes/logic/hysteresis.py
+++ b/obs/logic/nodes/logic/hysteresis.py
@@ -22,4 +22,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-hysteresis",
 )

--- a/obs/logic/nodes/logic/memory.py
+++ b/obs/logic/nodes/logic/memory.py
@@ -30,4 +30,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-memory",
 )

--- a/obs/logic/nodes/logic/merge.py
+++ b/obs/logic/nodes/logic/merge.py
@@ -30,4 +30,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-merge",
 )

--- a/obs/logic/nodes/logic/not_node.py
+++ b/obs/logic/nodes/logic/not_node.py
@@ -13,4 +13,5 @@ NODE_TYPE = NodeTypeDef(
     inputs=[port("in1", "IN 1")],
     outputs=[port("out", "Out")],
     color="#1d4ed8",
+    help_id="logic-block-not",
 )

--- a/obs/logic/nodes/logic/or_node.py
+++ b/obs/logic/nodes/logic/or_node.py
@@ -22,4 +22,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-or",
 )

--- a/obs/logic/nodes/logic/value_mapping.py
+++ b/obs/logic/nodes/logic/value_mapping.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from obs.logic.models import NodeTypeDef
-from obs.logic.nodes.base import port
+from obs.logic.nodes.base import CONDITION_OPERATORS, port
 
 NODE_TYPE = NodeTypeDef(
     type="value_mapping",
@@ -20,12 +20,41 @@ NODE_TYPE = NodeTypeDef(
             "label": "Ausgangstyp",
         },
         "rules": {
-            "type": "string",
-            "default": ('[{"operator":"eq","result":""},{"operator":"eq","result":""}]'),
+            "type": "array",
             "label": "Regeln",
+            "description": "Ordered rule list — the first rule that matches 'value' wins and its 'result' is output.",
+            "items": {
+                "type": "object",
+                "required": ["operator"],
+                "properties": {
+                    "operator": {
+                        "type": "string",
+                        "enum": list(CONDITION_OPERATORS),
+                        "default": "eq",
+                    },
+                    "value": {
+                        "description": ("Comparison operand — used by all operators except 'range' (which uses min/max)."),
+                    },
+                    "min": {"description": "Lower bound, operator 'range' only."},
+                    "max": {"description": "Upper bound, operator 'range' only."},
+                    "case_sensitive": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "text_eq/contains/starts_with/ends_with only.",
+                    },
+                    "result": {
+                        "description": "Value returned when this rule matches, coerced per 'output_type'.",
+                    },
+                },
+            },
+            "default": [
+                {"operator": "eq", "result": ""},
+                {"operator": "eq", "result": ""},
+            ],
         },
         "has_default": {"type": "boolean", "default": False, "label": "Sonst-Wert verwenden"},
         "default_value": {"type": "string", "default": "", "label": "Sonst-Wert"},
     },
     color="#1d4ed8",
+    help_id="logic-block-value-mapping",
 )

--- a/obs/logic/nodes/logic/xor_node.py
+++ b/obs/logic/nodes/logic/xor_node.py
@@ -22,4 +22,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#1d4ed8",
+    help_id="logic-block-xor",
 )

--- a/obs/logic/nodes/math/avg_multi.py
+++ b/obs/logic/nodes/math/avg_multi.py
@@ -42,4 +42,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#7c3aed",
+    help_id="logic-block-avg-multi",
 )

--- a/obs/logic/nodes/math/clamp.py
+++ b/obs/logic/nodes/math/clamp.py
@@ -17,4 +17,5 @@ NODE_TYPE = NodeTypeDef(
         "max": {"type": "number", "default": 100, "label": "Maximum"},
     },
     color="#7c3aed",
+    help_id="logic-block-clamp",
 )

--- a/obs/logic/nodes/math/consumption_counter.py
+++ b/obs/logic/nodes/math/consumption_counter.py
@@ -58,4 +58,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#7c3aed",
+    help_id="logic-block-consumption-counter",
 )

--- a/obs/logic/nodes/math/formula.py
+++ b/obs/logic/nodes/math/formula.py
@@ -17,4 +17,5 @@ NODE_TYPE = NodeTypeDef(
         "output_formula": {"type": "string", "default": ""},
     },
     color="#7c3aed",
+    help_id="logic-block-math-formula",
 )

--- a/obs/logic/nodes/math/heating_circuit.py
+++ b/obs/logic/nodes/math/heating_circuit.py
@@ -49,4 +49,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#7c3aed",
+    help_id="logic-block-heating-circuit",
 )

--- a/obs/logic/nodes/math/min_max_tracker.py
+++ b/obs/logic/nodes/math/min_max_tracker.py
@@ -75,4 +75,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#7c3aed",
+    help_id="logic-block-min-max-tracker",
 )

--- a/obs/logic/nodes/math/random_value.py
+++ b/obs/logic/nodes/math/random_value.py
@@ -34,4 +34,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#7c3aed",
+    help_id="logic-block-random-value",
 )

--- a/obs/logic/nodes/math/scale.py
+++ b/obs/logic/nodes/math/scale.py
@@ -19,4 +19,5 @@ NODE_TYPE = NodeTypeDef(
         "out_max": {"type": "number", "default": 1},
     },
     color="#7c3aed",
+    help_id="logic-block-math-map",
 )

--- a/obs/logic/nodes/math/statistics.py
+++ b/obs/logic/nodes/math/statistics.py
@@ -25,4 +25,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#7c3aed",
+    help_id="logic-block-statistics",
 )

--- a/obs/logic/nodes/notification/message_archive.py
+++ b/obs/logic/nodes/notification/message_archive.py
@@ -34,4 +34,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#2563eb",
+    help_id="logic-block-message-archive",
 )

--- a/obs/logic/nodes/notification/notify_message.py
+++ b/obs/logic/nodes/notification/notify_message.py
@@ -20,4 +20,5 @@ NODE_TYPE = NodeTypeDef(
         "priority": {"type": "integer", "default": 0, "min": -2, "max": 1, "label": "Priorität"},
     },
     color="#e11d48",
+    help_id="logic-block-notify-message",
 )

--- a/obs/logic/nodes/script/python_script.py
+++ b/obs/logic/nodes/script/python_script.py
@@ -19,4 +19,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#be185d",
+    help_id="logic-block-python-script",
 )

--- a/obs/logic/nodes/string/comment.py
+++ b/obs/logic/nodes/string/comment.py
@@ -22,4 +22,5 @@ NODE_TYPE = NodeTypeDef(
         "height": {"type": "number", "default": 140, "label": "Höhe"},
     },
     color="#ca8a04",
+    help_id="logic-block-comment",
 )

--- a/obs/logic/nodes/string/concat.py
+++ b/obs/logic/nodes/string/concat.py
@@ -23,4 +23,5 @@ NODE_TYPE = NodeTypeDef(
         "separator": {"type": "string", "default": "", "label": "Trennzeichen"},
     },
     color="#0891b2",
+    help_id="logic-block-string-concat",
 )

--- a/obs/logic/nodes/string/replace.py
+++ b/obs/logic/nodes/string/replace.py
@@ -21,10 +21,29 @@ NODE_TYPE = NodeTypeDef(
         # One empty rule so a freshly dropped block already shows an editable
         # row. Mirrored by _defaultReplaceRules() in NodeConfigPanel.vue.
         "rules": {
-            "type": "string",
-            "default": '[{"search":"","replace":"","mode":"plain","case_sensitive":true,"replace_all":true}]',
+            "type": "array",
             "label": "Regeln",
+            "description": "Ordered search/replace rules, each applied to the previous rule's result.",
+            "items": {
+                "type": "object",
+                "required": ["search"],
+                "properties": {
+                    "search": {"type": "string", "description": "Search term; a rule with no search term is skipped."},
+                    "replace": {"type": "string"},
+                    "mode": {"type": "string", "enum": ["plain", "regex"], "default": "plain"},
+                    "case_sensitive": {"type": "boolean", "default": True},
+                    "replace_all": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "False replaces only the first occurrence.",
+                    },
+                },
+            },
+            "default": [
+                {"search": "", "replace": "", "mode": "plain", "case_sensitive": True, "replace_all": True},
+            ],
         },
     },
     color="#0891b2",
+    help_id="logic-block-string-replace",
 )

--- a/obs/logic/nodes/timer/cron.py
+++ b/obs/logic/nodes/timer/cron.py
@@ -14,4 +14,5 @@ NODE_TYPE = NodeTypeDef(
     outputs=[port("trigger", "Trigger", "trigger")],
     config_schema={"cron": {"type": "string", "default": "0 7 * * *"}},
     color="#b45309",
+    help_id="logic-block-timer-cron",
 )

--- a/obs/logic/nodes/timer/datetime_node.py
+++ b/obs/logic/nodes/timer/datetime_node.py
@@ -17,4 +17,5 @@ NODE_TYPE = NodeTypeDef(
         "custom_format": {"type": "string", "default": DEFAULT_CUSTOM_FORMAT, "label": "Benutzerdefiniertes Format"},
     },
     color="#b45309",
+    help_id="logic-block-datetime",
 )

--- a/obs/logic/nodes/timer/delay.py
+++ b/obs/logic/nodes/timer/delay.py
@@ -14,4 +14,5 @@ NODE_TYPE = NodeTypeDef(
     outputs=[port("trigger", "Trigger", "trigger")],
     config_schema={"delay_s": {"type": "number", "default": 1.0, "min": 0}},
     color="#b45309",
+    help_id="logic-block-timer-delay",
 )

--- a/obs/logic/nodes/timer/operating_hours.py
+++ b/obs/logic/nodes/timer/operating_hours.py
@@ -23,4 +23,5 @@ NODE_TYPE = NodeTypeDef(
         },
     },
     color="#b45309",
+    help_id="logic-block-operating-hours",
 )

--- a/obs/logic/nodes/timer/pulse.py
+++ b/obs/logic/nodes/timer/pulse.py
@@ -14,4 +14,5 @@ NODE_TYPE = NodeTypeDef(
     outputs=[port("out", "Out")],
     config_schema={"duration_s": {"type": "number", "default": 1.0, "min": 0}},
     color="#b45309",
+    help_id="logic-block-timer-pulse",
 )

--- a/obs/logic/nodes/timer/value_sequence.py
+++ b/obs/logic/nodes/timer/value_sequence.py
@@ -20,4 +20,5 @@ NODE_TYPE = NodeTypeDef(
         "steps": {"type": "array", "default": []},
     },
     color="#b45309",
+    help_id="logic-block-value-sequence",
 )

--- a/tests/unit/logic/nodes/logic/test_decision.py
+++ b/tests/unit/logic/nodes/logic/test_decision.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import json
-
 from obs.logic.nodes.logic.decision import NODE_TYPE
 
 
 def test_decision_default_conditions_do_not_persist_localized_names():
-    conditions = json.loads(NODE_TYPE.config_schema["conditions"]["default"])
+    conditions = NODE_TYPE.config_schema["conditions"]["default"]
 
     assert conditions == [
         {"handle": "out_1", "operator": "eq"},

--- a/tests/unit/logic/nodes/logic/test_value_mapping.py
+++ b/tests/unit/logic/nodes/logic/test_value_mapping.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import json
-
 from obs.logic.nodes.logic.value_mapping import NODE_TYPE
 
 
 def test_value_mapping_default_rules_do_not_persist_localized_names():
-    rules = json.loads(NODE_TYPE.config_schema["rules"]["default"])
+    rules = NODE_TYPE.config_schema["rules"]["default"]
 
     assert rules == [
         {"operator": "eq", "result": ""},

--- a/tests/unit/logic/nodes/string/test_replace.py
+++ b/tests/unit/logic/nodes/string/test_replace.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 from obs.logic.nodes.string.replace import NODE_TYPE
 
 
@@ -15,7 +13,7 @@ def test_string_replace_declares_one_text_input_and_one_result_output():
 
 
 def test_string_replace_defaults_to_one_empty_plain_rule():
-    rules = json.loads(NODE_TYPE.config_schema["rules"]["default"])
+    rules = NODE_TYPE.config_schema["rules"]["default"]
 
     assert rules == [
         {"search": "", "replace": "", "mode": "plain", "case_sensitive": True, "replace_all": True},


### PR DESCRIPTION
## Zusammenfassung

Löst #1208 (Teil 1): macht die Logic-FB-Dokumentation über die laufende OBS-API direkt konsumierbar
für einen AI-Agenten, ohne dass dieser Repo-Zugriff braucht.

- **`help_id` als Single Source of Truth**: `NodeTypeDef.help_id` neu im Backend, für alle 43
  dokumentierten Blocktypen gesetzt (Werte 1:1 aus der bisherigen `NODE_HELP_IDS`-Map in
  `NodePalette.vue` übernommen). `edge_detect`/`notify_pushover`/`notify_sms` bleiben bewusst ohne
  `help_id` — dafür existiert noch keine Hilfe-Doku (`edge_detect` siehe #1200). Die duplizierte
  Frontend-Map ist entfernt; `NodePalette.vue` liest jetzt `nt.help_id` direkt aus der
  `GET /api/v1/logic/node-types`-Response.
- **Opake JSON-String-Configs formalisiert**: `decision.conditions`, `value_mapping.rules`,
  `string_replace.rules` und `api_client.variables` deklarieren jetzt ein echtes verschachteltes
  JSON-Schema (`items`/`properties`/`enum`) statt `"type": "string"` mit einem Beispiel-Blob als
  einzigem Hinweis auf die erwartete Struktur. Der Operator-Enum-Wortschatz (`eq`, `ne`, `gt`, …)
  ist als gemeinsame Konstante in `obs/logic/nodes/base.py` hinterlegt, damit `decision` und
  `value_mapping` nicht auseinanderdriften können. Bestätigt per Code-Lesung: die Config-Panels
  dieser vier Blocktypen sind im Frontend vollständig bespoke (`NodeConfigPanel.vue`) und lesen
  `config_schema` nie generisch — die Umstellung ändert am UI-Verhalten nichts.
- **Agent-taugliche OpenAPI-Docstrings**: `GET /node-types` erklärt jetzt Port-Semantik
  (`value` vs. `trigger`), die Regel "fehlender Key im Tick-Output ≠ `null`", `memory` als
  einzigen erlaubten Feedback-Loop-Baustein, die `help_id`-Auflösung über
  `GET /help/help-index.json` und enthält ein minimales `flow_data`-Beispiel. `POST /graphs/validate`
  dokumentiert präzise, was aktuell tatsächlich geprüft wird (nur Graph-Zyklen + Timer-Dauer-Grenzen,
  keine Config-Schema-Validierung), damit ein Agent kein falsches Vertrauen in ein grünes Ergebnis setzt.

## Bewusst nicht in diesem PR

Aus #1208 offen gelassen (siehe dortige Analyse, Punkt 4): Config-Schema-Validierung in
`POST /graphs/validate` einbauen — das wäre eine echte Verhaltensänderung mit eigenem
Test-/Designbedarf und ist als Folgearbeit vorgesehen.

## Test plan

- [x] `tools/with-venv pytest tests/unit tests/adapters tests/contracts` — 7047 passed
- [x] `tools/with-venv ./tools/lint.sh --check`
- [x] `(cd gui && npm run test)` — 2595 passed, inkl. aktualisiertem `NodePalette.help.spec.js`
- [x] `(cd gui && npm run test:coverage)` — `NodePalette.vue` 100% Line/Branch
- [x] `(cd gui && npm run build)` — Production-Build grün
- [x] `./tools/check-i18n-hardcoded-strings.sh` — grün
- [x] `node tools/gui-coverage-summary.mjs --changed-only --threshold=70` — keine Auffälligkeiten
- [x] Manuell per `list_node_types()` die serialisierte `decision`-Definition geprüft (siehe PR-Diskussion bei Bedarf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5wSc3rwpMnpqr35FrhorE