### PR TITLE
feat(logic): Config-Schema-Validierung in /graphs/validate (#1208, Teil 2)

### DIFF
--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -33,7 +33,7 @@ from obs.api.authz_service import filter_authorized_datapoints, load_role_grants
 from obs.api.v1.application_audit import audit_application_contract, mark_contract_audited, write_application_success
 from obs.db.database import Database, get_db
 from obs.logic.capabilities import LOGIC_CREATE_CAPABILITY
-from obs.logic.graph_analysis import topology_warnings
+from obs.logic.graph_analysis import config_schema_warnings, topology_warnings
 from obs.logic.manager import _migrate_legacy_api_client_field_names, _normalise_api_client_variables
 from obs.logic.models import (
     FlowData,
@@ -670,16 +670,28 @@ async def validate_graph(
     body: FlowData,
     _user: str = Depends(get_current_user),
 ) -> dict:
-    """Check `flow_data` for graph-topology problems before saving it.
+    """Check `flow_data` for problems before saving it — advisory, does not persist anything.
 
-    Today this checks exactly two things: graph cycles not broken by a `memory` node, and timer
-    duration bounds (`timer_delay`/`timer_pulse`/`api_client.timeout_s`). It does **not** validate
-    node `data` against each type's `config_schema` (types, enums, or the nested shape of fields
-    like `decision.conditions`) — a `{"status": "ok"}` response does not guarantee the graph will
-    execute as intended. `POST`/`PUT /graphs` accept and persist a structurally invalid node config
-    the same way; the mistake only shows up at run time.
+    Two independent checks, both returned as one flat `warnings` list (`{node_id, code, message}`):
+    - **Graph-cycle topology**: a cycle not broken by a `memory` node (see `GET /node-types`'s
+      "Memory is the only node allowed to close a feedback loop"). Codes: `graph_cycle`,
+      `graph_cycle_blocked`.
+    - **Config-schema conformance**: each node's `data` checked against its type's `config_schema`
+      from `GET /node-types` — unknown node types, values that don't match a declared `type` or
+      `enum`, and (for `type: array` fields such as `decision.conditions`) malformed JSON or a
+      missing required item field. Codes: `unknown_node_type`, `config_schema_type_mismatch`,
+      `config_schema_enum_invalid`, `config_schema_malformed_json`,
+      `config_schema_missing_required_field`. Deliberately narrow: no cross-entity checks (e.g.
+      whether a `datapoint_id` actually exists), and a key absent from `data` is never flagged
+      (it falls back to the schema default).
+
+    `status` is always `"ok"` — an empty `warnings` list is the actual "nothing found" signal, not
+    `status`. This endpoint is **not** enforced anywhere else: `POST`/`PUT /graphs` persist a graph
+    with cycles or invalid config the same way regardless of whether this was called first, except
+    for timer duration bounds (`timer_delay`/`timer_pulse`/`api_client.timeout_s`), which those two
+    endpoints reject outright (422) at save time — independently of this endpoint.
     """
-    return {"status": "ok", "warnings": topology_warnings(body)}
+    return {"status": "ok", "warnings": topology_warnings(body) + config_schema_warnings(body)}
 
 
 @router.get("/graphs", response_model=list[LogicGraphOut])

--- a/obs/logic/graph_analysis.py
+++ b/obs/logic/graph_analysis.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from typing import Any
 
 from obs.logic.models import FlowData, LogicNode
+from obs.logic.registry import get_node_type
 
 TICK_BOUNDARY_NODE_TYPES = {"memory"}
+
+# Import-time placeholder for an unresolved node type (obs/api/v1/logic.py) — an
+# already-known, intentional marker, not itself an "unknown" type to re-flag.
+_MISSING_NODE_TYPE = "missing_node"
+
+_NUMERIC_SCHEMA_TYPES = {"number", "integer"}
 
 
 @dataclass(frozen=True)
@@ -84,6 +93,108 @@ def topology_warnings(flow: FlowData) -> list[dict[str, str]]:
                     "message": f"Graph cycle detected upstream; node cannot be executed. Cycle nodes: {', '.join(ordered_cyclic[:5])}",
                 },
             )
+    return warnings
+
+
+def config_schema_warnings(flow: FlowData) -> list[dict[str, str]]:
+    """Check each node's ``data`` against its type's ``config_schema``.
+
+    Deliberately narrow: types, enums and array/object shape only — no cross-entity checks (e.g.
+    whether a ``datapoint_id`` actually exists). A key absent from ``data`` is never flagged (it
+    falls back to the schema default); a present ``None`` is always treated as "no value yet" and
+    skipped too. Mirrors the executor's own coercion leniency (``GraphExecutor._to_num``,
+    ``_load_rule_list``) so this reports exactly the inputs that would silently produce wrong
+    behaviour at run time, not inputs the executor already handles safely.
+    """
+    warnings: list[dict[str, str]] = []
+    for node in flow.nodes:
+        if node.type == _MISSING_NODE_TYPE:
+            continue
+        node_type = get_node_type(node.type)
+        if node_type is None:
+            warnings.append(_schema_warning(node.id, "unknown_node_type", f"Unknown node type '{node.type}'."))
+            continue
+        for key, field_schema in node_type.config_schema.items():
+            if key not in node.data:
+                continue
+            value = node.data[key]
+            if field_schema.get("type") == "array":
+                warnings.extend(_array_field_warnings(node.id, key, value, field_schema))
+            else:
+                warnings.extend(_field_warnings(node.id, key, value, field_schema))
+    return warnings
+
+
+def _schema_warning(node_id: str, code: str, message: str) -> dict[str, str]:
+    return {"node_id": node_id, "code": code, "message": message}
+
+
+def _is_numeric(value: Any) -> bool:
+    """Mirror ``GraphExecutor._to_num``'s coercion: bool, real number, or a numeric string."""
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value)
+        except ValueError:
+            return False
+        return True
+    return False
+
+
+def _field_warnings(node_id: str, key: str, value: Any, schema: dict[str, Any]) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if "enum" in schema:
+        if value in schema["enum"]:
+            return []
+        return [_schema_warning(node_id, "config_schema_enum_invalid", f"{key}: {value!r} is not one of {schema['enum']}.")]
+    field_type = schema.get("type")
+    if field_type in _NUMERIC_SCHEMA_TYPES:
+        if value == "" or _is_numeric(value):
+            return []
+        return [_schema_warning(node_id, "config_schema_type_mismatch", f"{key}: expected a {field_type}, got {value!r}.")]
+    if field_type == "string" and not isinstance(value, str):
+        return [_schema_warning(node_id, "config_schema_type_mismatch", f"{key}: expected a string, got {value!r}.")]
+    # "boolean" and untyped fields (e.g. decision/value_mapping's context-dependent "value"/"min"/
+    # "max") are intentionally not checked further — GraphExecutor._to_bool coerces any value, and
+    # an untyped field's legal shape is not declared, so nothing here can be flagged as invalid.
+    return []
+
+
+def _array_field_warnings(node_id: str, key: str, value: Any, schema: dict[str, Any]) -> list[dict[str, str]]:
+    items = value
+    if isinstance(items, str):
+        try:
+            items = json.loads(items) if items else []
+        except (TypeError, ValueError):
+            return [_schema_warning(node_id, "config_schema_malformed_json", f"{key}: could not parse as JSON.")]
+    if not isinstance(items, list):
+        return [_schema_warning(node_id, "config_schema_type_mismatch", f"{key}: expected an array, got {items!r}.")]
+
+    items_schema = schema.get("items")
+    if not isinstance(items_schema, dict):
+        return []
+
+    required = items_schema.get("required", [])
+    properties = items_schema.get("properties", {})
+    warnings: list[dict[str, str]] = []
+    for index, item in enumerate(items):
+        item_key = f"{key}[{index}]"
+        if not isinstance(item, dict):
+            warnings.append(_schema_warning(node_id, "config_schema_type_mismatch", f"{item_key}: expected an object, got {item!r}."))
+            continue
+        for field_name in required:
+            field_value = item.get(field_name)
+            if field_value is None or field_value == "":
+                warnings.append(
+                    _schema_warning(node_id, "config_schema_missing_required_field", f"{item_key}.{field_name}: required field is missing."),
+                )
+        for field_name, field_schema in properties.items():
+            if field_name in item:
+                warnings.extend(_field_warnings(node_id, f"{item_key}.{field_name}", item[field_name], field_schema))
     return warnings
 
 

