### PR TITLE
fix(tools): read Babel 8 ImportExpression in the help declaration scanner

### DIFF
--- a/tools/scan-help-declarations.mjs
+++ b/tools/scan-help-declarations.mjs
@@ -992,9 +992,17 @@ function collectWidgets(file, seen = new Set()) {
   // either way, so the import graph inside the widget's own directory is
   // followed. Anything outside it (`@/…`, a package) is not this widget's.
   // `import('./helper')` executes the module just as a static import does.
+  // Babel 8 parses it as an `ImportExpression` carrying the module in `source`;
+  // Babel 7 as a `CallExpression` whose callee is an `Import` node and whose
+  // first argument is that module. Both spellings name the same import.
   walk(ast, (node) => {
-    if (node.type !== 'Import' && !(node.type === 'CallExpression' && node.callee.type === 'Import')) return
-    const specifier = node.type === 'CallExpression' ? stringValue(node.arguments[0]) : null
+    const source =
+      node.type === 'ImportExpression'
+        ? node.source
+        : node.type === 'CallExpression' && node.callee.type === 'Import'
+          ? node.arguments[0]
+          : null
+    const specifier = stringValue(source)
     if (specifier === null || !isLocalSpecifier(specifier)) return
     const target = resolveLocalModule(dirname(file), specifier)
     if (target !== null && CODE_SUFFIXES.some((suffix) => target.endsWith(suffix))) collectWidgets(target, seen)


### PR DESCRIPTION
## Beschreibung

Der `help-contract`-Check schlägt in #1227 (`@babel/parser` 7 → 8) fehl, obwohl die PR nur
GUI-Dependencies anfasst. Der Zusammenhang: `tools/scan-help-declarations.mjs` ist ein
AST-Scanner, der sich seinen Parser aus `gui/` auflöst —

```js
const requireFromGui = createRequire(join(REPO_ROOT, 'gui', 'package.json'))
const { parse: parseJs, parseExpression } = requireFromGui('@babel/parser')
```

— ein Bump dieser Dependency ändert also den Syntaxbaum, den das Gate liest.

**Breaking Change in Babel 8:** `import('./helper')` wird jetzt als eigener Knoten
`ImportExpression` geparst, der das Modul in `source` trägt. Babel 7 lieferte dafür eine
`CallExpression`, deren Callee ein `Import`-Knoten ist und deren `arguments[0]` das Modul nennt.
Der Scanner kannte nur die Babel-7-Form, folgte dynamisch importierten Modulen nicht mehr und
verlor die dort registrierten Widgets — genau der eine fehlschlagende Test
(`a dynamically imported module executes and is followed`, 173/174 grün).

Beide Schreibweisen werden jetzt gelesen, das Gate hält damit auf beiden Majors. Der alte erste
Guard-Zweig (`node.type !== 'Import'`) war zudem effektiv tot — ein blanker `Import`-Knoten kam
durch den Guard und fiel danach über `specifier === null` wieder heraus; das ist mit aufgeräumt.

Verifiziert mit real installierten Parsern in einem Fixture-Baum:

| `@babel/parser` | `node --test tools/scan-help-declarations.test.mjs` |
|---|---|
| 7.29.8 (aktueller Stand `main`) | 174/174 grün |
| 8.0.4 (Stand aus #1227) | 174/174 grün — vor diesem Fix 173/174 |

Nach dem Merge sollte #1227 rebased werden, dann wird `help-contract` dort grün.

`'Import'`/`ImportExpression` kommt im ganzen Repo nur an dieser einen Stelle vor, und
`@babel/parser` wird außerhalb von `gui/package.json` nur von diesem Tool benutzt — andere
Babel-8-Breaking-Changes schlagen hier nicht durch (die übrigen 173 Tests bestätigen das).

## Typ der Änderung

- [x] Bug-Fix
- [ ] Neues Feature
- [x] Release-Engineering / CI / Dokumentation
- [ ] Backport → Label `backport-YYYY.M` setzen, Ziel-Branch `YYYY.M` angeben

## Milestone

2026.10

## Checkliste

- [x] Tests für neue oder geänderte Funktionalität vorhanden — der bestehende Test
  `a dynamically imported module executes and is followed` deckt den Pfad ab und war der
  reproduzierende Fehlschlag; er ist gegen beide Parser-Majors nachgefahren (Tabelle oben)
- [x] Lokale Gates grün: Pre-Push-Gate vollständig durchgelaufen (i18n-Gate, `ruff check`,
  `ruff format --check`, `pytest tests/` → 8058 passed, 1 skipped). Keine GUI-Quellen berührt,
  daher greift der Vitest-Zweig des Gates nicht.
- [x] Keine neuen nutzer-sichtbaren Strings (reines Dev-Tooling unter `tools/`)
- [x] Keine Release-Notes-Änderung nötig — nicht nutzer-relevant, betrifft nur das CI-Gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
