### PR TITLE
fix(logic): run Trigger (timer_cron) schedule in local timezone

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,20 @@
 # Changes
+## 2026.10.0
+### Breaking changes 🚨
+* none
+
+### New features ✨
+* none
+
+### Fixes 🐞
+* Logic Engine: The Trigger function block's cron schedule was evaluated against UTC instead of the configured application timezone, so a schedule such as "Daily at 07:00" fired at 07:00 UTC and drifted across daylight-saving transitions instead of firing at 07:00 local time. It now resolves the same configured timezone already used by the iCalendar and Host Check schedulers, falling back to `Europe/Zurich` if that setting is unresolvable. https://github.com/abeggled/openbridgeserver/issues/1201
+
+### Known Issues 🔔
+* none
+
+### Contributors ❤️
+* none
+
 ## 2026.9.0
 ### Breaking changes 🚨
 * none

--- a/help/de/logic/blocks-timer.md
+++ b/help/de/logic/blocks-timer.md
@@ -21,6 +21,10 @@ Konfiguration bietet drei ineinandergreifende Ebenen:
 
 Alle drei Ebenen sind synchron — eine Änderung an einer Stelle aktualisiert die anderen.
 
+Der Zeitplan wird in der eingestellten Anwendungs-Zeitzone ausgewertet (**Einstellungen →
+Allgemein**), nicht in UTC — ein Trigger „Täglich um 07:00" löst also um 07:00 Ortszeit aus und
+folgt automatisch der Zeitumstellung (Sommer-/Winterzeit).
+
 ## Datum/Zeit {#logic-block-datetime}
 
 Gibt das aktuelle Datum und die aktuelle Uhrzeit in der eingestellten Anwendungs-Zeitzone aus

--- a/help/en/logic/blocks-timer.md
+++ b/help/en/logic/blocks-timer.md
@@ -21,6 +21,9 @@ three interlinked levels:
 
 All three levels stay in sync — a change at any level updates the others.
 
+The schedule is evaluated in the configured application timezone (**Settings → General**), not
+UTC — a "Daily at 07:00" trigger fires at 7am local time and follows daylight-saving transitions.
+
 ## Date/Time {#logic-block-datetime}
 
 Outputs the current date and time in the configured application timezone (**Date**, **Time**,

--- a/obs/logic/manager.py
+++ b/obs/logic/manager.py
@@ -1881,12 +1881,22 @@ class LogicManager:
                     )
 
     async def _cron_loop(self, graph_id: str, node_id: str, cron_expr: str) -> None:
-        """Fires a timer_cron graph node on its cron schedule — runs indefinitely."""
+        """Fires a timer_cron graph node on its cron schedule — runs indefinitely.
+
+        The cron expression is interpreted in the configured system timezone
+        (not UTC), so e.g. "0 7 * * *" fires at 7am local time and follows
+        DST transitions like a user would expect.
+        """
         from croniter import croniter
 
         while True:
             try:
-                now = datetime.now(UTC)
+                tz_name = self._app_config.get("timezone", "Europe/Zurich")
+                try:
+                    tz = ZoneInfo(tz_name)
+                except ZoneInfoNotFoundError:
+                    tz = ZoneInfo("Europe/Zurich")
+                now = datetime.now(tz)
                 it = croniter(cron_expr, now)
                 next_dt = it.get_next(datetime)
                 wait_s = max(0.0, (next_dt - now).total_seconds())

--- a/tests/unit/test_coverage_adapters_hierarchy_logic.py
+++ b/tests/unit/test_coverage_adapters_hierarchy_logic.py
@@ -5286,6 +5286,59 @@ class TestStartCronTasks:
         assert sleep_calls == [60, 60]
 
     @pytest.mark.asyncio
+    async def test_cron_loop_evaluates_schedule_in_configured_timezone(self):
+        """_cron_loop must resolve `now` in the configured app timezone (issue
+        #1201), not UTC — otherwise a "Daily at 07:00" trigger fires at 07:00
+        UTC instead of 07:00 local time."""
+        import asyncio
+        from zoneinfo import ZoneInfo
+
+        mgr, _, _, _ = _make_logic_manager(graphs={"g1": ("G1", True, _make_flow())})
+        mgr._app_config["timezone"] = "Pacific/Kiritimati"  # UTC+14 — unambiguous vs. UTC
+
+        captured_now = []
+
+        class _FakeCroniter:
+            def __init__(self, expr, now):
+                captured_now.append(now)
+
+            def get_next(self, ret_type):
+                raise asyncio.CancelledError()
+
+        with patch("croniter.croniter", _FakeCroniter):
+            task = asyncio.create_task(mgr._cron_loop("g1", "c1", "0 7 * * *"))
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert captured_now[0].tzinfo == ZoneInfo("Pacific/Kiritimati")
+
+    @pytest.mark.asyncio
+    async def test_cron_loop_falls_back_to_zurich_on_unknown_timezone(self):
+        """An unresolvable configured timezone must not crash the cron
+        scheduler — it falls back to Europe/Zurich."""
+        import asyncio
+        from zoneinfo import ZoneInfo
+
+        mgr, _, _, _ = _make_logic_manager(graphs={"g1": ("G1", True, _make_flow())})
+        mgr._app_config["timezone"] = "Not/ARealZone"
+
+        captured_now = []
+
+        class _FakeCroniter:
+            def __init__(self, expr, now):
+                captured_now.append(now)
+
+            def get_next(self, ret_type):
+                raise asyncio.CancelledError()
+
+        with patch("croniter.croniter", _FakeCroniter):
+            task = asyncio.create_task(mgr._cron_loop("g1", "c1", "0 7 * * *"))
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert captured_now[0].tzinfo == ZoneInfo("Europe/Zurich")
+
+    @pytest.mark.asyncio
     async def test_ical_loop_logs_and_backs_off_on_error(self):
         """_ical_loop swallows an unexpected exception from _execute_graph,
         logs it and backs off for 60s rather than letting the loop die."""


### PR DESCRIPTION
## Summary
- `LogicManager._cron_loop` resolved `now` via `datetime.now(UTC)`, so the Trigger function block's cron schedule always fired in UTC instead of local time, drifting across DST twice a year.
- It now resolves the same app-level `timezone` setting already used by the `ical` and `host_check` schedulers (Settings → General), falling back to `Europe/Zurich` if that value is unresolvable.
- Help docs (EN/DE) updated to state the Trigger block runs in the configured application timezone.
- RELEASENOTES.md: started the `2026.10.0` release cycle and recorded this fix under it.

Fixes #1201

## Test plan
- [x] `tools/with-venv ./tools/lint.sh --check`
- [x] `tools/with-venv pytest tests/unit tests/adapters tests/contracts --cov=obs --cov-report=term-missing` (7072 passed)
- [x] New unit tests cover both branches of the timezone resolution (valid configured zone vs. unresolvable zone name falling back to Europe/Zurich)
- [x] `./tools/check-i18n-hardcoded-strings.sh` (no relevant changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR3TjvMo5rWD1K1NVSq8iL