--- a/obs/logic/graph_analysis.py
+++ b/obs/logic/graph_analysis.py
@@ -17,6 +17,54 @@ _MISSING_NODE_TYPE = "missing_node"
 
 _NUMERIC_SCHEMA_TYPES = {"number", "integer"}
 
+# Some enum-declared config fields accept additional runtime spellings beyond the schema's
+# canonical `enum` values — genuine synonyms GraphExecutor treats identically to a canonical
+# value, not typos that silently fall back to a different (wrong) default. Duplicated here
+# rather than imported from executor.py — executor.py already imports from this module, so the
+# reverse import would be circular. Kept honest by
+# tests/unit/logic/test_config_schema_warnings.py, which recomputes these unions from executor.py's
+# actual op-sets, mirroring the `_DURATION_FIELDS` precedent in obs/logic/validation.py.
+_COMPARE_OPERATOR_ALIASES: frozenset[str] = frozenset({">", "gt", "<", "lt", "=", "==", "eq", ">=", "gte", "<=", "lte", "!=", "ne"})
+_CONDITION_OPERATOR_ALIASES: frozenset[str] = frozenset(
+    {
+        "range",
+        "between",
+        "regex",
+        "regexp",
+        "contains",
+        "starts_with",
+        "startswith",
+        "begins_with",
+        "ends_with",
+        "endswith",
+        "text",
+        "text_eq",
+        "equals_text",
+        "=",
+        "==",
+        "eq",
+        "!=",
+        "ne",
+        ">",
+        "gt",
+        "<",
+        "lt",
+        ">=",
+        "gte",
+        "<=",
+        "lte",
+    }
+)
+
+# Keyed by the schema's own canonical enum values, so both `compare` and the shared
+# decision/value_mapping operator schema resolve to their respective alias supersets.
+_ENUM_ALIAS_SUPERSETS: dict[frozenset[str], frozenset[str]] = {
+    frozenset({">", "<", "=", ">=", "<=", "!="}): _COMPARE_OPERATOR_ALIASES,
+    frozenset(
+        {"eq", "ne", "gt", "lt", "gte", "lte", "range", "text_eq", "contains", "starts_with", "ends_with", "regex"}
+    ): _CONDITION_OPERATOR_ALIASES,
+}
+
 
 @dataclass(frozen=True)
 class TopologicalSortResult:
@@ -144,11 +192,30 @@ def _is_numeric(value: Any) -> bool:
     return False
 
 
+def _matches_enum(value: Any, enum_values: list[Any]) -> bool:
+    """True if ``value`` is accepted for a field declaring ``enum_values``.
+
+    Beyond an exact match: many enum-style config fields are read case/whitespace-normalized at
+    execution time (e.g. `GraphExecutor` lowers `compare.operator`/`string_replace.rules[].mode`,
+    `LogicManager` uppercases `api_client.method`) — checked here as a generic case-insensitive
+    comparison against the canonical values. A handful of fields additionally accept genuine
+    synonyms beyond their canonical spelling (`_ENUM_ALIAS_SUPERSETS`), which is checked instead of
+    the canonical set when the field has an entry there.
+    """
+    if value in enum_values:
+        return True
+    if not isinstance(value, str):
+        return False
+    candidates = _ENUM_ALIAS_SUPERSETS.get(frozenset(enum_values), enum_values)
+    normalized = value.strip().lower()
+    return any(isinstance(candidate, str) and candidate.strip().lower() == normalized for candidate in candidates)
+
+
 def _field_warnings(node_id: str, key: str, value: Any, schema: dict[str, Any]) -> list[dict[str, str]]:
     if value is None:
         return []
     if "enum" in schema:
-        if value in schema["enum"]:
+        if _matches_enum(value, schema["enum"]):
             return []
         return [_schema_warning(node_id, "config_schema_enum_invalid", f"{key}: {value!r} is not one of {schema['enum']}.")]
     field_type = schema.get("type")

--- a/tests/integration/test_logic_graphs.py
+++ b/tests/integration/test_logic_graphs.py
@@ -126,6 +126,53 @@ async def test_validate_graph_allows_feedback_through_memory(client, auth_header
     assert resp.json()["warnings"] == []
 
 
+async def test_validate_graph_reports_invalid_enum_value(client, auth_headers):
+    flow_data = {
+        "nodes": [
+            {"id": "cmp", "type": "compare", "position": {"x": 0, "y": 0}, "data": {"operator": "greater_than"}},
+        ],
+        "edges": [],
+    }
+
+    resp = await client.post("/api/v1/logic/graphs/validate", json=flow_data, headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["warnings"] == [
+        {
+            "node_id": "cmp",
+            "code": "config_schema_enum_invalid",
+            "message": "operator: 'greater_than' is not one of ['>', '<', '=', '>=', '<=', '!='].",
+        }
+    ]
+
+
+async def test_validate_graph_reports_unknown_node_type_and_nested_config_schema_issues(client, auth_headers):
+    flow_data = {
+        "nodes": [
+            {"id": "ghost", "type": "totally_made_up", "position": {"x": 0, "y": 0}, "data": {}},
+            {
+                "id": "dec",
+                "type": "decision",
+                "position": {"x": 200, "y": 0},
+                "data": {"conditions": [{"operator": "greater_than"}]},
+            },
+        ],
+        "edges": [],
+    }
+
+    resp = await client.post("/api/v1/logic/graphs/validate", json=flow_data, headers=auth_headers)
+
+    assert resp.status_code == 200
+    codes = {(w["node_id"], w["code"]) for w in resp.json()["warnings"]}
+    assert codes == {
+        ("ghost", "unknown_node_type"),
+        ("dec", "config_schema_missing_required_field"),
+        ("dec", "config_schema_enum_invalid"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # POST /logic/graphs
 # ---------------------------------------------------------------------------

--- a/tests/unit/logic/test_config_schema_warnings.py
+++ b/tests/unit/logic/test_config_schema_warnings.py
@@ -1,0 +1,119 @@
+"""Unit tests for ``config_schema_warnings`` — see obs/logic/graph_analysis.py."""
+
+from __future__ import annotations
+
+from obs.logic.graph_analysis import config_schema_warnings
+from obs.logic.models import FlowData, LogicNode
+from obs.logic.registry import BUILTIN_NODE_TYPES
+
+
+def _flow(node_type: str, data: dict | None = None, node_id: str = "n1") -> FlowData:
+    return FlowData(nodes=[LogicNode(id=node_id, type=node_type, position={"x": 0, "y": 0}, data=data or {})])
+
+
+def _codes(flow: FlowData) -> list[str]:
+    return [w["code"] for w in config_schema_warnings(flow)]
+
+
+def test_unknown_node_type_is_flagged():
+    warnings = config_schema_warnings(_flow("totally_made_up"))
+
+    assert [w["code"] for w in warnings] == ["unknown_node_type"]
+    assert warnings[0]["node_id"] == "n1"
+
+
+def test_missing_node_placeholder_is_not_flagged():
+    assert config_schema_warnings(_flow("missing_node")) == []
+
+
+def test_absent_key_is_never_flagged():
+    # decision's "conditions" has a rich schema but isn't set here at all.
+    assert config_schema_warnings(_flow("decision", {})) == []
+
+
+def test_enum_valid_and_invalid():
+    assert _codes(_flow("compare", {"operator": ">"})) == []
+    assert _codes(_flow("compare", {"operator": "greater_than"})) == ["config_schema_enum_invalid"]
+
+
+def test_numeric_field_accepts_real_numbers_bool_numeric_strings_and_the_empty_string_sentinel():
+    for value in (5, 5.5, True, "5.5", ""):
+        assert _codes(_flow("compare", {"operand": value})) == [], value
+
+
+def test_numeric_field_rejects_non_numeric_content():
+    assert _codes(_flow("compare", {"operand": "abc"})) == ["config_schema_type_mismatch"]
+    # Neither a number, a bool, nor a string — the final `_is_numeric` fallback.
+    assert _codes(_flow("compare", {"operand": [1, 2]})) == ["config_schema_type_mismatch"]
+
+
+def test_none_is_always_skipped_regardless_of_declared_type():
+    assert _codes(_flow("compare", {"operand": None})) == []
+    assert _codes(_flow("compare", {"operator": None})) == []
+
+
+def test_string_field_type_mismatch():
+    assert _codes(_flow("datapoint_read", {"datapoint_name": 123})) == ["config_schema_type_mismatch"]
+    assert _codes(_flow("datapoint_read", {"datapoint_name": "living_room_temp"})) == []
+
+
+def test_boolean_field_is_never_flagged():
+    # GraphExecutor._to_bool coerces any value, so nothing here is "invalid".
+    assert _codes(_flow("datapoint_read", {"trigger_on_change": "not-a-bool"})) == []
+    assert _codes(_flow("datapoint_read", {"trigger_on_change": 42})) == []
+
+
+def test_array_field_malformed_json_string():
+    assert _codes(_flow("decision", {"conditions": "{not valid json"})) == ["config_schema_malformed_json"]
+
+
+def test_array_field_wrong_top_level_type():
+    assert _codes(_flow("decision", {"conditions": 42})) == ["config_schema_type_mismatch"]
+    # A JSON string that parses fine but not to a list goes through the same check.
+    assert _codes(_flow("decision", {"conditions": "42"})) == ["config_schema_type_mismatch"]
+    # An empty string is treated like an empty list — no items, nothing to flag.
+    assert _codes(_flow("decision", {"conditions": ""})) == []
+
+
+def test_array_item_not_an_object():
+    assert _codes(_flow("decision", {"conditions": [123]})) == ["config_schema_type_mismatch"]
+
+
+def test_array_item_missing_required_field():
+    assert _codes(_flow("decision", {"conditions": [{"operator": "eq"}]})) == ["config_schema_missing_required_field"]
+    # Empty string counts as "missing" too, matching the executor's own `or` fallback.
+    assert _codes(_flow("decision", {"conditions": [{"handle": "", "operator": "eq"}]})) == ["config_schema_missing_required_field"]
+
+
+def test_array_item_nested_enum_is_validated():
+    warnings = config_schema_warnings(_flow("decision", {"conditions": [{"handle": "out_1", "operator": "greater_than"}]}))
+
+    assert [w["code"] for w in warnings] == ["config_schema_enum_invalid"]
+
+
+def test_array_item_nested_untyped_fields_are_never_flagged():
+    data = {"conditions": [{"handle": "out_1", "operator": "eq", "value": {"nested": "anything"}, "min": object()}]}
+    # "value"/"min" are deliberately untyped (their legal shape depends on the operator) —
+    # asserting no crash and no warning for an arbitrary dict/object value.
+    assert config_schema_warnings(_flow("decision", data)) == []
+
+
+def test_array_field_without_items_schema_only_checks_list_shape():
+    # value_sequence.steps has no "items" schema — shallow check only.
+    assert _codes(_flow("value_sequence", {"steps": [1, 2, 3]})) == []
+    assert _codes(_flow("value_sequence", {"steps": "not json"})) == ["config_schema_malformed_json"]
+
+
+def test_every_node_types_own_default_config_is_self_consistent():
+    # string_replace's default is a deliberate exception: its one starter rule ships with an
+    # empty "search" on purpose ("a freshly dropped block already shows an editable row" —
+    # obs/logic/nodes/string/replace.py), and an empty "search" is exactly what the executor
+    # itself treats as "this rule does nothing yet" (GraphExecutor._apply_replace_rules skips a
+    # blank search). The validator correctly reports that starter rule as incomplete.
+    expected_warning_codes = {"string_replace": ["config_schema_missing_required_field"]}
+
+    for node_type in BUILTIN_NODE_TYPES:
+        data = {key: field_schema["default"] for key, field_schema in node_type.config_schema.items() if "default" in field_schema}
+
+        codes = _codes(_flow(node_type.type, data))
+        assert codes == expected_warning_codes.get(node_type.type, []), node_type.type

--- a/tests/unit/logic/test_config_schema_warnings.py
+++ b/tests/unit/logic/test_config_schema_warnings.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from obs.logic.graph_analysis import config_schema_warnings
+from obs.logic import executor as executor_module
+from obs.logic.graph_analysis import (
+    _COMPARE_OPERATOR_ALIASES,
+    _CONDITION_OPERATOR_ALIASES,
+    config_schema_warnings,
+)
 from obs.logic.models import FlowData, LogicNode
 from obs.logic.registry import BUILTIN_NODE_TYPES
 
@@ -34,6 +39,53 @@ def test_absent_key_is_never_flagged():
 def test_enum_valid_and_invalid():
     assert _codes(_flow("compare", {"operator": ">"})) == []
     assert _codes(_flow("compare", {"operator": "greater_than"})) == ["config_schema_enum_invalid"]
+
+
+def test_enum_accepts_genuine_executor_aliases_not_just_the_canonical_spelling():
+    # "gt" is a real GraphExecutor._COMPARE_OPS alias for ">", not a typo — must not be flagged
+    # (review finding on PR #1216: flagging it would contradict a graph that runs correctly).
+    assert _codes(_flow("compare", {"operator": "gt"})) == []
+    # Same story for decision/value_mapping's shared operator vocabulary: "between" is a real
+    # _RANGE_OPS alias for "range".
+    assert _codes(_flow("decision", {"conditions": [{"handle": "out_1", "operator": "between"}]})) == []
+
+
+def test_enum_check_is_case_and_whitespace_insensitive():
+    # GraphExecutor normalizes compare.operator/conditions[].operator via .strip().lower(), and
+    # api_client.method via .upper() — either direction must compare equal here.
+    assert _codes(_flow("compare", {"operator": " GT "})) == []
+    assert _codes(_flow("api_client", {"method": "get"})) == []
+
+
+def test_enum_check_rejects_a_non_string_value_outright():
+    # A non-string can never match case/whitespace-normalized or aliased, so it short-circuits
+    # to "invalid" without attempting to .strip()/.lower() it.
+    assert _codes(_flow("compare", {"operator": 5})) == ["config_schema_enum_invalid"]
+
+
+def test_enum_check_rejects_a_value_not_covered_by_any_alias_or_canonical_spelling():
+    # "method" has no registered alias superset — falls back to case-insensitive comparison
+    # against its own canonical enum, and still correctly rejects a genuinely wrong value.
+    assert _codes(_flow("api_client", {"method": "FETCH"})) == ["config_schema_enum_invalid"]
+
+
+def test_compare_operator_alias_superset_matches_executors_actual_compare_ops():
+    assert _COMPARE_OPERATOR_ALIASES == frozenset(executor_module._COMPARE_OPS)
+
+
+def test_condition_operator_alias_superset_matches_executors_actual_op_sets():
+    expected = (
+        frozenset(executor_module._RANGE_OPS)
+        | frozenset(executor_module._REGEX_OPS)
+        | frozenset(executor_module._CONTAINS_OPS)
+        | frozenset(executor_module._STARTS_WITH_OPS)
+        | frozenset(executor_module._ENDS_WITH_OPS)
+        | frozenset(executor_module._TEXT_COMPARE_OPS)
+        | frozenset(executor_module._COMPARE_OPS)
+        | {"=", "==", "eq", "!=", "ne"}
+    )
+
+    assert _CONDITION_OPERATOR_ALIASES == expected
 
 
 def test_numeric_field_accepts_real_numbers_bool_numeric_strings_and_the_empty_string_sentinel():


### PR DESCRIPTION
## Zusammenfassung

Löst #1208 (Teil 2, Nachfolger von #1209): der in #1209 explizit zurückgestellte Punkt aus der
Analyse — `POST /api/v1/logic/graphs/validate` prüft bisher nur Graph-Zyklen, nicht die `data`
eines Nodes gegen das `config_schema` seines Typs. Damit bekam ein Client (insb. ein AI-Agent) bei
z. B. `{"operator": "greater_than"}` statt `">"` oder kaputtem JSON in `decision.conditions` ein
`{"status": "ok"}` und die Laufzeit degradiert das nur still (`GraphExecutor._to_num`/
`_condition_matches` fallen lautlos auf `0`/`eq` zurück) — genau das "Herumprobieren bis es
irgendwie geht", das #1208 beschreibt.

## Änderungen

- **`obs/logic/graph_analysis.py`**: neue Funktion `config_schema_warnings(flow)`, gleiche
  Rückgabeform wie `topology_warnings` (`{node_id, code, message}`). Neue Codes:
  `unknown_node_type`, `config_schema_type_mismatch`, `config_schema_enum_invalid`,
  `config_schema_malformed_json`, `config_schema_missing_required_field`.
  - Bewusst schmal gehalten: nur Typ/Enum/Array-Struktur, keine Cross-Entity-Checks (z. B. ob eine
    `datapoint_id` wirklich existiert).
  - Ein im `data` fehlender Key wird nie gemeldet (Default greift), ein explizites `None` ebenso
    nicht.
  - Numerische Felder tolerieren `""` als "noch nicht gesetzt" — exakter Spiegel der im Code
    etablierten Konvention (6 Zahl-Felder deklarieren `"default": ""`) und von
    `GraphExecutor._to_num`s eigener Koartierung. Ohne diese Ausnahme hätte praktisch jeder frisch
    abgelegte `compare`-Block sofort eine Falschmeldung produziert.
  - Bei `type: array`-Feldern (`decision.conditions`, `value_mapping.rules`,
    `string_replace.rules`, `api_client.variables`) wird ein JSON-String genau wie
    `GraphExecutor._load_rule_list`/`manager.py::_sequence_steps` behandelt, dann pro Element
    gegen `items.required`/`items.properties` geprüft — inkl. rekursiver Enum-Prüfung, z. B. für
    ein falsches `operator` innerhalb von `conditions`.
- **`obs/api/v1/logic.py`**: `validate_graph` mergt `topology_warnings(body)` mit
  `config_schema_warnings(body)` in dieselbe `warnings`-Liste; Docstring aktualisiert (inkl. einer
  Korrektur: die alte Doku behauptete fälschlich, dieser Endpunkt prüfe auch Timer-Dauer-Grenzen —
  das passiert tatsächlich nur separat beim Speichern in `create_graph`/`update_graph_full`).
- Response-Form unverändert (`status` bleibt immer `"ok"`, die `warnings`-Liste ist das Signal) —
  reine Erweiterung, keine Breaking Change. `POST`/`PUT /graphs` bleiben unverändert (persistieren
  wie bisher, unabhängig davon ob `validate` vorher aufgerufen wurde).
- Keine GUI-Änderung nötig: die Admin-GUI ruft diesen Endpunkt nirgends auf (eigene
  Client-seitige Zyklus-Erkennung in `LogicView.vue`) — geprüft per Grep, keine Treffer.

## Test plan

- [x] `tools/with-venv pytest tests/unit/logic/test_config_schema_warnings.py -v` — 17 neue Unit-Tests
- [x] `tools/with-venv pytest tests/integration/test_logic_graphs.py -q` — 55 passed, inkl. 2 neuer
      End-to-End-Tests über den echten Endpunkt; beide bestehenden `validate`-Tests unverändert grün
- [x] `tools/with-venv pytest tests/unit tests/adapters tests/contracts tests/integration/test_logic_graphs.py -q` — 7119 passed
- [x] `tools/with-venv pytest ... --cov-branch --cov=obs.logic.graph_analysis --cov=obs.api.v1.logic --cov-report=term-missing` — neuer Code 100% Line+Branch, alle verbleibenden Lücken sind vorbestehender, unberührter Code
- [x] `tools/with-venv ./tools/lint.sh --check`
- Kein GUI-Diff → keine Frontend-Gates nötig

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5wSc3rwpMnpqr35FrhorE